### PR TITLE
SEPA Import: Überprüfe PAIN Typ

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ImportDialog.java
@@ -32,6 +32,7 @@ import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.LabelInput;
 import de.willuhn.jameica.gui.input.SelectInput;
+import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.gui.util.Container;
@@ -59,6 +60,7 @@ public class ImportDialog extends AbstractDialog
 	private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   private Input importerListe     = null;
+  private CheckboxInput forceBox  = null;
   private GenericObject context   = null;	
   private Class type              = null;
   
@@ -93,6 +95,13 @@ public class ImportDialog extends AbstractDialog
 
     Input formats = getImporterList();
 		group.addLabelPair(i18n.tr("Verfügbare Formate:"),formats);
+
+    if (this.forceBox == null) {
+      String newName = i18n.tr("Import erzwingen");
+      this.forceBox = new CheckboxInput(false);
+      this.forceBox.setName(newName);
+    }
+    group.addInput(this.forceBox);
 
 		ButtonArea buttons = new ButtonArea();
 		Button button = new Button(i18n.tr("Import starten"),new Action()
@@ -138,6 +147,8 @@ public class ImportDialog extends AbstractDialog
 
     settings.setAttribute("lastformat",imp.format.getName());
 
+    final boolean useForce = ((Boolean)this.forceBox.getValue()).booleanValue();
+
     FileDialog fd = new FileDialog(GUI.getShell(),SWT.OPEN);
     fd.setText(i18n.tr("Bitte wählen Sie die Datei aus, welche für den Import verwendet werden soll."));
     fd.setFilterNames(imp.format.getFileExtensions());
@@ -174,7 +185,7 @@ public class ImportDialog extends AbstractDialog
         try
         {
           InputStream is = new BufferedInputStream(new FileInputStream(file));
-          importer.doImport(context,format,is,monitor);
+          importer.doImport(context,format,is,monitor,useForce);
           monitor.setPercentComplete(100);
           monitor.setStatus(ProgressMonitor.STATUS_DONE);
           GUI.getStatusBar().setSuccessText(i18n.tr("Daten importiert aus {0}",s));

--- a/src/de/willuhn/jameica/hbci/io/AbstractDTAUSImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractDTAUSImporter.java
@@ -45,10 +45,10 @@ public abstract class AbstractDTAUSImporter extends AbstractDTAUSIO implements I
   private Hashtable kontenCache = new Hashtable();
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
   public void doImport(Object context, IOFormat format, InputStream is,
-      ProgressMonitor monitor) throws RemoteException, ApplicationException
+      ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
     // Wir merken uns die Konten, die der User schonmal ausgewaehlt
     // hat, um ihn nicht fuer jede Buchung mit immer wieder dem

--- a/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
@@ -28,13 +28,16 @@ import de.willuhn.util.ProgressMonitor;
 public abstract class AbstractImporter implements Importer
 {
   final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  protected boolean useForce = false;
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
   @Override
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
+    this.useForce = force;
+
     try
     {
       Object[] objects = this.setup(context,format,is,monitor);

--- a/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
@@ -68,8 +68,20 @@ public abstract class AbstractSepaImporter extends AbstractImporter
     PainVersion version = PainVersion.autodetect(new ByteArrayInputStream(bos.toByteArray()));
     if (version == null)
       throw new ApplicationException(i18n.tr("SEPA-Version der XML-Datei nicht ermittelbar"));
-    
+ 
     monitor.log(i18n.tr("SEPA-Version: {0}",version.getURN()));
+
+    // Überprüfe PAIN Typ
+    PainVersion.Type[] types = this.getSupportedPainTypes();
+    PainVersion.Type type = version.getType();
+    boolean found = false;
+    for (int i = 0; types != null && i < types.length; i++) {
+      if (types[i] == type) {
+        found = true;
+      }
+    }
+    if (!found)
+      throw new ApplicationException(i18n.tr("Unzulässige SEPA-Version in der XML-Datei - Überweisung und Lastschrift verwechselt?"));
     
     List<Properties> props = new ArrayList<Properties>();
     ISEPAParser parser = SEPAParserFactory.get(version);
@@ -139,5 +151,12 @@ public abstract class AbstractSepaImporter extends AbstractImporter
     }
     throw new ApplicationException(i18n.tr("Kein Konto ausgewählt"));
   }
+
+  /**
+   * Liste der zulässigen XML Daten
+   * Wird benötigt, damit eine Lastschrift nicht als Überweisung importiert werden kann.
+   * @return erlaubte PAIN Typen
+   */
+  abstract PainVersion.Type[] getSupportedPainTypes();
 
 }

--- a/src/de/willuhn/jameica/hbci/io/Importer.java
+++ b/src/de/willuhn/jameica/hbci/io/Importer.java
@@ -33,11 +33,12 @@ public interface Importer extends IO
    * @param is der Stream, aus dem die Daten gelesen werden.
    * @param monitor ein Monitor, an den der Importer Ausgaben ueber seinen
    * Bearbeitungszustand ausgeben kann.
+   * @param force Ob nicht-fatale Fehler übersprungen werden.
    * Der Importer muss den Import-Stream selbst schliessen!
    * @throws RemoteException
    * @throws ApplicationException 
    */
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException;
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException;
 
 }
 

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzImporter.java
@@ -48,9 +48,9 @@ public class MT940UmsatzImporter implements Importer
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
 
     if (is == null)

--- a/src/de/willuhn/jameica/hbci/io/MoneyplexUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MoneyplexUmsatzImporter.java
@@ -57,9 +57,9 @@ public class MoneyplexUmsatzImporter implements Importer
   private Map<String,UmsatzTyp> cache = new HashMap<String,UmsatzTyp>();
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
     cache.clear(); // Cache leeren
 

--- a/src/de/willuhn/jameica/hbci/io/SepaLastschriftImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaLastschriftImporter.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
 import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV.parsers.ISEPAParser;
+import org.kapott.hbci.sepa.PainVersion;
 
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.hbci.messaging.ImportMessage;
@@ -78,6 +79,15 @@ public class SepaLastschriftImporter extends AbstractSepaImporter
   Class[] getSupportedObjectTypes()
   {
     return new Class[]{SepaLastschrift.class};
+  }
+
+  /**
+   * @see de.willuhn.jameica.hbci.io.AbstractSepaImporter#getSupportedPainTypes()
+   */
+  @Override
+  PainVersion.Type[] getSupportedPainTypes()
+  {
+    return new PainVersion.Type[]{PainVersion.Type.PAIN_008};
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/io/SepaSammelLastschriftImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaSammelLastschriftImporter.java
@@ -16,6 +16,7 @@ import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
 import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV.parsers.ISEPAParser;
+import org.kapott.hbci.sepa.PainVersion;
 
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.hbci.HBCI;
@@ -94,6 +95,15 @@ public class SepaSammelLastschriftImporter extends AbstractSepaImporter
   Class[] getSupportedObjectTypes()
   {
     return new Class[]{SepaSammelLastschrift.class};
+  }
+
+  /**
+   * @see de.willuhn.jameica.hbci.io.AbstractSepaImporter#getSupportedPainTypes()
+   */
+  @Override
+  PainVersion.Type[] getSupportedPainTypes()
+  {
+    return new PainVersion.Type[]{PainVersion.Type.PAIN_008};
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/io/SepaSammelUeberweisungImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaSammelUeberweisungImporter.java
@@ -16,6 +16,7 @@ import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
 import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV.parsers.ISEPAParser;
+import org.kapott.hbci.sepa.PainVersion;
 
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.hbci.HBCI;
@@ -83,6 +84,15 @@ public class SepaSammelUeberweisungImporter extends AbstractSepaImporter
   Class[] getSupportedObjectTypes()
   {
     return new Class[]{SepaSammelUeberweisung.class};
+  }
+
+  /**
+   * @see de.willuhn.jameica.hbci.io.AbstractSepaImporter#getSupportedPainTypes()
+   */
+  @Override
+  PainVersion.Type[] getSupportedPainTypes()
+  {
+    return new PainVersion.Type[]{PainVersion.Type.PAIN_001};
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/io/SepaUeberweisungImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaUeberweisungImporter.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import org.apache.commons.lang.StringUtils;
 import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV.parsers.ISEPAParser;
+import org.kapott.hbci.sepa.PainVersion;
 
 import de.willuhn.datasource.rmi.DBService;
 import de.willuhn.jameica.hbci.messaging.ImportMessage;
@@ -66,6 +67,15 @@ public class SepaUeberweisungImporter extends AbstractSepaImporter
   Class[] getSupportedObjectTypes()
   {
     return new Class[]{AuslandsUeberweisung.class};
+  }
+
+  /**
+   * @see de.willuhn.jameica.hbci.io.AbstractSepaImporter#getSupportedPainTypes()
+   */
+  @Override
+  PainVersion.Type[] getSupportedPainTypes()
+  {
+    return new PainVersion.Type[]{PainVersion.Type.PAIN_001};
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/io/XMLImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLImporter.java
@@ -42,9 +42,9 @@ public class XMLImporter implements Importer
   protected final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
 
     if (is == null)

--- a/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferImporter.java
@@ -38,7 +38,7 @@ import de.willuhn.util.ProgressMonitor;
 public class XMLSepaSammelTransferImporter extends XMLImporter
 {
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
   public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
   {

--- a/src/de/willuhn/jameica/hbci/io/XMLUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLUmsatzImporter.java
@@ -37,7 +37,7 @@ import de.willuhn.util.ProgressMonitor;
 public class XMLUmsatzImporter extends XMLImporter
 {
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
   public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
   {

--- a/src/de/willuhn/jameica/hbci/io/XMLUmsatzTypImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLUmsatzTypImporter.java
@@ -39,9 +39,9 @@ public class XMLUmsatzTypImporter implements Importer
   protected final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
 
     if (is == null)

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -54,9 +54,9 @@ public class CsvImporter implements Importer
   private static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   /**
-   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
+   * @see de.willuhn.jameica.hbci.io.Importer#doImport(java.lang.Object, de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor, boolean)
    */
-  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor) throws RemoteException, ApplicationException
+  public void doImport(Object context, IOFormat format, InputStream is, ProgressMonitor monitor, boolean force) throws RemoteException, ApplicationException
   {
     try
     {


### PR DESCRIPTION
Bislang konnten SEPA Sammel-Lastschriften als SEPA Sammel-Überweisung importiert werden.
Dies konnte dazu führen, dass versehentlich die falsche Transaktionsart ausgeführt wurde.

Diese Änderung überprüft den PAIN Typ und erlaubt für den Import bei Überweisungen nur Überweisungen und bei Lastschriften nur Lastschriften.