### PR TITLE
BUGZILLA 1513 add "not catagorized" to filter

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -193,7 +193,7 @@ public class UmsatzDetailControl extends AbstractControl
     
     // Ansonsten alle - damit die zugeordnete Kategorie auch dann noch
     // noch angeboten wird, der User nachtraeglich den Kat-Typ geaendert hat.
-    this.umsatzTyp = new UmsatzTypInput(ut,typ);
+    this.umsatzTyp = new UmsatzTypInput(ut,typ, false);
     
     this.umsatzTyp.setEnabled((u.getFlags() & Umsatz.FLAG_NOTBOOKED) == 0);
     return this.umsatzTyp;

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
@@ -257,7 +257,7 @@ public class UmsatzTypControl extends AbstractControl
   public UmsatzTypInput getParent() throws RemoteException
   {
     if (this.parent == null)
-      this.parent = new UmsatzTypInput((UmsatzTyp)getUmsatzTyp().getParent(),getUmsatzTyp(),UmsatzTyp.TYP_EGAL);
+      this.parent = new UmsatzTypInput((UmsatzTyp)getUmsatzTyp().getParent(),getUmsatzTyp(),UmsatzTyp.TYP_EGAL, false);
     return this.parent;
   }
 

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -381,7 +381,7 @@ public class KontoauszugList extends UmsatzList
     UmsatzTyp preset = (UmsatzTyp) cache.get("kontoauszug.list.kategorie");
     if (preset == null || preset.getID() == null)
       preset = null; // wurde zwischenzeitlich geloescht
-    this.kategorie = new UmsatzTypInput(preset,UmsatzTyp.TYP_EGAL);
+    this.kategorie = new UmsatzTypInput(preset,UmsatzTyp.TYP_EGAL, true);
     this.kategorie.setPleaseChoose(i18n.tr("<Alle Kategorien>"));
     this.kategorie.setComment(null);
     this.kategorie.addListener(this.listener);


### PR DESCRIPTION
Eine zugegebenermaßen ziemlich hackiger Ansatz auch nach nicht kategoriserten Umsätzen filtern zu können - man erzeugt ein On-The-Fly-UmsatzTypBean und hofft, dass außer den beiden überschriebenen Methoden nichts aufgerufen wird, insb. was in Richtung Datenbank gehen würde... Funktioniert bis auf die Einstellung, die sich die letzte Auswahl merkt, ganz gut.