### PR TITLE
enhance PR #19, valuta date not preset/mandatory for offline accounts

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzDetailEdit.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzDetailEdit.java
@@ -51,7 +51,6 @@ public class UmsatzDetailEdit implements Action
         Umsatz u = (Umsatz) Settings.getDBService().createObject(Umsatz.class,null);
         u.setKonto(k);
         Date d = new Date();
-        u.setValuta(d);
         u.setDatum(d);
         context = u;
       }

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
@@ -177,7 +177,14 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
     Input input = super.getValuta();
     if (!input.isEnabled())
     {
-      input.setMandatory(true);
+      boolean mandatory=true;
+      Object current = getCurrentObject();
+      if(current instanceof Umsatz){
+        if(((Umsatz) current).getKonto().hasFlag(Konto.FLAG_OFFLINE)){
+          mandatory=false;
+        }
+      }
+      input.setMandatory(mandatory);
       input.setEnabled(true);
     }
     return input;


### PR DESCRIPTION
Die Modifikationen, die für Pull Request #19 gemacht wurden, greifen noch nicht ganz. Wenn man für ein Offline-Konto eine Buchung anlegt, ist das Valuta-Datum schon vorbelegt. Man müsste es also zunächst löschen, damit es dann automatisch mit dem selbst eingegebenen Datum belegt wird.

Diese Ergänzung lässt das Vorbelegen weg und setzt auch nicht das "Mandatory"-Flag für das Feld, sonst sieht es für den Nutzer so aus, als ob er vor dem Speichern ein Datum eingeben müsste.