### PR TITLE
auto valuta date for offline accounts

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -264,8 +264,25 @@ public class UmsatzDetailControl extends AbstractControl
     {
       this.datum = new DateInput(getUmsatz().getDatum(),HBCI.DATEFORMAT);
       this.datum.setEnabled(false);
+      adaptValutaInput(this.datum);
     }
     return this.datum;
+  }
+
+  //Wenn das Valuta-Datum automtisch angepasst werden soll, wird ein entsprechender Listener hinzugefügt
+  private void adaptValutaInput(final Input datum) throws RemoteException{
+    if(umsatz!=null && umsatz.getKonto().hasFlag(Konto.FLAG_AUTO_VALUTA_DATE)){
+      final Input valuta = getValuta();
+      datum.addListener(new Listener() {
+        @Override
+        public void handleEvent(Event event)
+        {
+          if(datum.hasChanged()){
+            valuta.setValue(datum.getValue());
+          }
+        }
+      });
+    }
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
@@ -173,7 +173,8 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
   public Input getValuta() throws RemoteException
   {
     Input input = super.getValuta();
-    if (!input.isEnabled())
+    boolean suppressEnablement=getUmsatz().getKonto().hasFlag(Konto.FLAG_AUTO_VALUTA_DATE);
+    if (!input.isEnabled() && !suppressEnablement)
     {
       input.setMandatory(true);
       input.setEnabled(true);

--- a/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
@@ -158,6 +158,7 @@ public class KontoNew extends AbstractView
       right.addLabelPair(i18n.tr("IBAN"),                     control.getIban());
       right.addLabelPair(i18n.tr("BIC"),                      control.getBic());
       right.addInput(control.getOffline());
+      right.addInput(control.getSynchDates());
     }
     
     // und noch die Abschicken-Knoepfe

--- a/src/de/willuhn/jameica/hbci/rmi/Konto.java
+++ b/src/de/willuhn/jameica/hbci/rmi/Konto.java
@@ -38,6 +38,11 @@ public interface Konto extends HibiscusDBObject, Checksum, Flaggable
   public final static int FLAG_OFFLINE = 1 << 1;
 
   /**
+   * Flag "Valuta-Datum automatisch mit Buchungsdatum belegen".
+   */
+  public final static int FLAG_AUTO_VALUTA_DATE = 1 << 2;
+
+  /**
 	 * Liefert die Kontonummer fuer diese Bankverbindung.
 	 * 
 	 * @return Kontonummer.

--- a/src/lang/hibiscus_messages_en.properties
+++ b/src/lang/hibiscus_messages_en.properties
@@ -974,4 +974,4 @@ Aktualisiere\ BPD=Updating\ BPD
 Einnahmen\ ({0}\ Tage)=Revenues\ ({0}\ Days)
 Ausgaben\ ({0}\ Tage)=Expenditures\ ({0}\ Days)
 Die\ Auswahl\ einer\ Konto-Gruppen\ ist\ hier\ nicht\ m\u00F6glich=Selecting\ a\ whole\ group\ \of\ bank-accounts\ is\ not\ supported
-
+automatisches\ Valutadatum= auto Valuta date


### PR DESCRIPTION
Bei Offline-Konten ist eine Unterscheidung zwischen Buchungs- und Valuta-Datum häufig nicht sinnvoll. Ein zusätzliches Flag steuert, dass beim Editieren des Umsatzes das Valuta-Datum automatisch mit dem Buchungsdatum belegt wird.