### PR TITLE
BUGZILLA 1146 counter entry can be created from context menu

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzDetailEdit.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzDetailEdit.java
@@ -32,6 +32,20 @@ import de.willuhn.util.I18N;
 public class UmsatzDetailEdit implements Action
 {
 
+  private boolean createReverse=false;
+  private Konto toBookTo=null;
+
+  /**
+   * setzt ein flag, dass die Gegenbuchung des Kontext-Objects erstellt werden soll
+   * @param toBookTo Offline-Konto, auf das die Gegenbuchung erstellt werden soll
+   * @return das (modifizierte) Objekt selbst
+   * */
+  public UmsatzDetailEdit asReverse(Konto toBookTo){
+    this.createReverse=true;
+    this.toBookTo=toBookTo;
+    return this;
+  }
+
   /**
    * Erwartet ein Objekt vom Typ <code>Umsatz</code> im Context.
    * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
@@ -61,8 +75,26 @@ public class UmsatzDetailEdit implements Action
         throw new ApplicationException(i18n.tr("Fehler beim Anlegen des Umsatzes: {0}",re.getMessage()));
       }
     }
-    else if (!(context instanceof Umsatz))
+    else if (!(context instanceof Umsatz)){
       return;
+    }else if(createReverse){
+      try
+      {
+        Umsatz orig=(Umsatz)context;
+        Umsatz u = orig.duplicate();
+        u.setKonto(toBookTo);
+        u.setBetrag(-orig.getBetrag());
+        Konto konto = orig.getKonto();
+        u.setGegenkontoBLZ(konto.getBLZ());
+        u.setGegenkontoName(konto.getName());
+        u.setGegenkontoNummer(konto.getKontonummer());
+        u.setUmsatzTyp(null);
+        context = u;
+      } catch (RemoteException e)
+      {
+        throw new ApplicationException(e);
+      } 
+    }
 		GUI.startView(de.willuhn.jameica.hbci.gui.views.UmsatzDetailEdit.class,context);
   }
 }

--- a/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
@@ -7,6 +7,8 @@
 
 package de.willuhn.jameica.hbci.gui.views;
 
+import java.rmi.RemoteException;
+
 import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.util.ColumnLayout;
@@ -14,6 +16,7 @@ import de.willuhn.jameica.gui.util.SimpleContainer;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.controller.UmsatzDetailControl;
 import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.rmi.Umsatz;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.util.I18N;
 
@@ -85,5 +88,24 @@ public abstract class AbstractUmsatzDetail extends AbstractView
     bottom.addHeadline(i18n.tr("Verwendungszweck"));
     bottom.addPart(control.getZweck());
     bottom.addInput(control.getZweckSwitch());
+
+    forceSaldoUpdateforReverseBooking();
+  }
+
+  private void forceSaldoUpdateforReverseBooking()
+  {
+    if(getCurrentObject() instanceof Umsatz){
+      Umsatz umsatz=(Umsatz)getCurrentObject();
+      try
+      {
+        if(umsatz.isNewObject() && umsatz.getKonto().hasFlag(Konto.FLAG_OFFLINE)){
+          getControl().getBetrag().getControl().forceFocus();//->Saldenberechnungslistener feuert
+          getControl().getUmsatzTyp().focus();
+        }
+      } catch (RemoteException e)
+      {
+        //einfach ignoriere, wir wollen ja nur ein Feld vorsorglich aktualisieren
+      }
+    }
   }
 }

--- a/src/lang/hibiscus_messages_en.properties
+++ b/src/lang/hibiscus_messages_en.properties
@@ -982,4 +982,4 @@ Fehler\ beim\ Berechnen\ der\ Salden.=Error\ while\ recalculating\ balances.
 Die\ Umsatzsalden\ werden\ ab\ dem\ letzten\ geprüften\ Umsatz\ neu\ berechnet.\nSollte\ es\ keinen\ geben,\ werden\ alle\ Salden\ neu\ berechnet,\ wobei\ der\ Anfangssaldo\ 0,00\ angenommen\ wird.=Starting\ with\ the\ last\ confirmed\ transaction,\ balances\ are\ recalculated.\nIf\ there\ is\none,\ all\ are\ recalculated\ assuming\ the inital\ account\ balance\ is 0.00.
 Reihenfolge\ der\ Buchungsdaten\ falsch.\ Buchung\ Nr.\ {0}\ befindet\ sich\ vor\ Buchung\ Nr.\ {1}=Order\ of\ bookings\ wrong.\ Date\ of\ booking\ no.\ {0}\ before\ booking\ no.\ {1}
 Die\ zu\ exportierenden\ Umsätze\ müssen\ vom\ selben\ Konto\ stammen=The\ bookings\ to\ be\ exported\ have\ to\ be\ come\ from\ the\ same\ account
- 
+Gegenbuchung\ erzeugen\ auf=Create\ reversing\ entry\ in


### PR DESCRIPTION
Im Umsatz-Kontextmenü gibt es einen zusätzlichen Eintrag für das Erzeugen von Gegenbuchungen auf Offline-Konten. Gibt es nur ein Offline-Konto, kann direkt darauf gebucht werden, ansonsten muss aus einem Untermnü zunächst das Zielkonto ausgewählt werden. Es ist nicht möglich eine Gegenbuchung auf das Ursprungskonto zu erzeugen. Der Betrag wird negiert und die Umsatzkategorie entfernt, die Gegenkontoinformation wird aus der Ursprungsbuchung übernommen.

Es handelt sich um eine reine Abkürzung für die Erzeugung einer manuellen Buchung, d.h. es liegt in der Verantwortung des Nutzer, nicht mehrere identische Gegenbuchungen zu erzeugen.