### PR TITLE
Button 'Neue Ueberweisung' unter Konto-Details eingefuegt

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
@@ -16,6 +16,7 @@ import java.rmi.RemoteException;
 
 import javax.annotation.Resource;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Event;
@@ -33,6 +34,7 @@ import de.willuhn.jameica.gui.util.Container;
 import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.gui.action.AuslandsUeberweisungNew;
 import de.willuhn.jameica.hbci.gui.action.KontoFetchUmsaetze;
 import de.willuhn.jameica.hbci.gui.action.KontoSyncViaScripting;
 import de.willuhn.jameica.hbci.gui.action.KontoauszugRpt;
@@ -190,6 +192,12 @@ public class KontoNew extends AbstractView
     Button fetch = null;
 
     Konto konto = control.getKonto();
+    
+    if (StringUtils.trimToNull(konto.getIban()) != null)
+    {
+      buttons.addButton(i18n.tr("Neue Überweisung"),new AuslandsUeberweisungNew(),konto,false,"stock_next.png");
+    }
+    
     if (konto.hasFlag(Konto.FLAG_OFFLINE))
     {
       fetch = new Button(i18n.tr("Umsatz anlegen"), new UmsatzDetailEdit(),konto,false,"emblem-documents.png");


### PR DESCRIPTION
Der Button "Neue Überweisung" würde in der Ansicht "Konto-Details" die usability verbessern. 

Um aus der Ansicht "Konto-Details" eine Überweisung zu tätigen, muss man ansonsten:
* über den Zurück-Button auf die Kontoübersicht wechseln, um hier das selbe Konto nochmal zu suchen und per Kontext-Menü "Neue Überweisung" auszuwählen
* oder per Shortcut ALT-U, wobei man hier auch nochmals das Konto aus der Auswahlbox suchen muss

Die beiden jetzigen Möglichkeiten sind mit einigen Klicks verbunden, welche ich gerne vermeiden möchte.