### PR TITLE
reload only on value change

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/EventUtil.java
+++ b/src/de/willuhn/jameica/hbci/gui/EventUtil.java
@@ -1,0 +1,19 @@
+package de.willuhn.jameica.hbci.gui;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+
+/**
+ * Util-Klasse fuer Event-Behandlung
+ * */
+public class EventUtil
+{
+
+  /**
+   * @param event Event, das geprüft werden soll
+   * @return ist Event vom Typ Fokus bekommen/verloren
+   */
+  public static boolean isFocusEvent(Event event){
+    return event!=null && (event.type==SWT.FocusIn || event.type==SWT.FocusOut);
+  }
+}

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
@@ -15,7 +15,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
@@ -32,6 +31,7 @@ import de.willuhn.jameica.gui.parts.TreePart;
 import de.willuhn.jameica.gui.util.DelayedListener;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.HBCIProperties;
+import de.willuhn.jameica.hbci.gui.EventUtil;
 import de.willuhn.jameica.hbci.gui.filter.KontoFilter;
 import de.willuhn.jameica.hbci.gui.input.DateFromInput;
 import de.willuhn.jameica.hbci.gui.input.DateToInput;
@@ -82,7 +82,9 @@ public class UmsatzTypTreeControl extends AbstractControl
     this.listener = new DelayedListener(new Listener() {
       public void handleEvent(Event event)
       {
-        handleReload();
+        if(!EventUtil.isFocusEvent(event)){
+          handleReload();
+        }
       }
     });
   }
@@ -131,13 +133,10 @@ public class UmsatzTypTreeControl extends AbstractControl
       return this.range;
     
     this.range = new RangeInput(this.getStart(),this.getEnd(),"umsatzlist.filter.range");
-    this.range.addListener(new Listener()
+    range.addRangeValueListener(new Listener()
     {
       public void handleEvent(Event event)
       {
-        //TODO maybe add addSetValueListener method to RangeInput wrapping this check
-        //because the typical usecase will be a reload on value change
-        if (event.type==SWT.Selection && range.getValue() != null)
           handleReload();
       }
     });

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
@@ -134,7 +135,9 @@ public class UmsatzTypTreeControl extends AbstractControl
     {
       public void handleEvent(Event event)
       {
-        if (range.getValue() != null)
+        //TODO maybe add addSetValueListener method to RangeInput wrapping this check
+        //because the typical usecase will be a reload on value change
+        if (event.type==SWT.Selection && range.getValue() != null)
           handleReload();
       }
     });

--- a/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
@@ -7,6 +7,7 @@
 
 package de.willuhn.jameica.hbci.gui.input;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
@@ -98,6 +99,22 @@ public class RangeInput extends SelectInput
         
         settings.setAttribute(param,choosen != null ? choosen.getId() : null);
         applyRange(choosen);
+      }
+    });
+  }
+
+  /**
+   * Delegiert an listener, wenn es sich um ein Selection-Event handelt und die Auswahl nicht null ist
+   * @param listener Listener, an den das Selection-Event weitergegeben wird
+   * */ 
+  public void addRangeValueListener(final Listener listener){
+    addListener(new Listener(){
+      @Override
+      public void handleEvent(Event event)
+      {
+        if(event.type==SWT.Selection && getValue()!=null){
+          listener.handleEvent(event);
+        }
       }
     });
   }

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractFromToList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractFromToList.java
@@ -37,6 +37,7 @@ import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.HBCIProperties;
+import de.willuhn.jameica.hbci.gui.EventUtil;
 import de.willuhn.jameica.hbci.gui.filter.KontoFilter;
 import de.willuhn.jameica.hbci.gui.input.DateFromInput;
 import de.willuhn.jameica.hbci.gui.input.DateToInput;
@@ -87,7 +88,9 @@ public abstract class AbstractFromToList extends TablePart implements Part
         // forciertes Update - ohne zu beruecksichtigen,
         // ob in den Eingabe-Feldern wirklich was geaendert
         // wurde
-        handleReload(event == null);
+        if(!EventUtil.isFocusEvent(event)){
+          handleReload(event == null);
+        }
       }
     };
     

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -356,12 +356,11 @@ public class KontoauszugList extends UmsatzList
       return this.range;
     
     this.range = new RangeInput(this.getStart(),this.getEnd(),"umsatzlist.filter.range");
-    this.range.addListener(new Listener()
+    this.range.addRangeValueListener(new Listener()
     {
       public void handleEvent(Event event)
       {
-        if (range.getValue() != null)
-          handleReload(true);
+        handleReload(true);
       }
     });
     

--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -44,6 +44,7 @@ import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.jameica.hbci.gui.ColorUtil;
+import de.willuhn.jameica.hbci.gui.EventUtil;
 import de.willuhn.jameica.hbci.gui.action.SparQuoteExport;
 import de.willuhn.jameica.hbci.gui.chart.LineChart;
 import de.willuhn.jameica.hbci.gui.chart.LineChartData;
@@ -99,10 +100,12 @@ public class SparQuote implements Part
       {
         try
         {
-          load();
-          redraw();
-          if (chart != null)
-            chart.redraw();
+          if(!EventUtil.isFocusEvent(event)){
+            load();
+            redraw();
+            if (chart != null)
+              chart.redraw();
+          }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
Currently, a reload is done for every event, including focus gained and focus lost. This leads to unnecessary reloads of the data. For large data sets this can cause noticeable delays (at least I find them annoying).

This commit is a proof of concept. Actually I would prefer adding a dedicated addSetValue method to RangeInput, the advantage being that the guards would not have to be implemented in every class using the RangeInput.