### PR TITLE
Keine Auswahl des Kontos notwendig wenn nur ein Konto hinterlegt ist.

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
@@ -65,7 +65,12 @@ public class KontoInput extends SelectInput
   {
     super(init(filter),konto);
     setName(i18n.tr("Konto"));
-    setPleaseChoose(i18n.tr("Bitte wählen..."));
+    // Wenn nur ein Konto hinterlegt ist das gleich selektieren
+    if ( super.getList().size() == 1 ) {
+      super.setPreselected(super.getList().get(0));
+    } else {
+      setPleaseChoose(i18n.tr("Bitte wählen..."));
+    }
     this.setComment("");
 
     this.listener = new KontoListener();


### PR DESCRIPTION
hibiscus verlangte die Auswahl eines Kontos, auch wenn nur ein Konto hinterlegt ist. Für diesen Fall (Anzahl der Konten gleich Eins) findet jetzt eine Vorauswahl statt.
