### PR TITLE
action for recalculating offline account balances

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/KontoRecalculateOfflineSaldo.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoRecalculateOfflineSaldo.java
@@ -1,0 +1,101 @@
+package de.willuhn.jameica.hbci.gui.action;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.messaging.ObjectChangedMessage;
+import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.rmi.Umsatz;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+/**
+ * Action zur Neubestimmung der Buchungssalden eines Offline-Kontos
+ */
+public class KontoRecalculateOfflineSaldo implements Action
+{
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+
+  /**
+   * Erwartet ein Objekt vom Typ <code>Konto</code> im Context.
+   * 
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  public void handleAction(Object context) throws ApplicationException
+  {
+
+    if (context == null || !(context instanceof Konto))
+      throw new ApplicationException(i18n.tr("Bitte wählen Sie ein Konto aus"));
+
+    try
+    {
+      Konto k = (Konto) context;
+      if (k.isNewObject() || !k.hasFlag(Konto.FLAG_OFFLINE))
+        return;
+
+      String q = i18n.tr("SaldenNeuBerechnenBestaetigung");
+
+      if (!Application.getCallback().askUser(q))
+        return;
+
+      Umsatz previousIterator=null;
+      List<Umsatz> umsaetze=new ArrayList<Umsatz>();
+      DBIterator it = k.getUmsaetze();
+      double currentSaldo=0d;
+      while (it.hasNext()){
+        Umsatz um = (Umsatz)it.next();
+        checkOrder(previousIterator, um);
+        if(um.hasFlag(Umsatz.FLAG_CHECKED)){
+          currentSaldo=um.getSaldo();
+          break;
+        }
+        umsaetze.add(um);
+        previousIterator=um;
+      }
+
+      Collections.reverse(umsaetze);
+
+      for (Umsatz umsatz : umsaetze)
+      {
+        currentSaldo+=umsatz.getBetrag();
+        umsatz.setSaldo(currentSaldo);
+        umsatz.store();
+      }
+      k.setSaldo(currentSaldo);
+      k.store();
+      Application.getMessagingFactory().sendMessage(new ObjectChangedMessage(k));
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Salden neu berechnet."), StatusBarMessage.TYPE_SUCCESS));
+    }
+    catch (Exception e)
+    {
+      Logger.error("error while recalculating balances", e);
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Fehler beim Berechnen der Salden."), StatusBarMessage.TYPE_ERROR));
+      return;
+    }
+  }
+
+  private void checkOrder(Umsatz previousIterator, Umsatz current) throws RemoteException{
+    if(previousIterator!=null){
+      boolean orderOK=true;
+      if(current.getDatum().after(previousIterator.getDatum())){
+        orderOK=false;
+      }else if(current.getDatum().equals(previousIterator.getDatum())){
+        if(Long.parseLong(current.getID())>Long.parseLong(previousIterator.getID())){
+          orderOK=false;
+        }
+      }
+      if(!orderOK){
+        throw new IllegalStateException("unexpected order of bookings; cancel recalculating balance");
+      }
+    }
+  }
+
+}

--- a/src/de/willuhn/jameica/hbci/gui/menus/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/KontoList.java
@@ -30,6 +30,7 @@ import de.willuhn.jameica.hbci.gui.action.KontoExport;
 import de.willuhn.jameica.hbci.gui.action.KontoFetchUmsaetze;
 import de.willuhn.jameica.hbci.gui.action.KontoImport;
 import de.willuhn.jameica.hbci.gui.action.KontoNew;
+import de.willuhn.jameica.hbci.gui.action.KontoRecalculateOfflineSaldo;
 import de.willuhn.jameica.hbci.gui.action.KontoResetAuszugsdatum;
 import de.willuhn.jameica.hbci.gui.action.KontoauszugRpt;
 import de.willuhn.jameica.hbci.gui.action.SepaDauerauftragNew;
@@ -163,6 +164,7 @@ public class KontoList extends ContextMenu implements Extendable
       this.setText(i18n.tr("Erweitert"));
       this.setImage(SWTUtil.getImage("emblem-symbolic-link.png"));
       addItem(new CheckedSingleContextMenuItem(i18n.tr("Saldo und Datum zurücksetzen..."), new KontoResetAuszugsdatum(),"edit-undo.png"));
+      addItem(new AccountItem(i18n.tr("Salden neu berechnen..."), new KontoRecalculateOfflineSaldo(),"accessories-calculator.png").offlineAccount());
       addItem(new ChangeFlagsMenuItem(i18n.tr("Konto deaktivieren..."), new KontoDisable(),"network-offline.png",false));
       addItem(new ChangeFlagsMenuItem(i18n.tr("Konto aktivieren..."), new FlaggableChange(Konto.FLAG_DISABLED,false),"network-transmit-receive.png",true));
     }

--- a/src/lang/hibiscus_messages_de_DE.properties
+++ b/src/lang/hibiscus_messages_de_DE.properties
@@ -1,0 +1,1 @@
+SaldenNeuBerechnenBestaetigung=Die Umsatzsalden werden ab dem letzten geprüften Umsatz neu berechnet.\nSollte es keinen geben, werden alle Salden neu berechnet, wobei der Kontoanfangssaldo 0,00 angenommen wird.

--- a/src/lang/hibiscus_messages_en.properties
+++ b/src/lang/hibiscus_messages_en.properties
@@ -974,4 +974,7 @@ Aktualisiere\ BPD=Updating\ BPD
 Einnahmen\ ({0}\ Tage)=Revenues\ ({0}\ Days)
 Ausgaben\ ({0}\ Tage)=Expenditures\ ({0}\ Days)
 Die\ Auswahl\ einer\ Konto-Gruppen\ ist\ hier\ nicht\ m\u00F6glich=Selecting\ a\ whole\ group\ \of\ bank-accounts\ is\ not\ supported
-
+Salden\ neu\ berechnen...=Recalculate balances...
+SaldenNeuBerechnenBestaetigung=Starting\ with\ the\ last\ confirmed\ transaction,\ balances\ are\ recalculated.\nIf\ there\ is\none,\ all\ are\ recalculated\ assuming\ the inital\ account\ balance\ is 0.00.
+Salden\ neu\ berechnet.=Finished\ balance\ recalculation.
+Fehler\ beim\ Berechnen\ der\ Salden.=Error while recalculating balances.


### PR DESCRIPTION
Wenn man neue Buchungen einträgt, erfolgt die Saldenberechnung anhand des aktuellen Kontosaldos. Wenn man die Buchungen also in der falschen Reihenfolge einträgt, stimmen weder die Umsatzsalden noch der Endsaldo des Kontos. Die neue Aktion "Salden neu berechnen" bereinigt das. Die Sortierreihenfolge der Buchungen passt zu der von erwarteten (Buchungsdatum dann ID).

Bugzilla 451 behandelt ein verwandtes Problem, das ich aber hier außen vor lasse.