### PR TITLE
BUGZILLA 1279 toggle chart elements

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/chart/BarChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/BarChart.java
@@ -26,10 +26,10 @@ import org.swtchart.IAxis;
 import org.swtchart.IAxisTick;
 import org.swtchart.IBarSeries;
 import org.swtchart.IGrid;
+import org.swtchart.ISeries.SeriesType;
 import org.swtchart.ISeriesLabel;
 import org.swtchart.ITitle;
 import org.swtchart.LineStyle;
-import org.swtchart.ISeries.SeriesType;
 import org.swtchart.ext.InteractiveChart;
 
 import de.willuhn.datasource.BeanUtil;
@@ -60,22 +60,22 @@ public class BarChart extends AbstractChart
     SWTUtil.disposeChildren(this.comp);
     this.comp.setLayout(SWTUtil.createGrid(1,false));
 
-    this.chart = new InteractiveChart(this.comp,SWT.BORDER);
-    this.chart.setLayoutData(new GridData(GridData.FILL_BOTH));
-    this.chart.getLegend().setVisible(false);
-    this.chart.setOrientation(SWT.VERTICAL);
+    setChart(new InteractiveChart(this.comp,SWT.BORDER));
+    getChart().setLayoutData(new GridData(GridData.FILL_BOTH));
+    getChart().getLegend().setVisible(false);
+    getChart().setOrientation(SWT.VERTICAL);
 
     ////////////////////////////////////////////////////////////////////////////
     // Farben des Charts
-    this.chart.setBackground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-    this.chart.setBackgroundInPlotArea(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+    getChart().setBackground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+    getChart().setBackgroundInPlotArea(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
     //
     ////////////////////////////////////////////////////////////////////////////
     
     ////////////////////////////////////////////////////////////////////////////
     // Titel des Charts
     {
-      ITitle title = this.chart.getTitle();
+      ITitle title = getChart().getTitle();
       title.setText(this.getTitle());
       title.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_BLACK));
       title.setFont(Font.BOLD.getSWTFont());
@@ -89,7 +89,7 @@ public class BarChart extends AbstractChart
     
     // X-Achse
     {
-      IAxis axis = this.chart.getAxisSet().getXAxis(0);
+      IAxis axis = getChart().getAxisSet().getXAxis(0);
       axis.getTitle().setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE)); // wenn wir den auch ausblenden, geht die initiale Skalierung kaputt. Scheint ein Bug zu sein
 
       IGrid grid = axis.getGrid();
@@ -101,7 +101,7 @@ public class BarChart extends AbstractChart
     
     // Y-Achse
     {
-      IAxis axis = this.chart.getAxisSet().getYAxis(0);
+      IAxis axis = getChart().getAxisSet().getYAxis(0);
       axis.getTitle().setVisible(false);
 
       IGrid grid = axis.getGrid();
@@ -155,11 +155,11 @@ public class BarChart extends AbstractChart
       if (dataLine.size() == 0)
         continue; // wir haben gar keine Werte
 
-      IAxis axis = this.chart.getAxisSet().getXAxis(0);
+      IAxis axis = getChart().getAxisSet().getXAxis(0);
       axis.setCategorySeries(labelLine.toArray(new String[labelLine.size()]));
       axis.enableCategory(true);
 
-      IBarSeries barSeries = (IBarSeries) this.chart.getSeriesSet().createSeries(SeriesType.BAR,Integer.toString(i));
+      IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,Integer.toString(i));
       barSeries.setYSeries(toArray(dataLine));
       
       //////////////////////////////////////////////////////////////////////////
@@ -177,11 +177,11 @@ public class BarChart extends AbstractChart
     }
 
     // Titel aktualisieren
-    ITitle title = this.chart.getTitle();
+    ITitle title = getChart().getTitle();
     title.setText(this.getTitle());
 
     this.comp.layout();
-    this.chart.getAxisSet().adjustRange();
+    getChart().getAxisSet().adjustRange();
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/chart/LineChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/LineChart.java
@@ -55,12 +55,12 @@ public class LineChart extends AbstractChart<LineChartData>
    */
   public void redraw() throws RemoteException
   {
-    if (this.chart == null || this.chart.isDisposed())
+    if (getChart() == null || getChart().isDisposed())
       return;
     
     // Cleanup, falls noetig
     {
-      ISeriesSet set = this.chart.getSeriesSet();
+      ISeriesSet set = getChart().getSeriesSet();
       ISeries[] series = set.getSeries();
       for (ISeries s:series)
         set.deleteSeries(s.getId());
@@ -104,7 +104,7 @@ public class LineChart extends AbstractChart<LineChartData>
       if (cd.getLabel() != null)
         id += " " + cd.getLabel();
       
-      ILineSeries lineSeries = (ILineSeries) this.chart.getSeriesSet().createSeries(SeriesType.LINE,id);
+      ILineSeries lineSeries = (ILineSeries) getChart().getSeriesSet().createSeries(SeriesType.LINE,id);
       lineSeries.setXDateSeries(labelLine.toArray(new Date[labelLine.size()]));
       lineSeries.setYSeries(toArray(dataLine));
       
@@ -131,7 +131,7 @@ public class LineChart extends AbstractChart<LineChartData>
       //////////////////////////////////////////////////////////////////////////
     }
     
-    this.chart.getAxisSet().adjustRange();
+    getChart().getAxisSet().adjustRange();
   }
 
   /**
@@ -139,23 +139,23 @@ public class LineChart extends AbstractChart<LineChartData>
    */
   public void paint(Composite parent) throws RemoteException
   {
-    if (this.chart != null)
+    if (getChart() != null)
       return;
     
-    this.chart = new InteractiveChart(parent,SWT.BORDER);
-    this.chart.setLayoutData(new GridData(GridData.FILL_BOTH));
+    setChart(new InteractiveChart(parent,SWT.BORDER));
+    getChart().setLayoutData(new GridData(GridData.FILL_BOTH));
 
     ////////////////////////////////////////////////////////////////////////////
     // Farben des Charts
-    this.chart.setBackground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
-    this.chart.setBackgroundInPlotArea(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+    getChart().setBackground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+    getChart().setBackgroundInPlotArea(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
     //
     ////////////////////////////////////////////////////////////////////////////
     
     ////////////////////////////////////////////////////////////////////////////
     // Titel des Charts
     {
-      ITitle title = this.chart.getTitle();
+      ITitle title = getChart().getTitle();
       title.setText(this.getTitle());
       title.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
       title.setFont(Font.BOLD.getSWTFont());
@@ -166,7 +166,7 @@ public class LineChart extends AbstractChart<LineChartData>
     ////////////////////////////////////////////////////////////////////////////
     // Legende
     {
-      ILegend legend = this.chart.getLegend();
+      ILegend legend = getChart().getLegend();
       legend.setFont(Font.SMALL.getSWTFont());
       legend.setPosition(SWT.RIGHT);
       legend.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
@@ -180,7 +180,7 @@ public class LineChart extends AbstractChart<LineChartData>
     
     // X-Achse
     {
-      IAxis axis = this.chart.getAxisSet().getXAxis(0);
+      IAxis axis = getChart().getAxisSet().getXAxis(0);
       axis.getTitle().setFont(Font.SMALL.getSWTFont());
       axis.getTitle().setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE)); // wenn wir den auch ausblenden, geht die initiale Skalierung kaputt. Scheint ein Bug zu sein
 
@@ -195,7 +195,7 @@ public class LineChart extends AbstractChart<LineChartData>
     
     // Y-Achse
     {
-      IAxis axis = this.chart.getAxisSet().getYAxis(0);
+      IAxis axis = getChart().getAxisSet().getYAxis(0);
       axis.getTitle().setVisible(false);
 
       IGrid grid = axis.getGrid();

--- a/src/lang/hibiscus_messages_en.properties
+++ b/src/lang/hibiscus_messages_en.properties
@@ -983,3 +983,5 @@ Die\ Umsatzsalden\ werden\ ab\ dem\ letzten\ geprüften\ Umsatz\ neu\ berechnet.\
 Reihenfolge\ der\ Buchungsdaten\ falsch.\ Buchung\ Nr.\ {0}\ befindet\ sich\ vor\ Buchung\ Nr.\ {1}=Order\ of\ bookings\ wrong.\ Date\ of\ booking\ no.\ {0}\ before\ booking\ no.\ {1}
 Die\ zu\ exportierenden\ Umsätze\ müssen\ vom\ selben\ Konto\ stammen=The\ bookings\ to\ be\ exported\ have\ to\ be\ come\ from\ the\ same\ account
 Gegenbuchung\ erzeugen\ auf=Create\ reversing\ entry\ in
+alle\ anzeigen=show\ all
+alle\ ausblenden=hide\ all


### PR DESCRIPTION
In einer Chartlegende kann man mit Doppelklick eine Datenserie ein-/ausblenden. Im Kontextmenü kann man alle ein-/ausblenden lassen.
Ich habe Doppelklick gewählt, damit die Änderung nicht aus Versehen passiert. Außerdem müsste man sonst noch den Button prüfen, um nicht beim Kontextmenü-Öffnen eine Serie auszublenden.

Ein Kontextmenüeintrag "nur diesen anzeigen" ist mit mehr Aufwand verbunden, da die Position, an der das Menü geöffnet wird, nicht unmittelbar verfügbar ist und des in der Legende ja kein selektiertes Element gibt. Es wäre möglich, die zuletzt gewählte Serie im MouseListener (AbstractChart Zeile 88) zu speichern um sie dann im Menü verfügbar zu haben. Das halte ich aktuell aber für Overkill.

Mit der Kombination alles an/aus + toggle sollte man gut hinkommen.