### PR TITLE
simplify entering multiple offline account bookings

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/views/UmsatzDetailEdit.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UmsatzDetailEdit.java
@@ -13,10 +13,16 @@
 
 package de.willuhn.jameica.hbci.gui.views;
 
+import java.rmi.RemoteException;
+
 import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.parts.Button;
 import de.willuhn.jameica.gui.parts.ButtonArea;
 import de.willuhn.jameica.hbci.gui.controller.UmsatzDetailControl;
 import de.willuhn.jameica.hbci.gui.controller.UmsatzDetailEditControl;
+import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.rmi.Umsatz;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 
 /**
@@ -34,14 +40,37 @@ public class UmsatzDetailEdit extends AbstractUmsatzDetail
     super.bind();
     
     ButtonArea buttons = new ButtonArea();
+    final Button newBooking=getNewBookingButton();
+    if(newBooking!=null){
+      buttons.addButton(newBooking);
+    }
     buttons.addButton(i18n.tr("&Speichern"),new Action()
     {
       public void handleAction(Object context) throws ApplicationException
       {
         getControl().handleStore();
+        if(newBooking!=null){
+          newBooking.setEnabled(true);
+        }
       }
     },null,true,"document-save.png");
     buttons.paint(getParent());
+  }
+
+  private Button getNewBookingButton(){
+    Umsatz umsatz = getControl().getUmsatz();
+    try
+    {
+      if(umsatz.isNewObject() && umsatz.getKonto().hasFlag(Konto.FLAG_OFFLINE)){
+        Button button=new Button(i18n.tr("weiteren Umsatz anlegen"), new de.willuhn.jameica.hbci.gui.action.UmsatzDetailEdit(), umsatz.getKonto(), false, "emblem-documents.png");
+        button.setEnabled(false);
+        return button;
+      }
+    } catch (RemoteException e)
+    {
+      Logger.error("error while checking checking whether to add 'New Booking' button",e);
+    }
+    return null;
   }
 
   /**

--- a/src/lang/hibiscus_messages_en.properties
+++ b/src/lang/hibiscus_messages_en.properties
@@ -757,6 +757,7 @@ Passende\ Gegenbuchungen\ automatisch\ anlegen=Automatically\ create\ matching\ 
 via\ Scripting\ synchronisieren=Synchronize\ via\ Scripting
 hibiscus-export-{0}.html=hibiscus-export-{0}.html
 Umsatz\ anlegen=Create\ Booking
+weiteren\ Umsatz\ anlegen=Create\ another\ Booking
 Cash\ Management\ Transfer=Cash\ Management\ Transfer
 Gutschrift/R\u00FCck\u00FCberweisung=Refund/Credit\ Note
 Miete=Rent


### PR DESCRIPTION
Die vorgeschlagene Änderung erleichtert die Eingabe mehrerer Offline-Umsätze hintereinander. Handelt es sich um einen neuen Umsatz für ein Offline-Konto wird neben dem Speichern-Knopf ein weiterer angezeigt, der nach dem Speichern aktiviert wird und die nächste Eingabemaske öffnet.