### PR TITLE
Sepa import: determine missing BIC from IBAN

### DIFF
--- a/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
@@ -21,13 +21,17 @@ import org.kapott.hbci.GV.parsers.ISEPAParser;
 import org.kapott.hbci.GV.parsers.SEPAParserFactory;
 import org.kapott.hbci.sepa.PainVersion;
 
+import de.jost_net.OBanToo.SEPA.IBAN;
 import de.willuhn.io.IOUtil;
+import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.jameica.hbci.gui.dialogs.KontoAuswahlDialog;
 import de.willuhn.jameica.hbci.gui.filter.KontoFilter;
 import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.rmi.SepaBooking;
 import de.willuhn.jameica.hbci.server.KontoUtil;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.ProgressMonitor;
 
@@ -55,6 +59,23 @@ public abstract class AbstractSepaImporter extends AbstractImporter
   String[] getFileExtensions()
   {
     return new String[]{"*.xml"};
+  }
+
+  protected void setBicFromIbanIfAbsent(SepaBooking booking)
+      throws RemoteException
+  {
+    if (booking.getGegenkontoBLZ() == null && booking.getGegenkontoNummer() != null)
+    {
+      try{
+        IBAN ibanObject = HBCIProperties.getIBAN(booking.getGegenkontoNummer());
+        if(ibanObject!=null){
+          String autoBic=ibanObject.getBIC();
+          booking.setGegenkontoBLZ(autoBic);
+        }
+      }catch(ApplicationException e){
+        Logger.error("error while trying to determine missing BIC", e);
+      }
+    }
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/io/SepaLastschriftImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaLastschriftImporter.java
@@ -68,6 +68,8 @@ public class SepaLastschriftImporter extends AbstractSepaImporter
     u.setSequenceType(SepaLastSequenceType.valueOf(prop.getProperty(ISEPAParser.Names.SEQUENCETYPE.getValue())));
     u.setType(SepaLastType.valueOf(prop.getProperty(ISEPAParser.Names.LAST_TYPE.getValue())));
 
+    setBicFromIbanIfAbsent(u);
+
     u.store();
     Application.getMessagingFactory().sendMessage(new ImportMessage(u));
   }

--- a/src/de/willuhn/jameica/hbci/io/SepaSammelLastschriftImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaSammelLastschriftImporter.java
@@ -83,6 +83,8 @@ public class SepaSammelLastschriftImporter extends AbstractSepaImporter
     if (mandDate != null && !SepaUtil.DATE_UNDEFINED.equals(mandDate))
       u.setSignatureDate(ISO_DATE.parse(mandDate));
 
+    setBicFromIbanIfAbsent(u);
+
     u.store();
     Application.getMessagingFactory().sendMessage(new ObjectChangedMessage(ueb));
 

--- a/src/de/willuhn/jameica/hbci/io/SepaSammelUeberweisungImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaSammelUeberweisungImporter.java
@@ -72,6 +72,8 @@ public class SepaSammelUeberweisungImporter extends AbstractSepaImporter
     u.setEndtoEndId(StringUtils.trimToNull(prop.getProperty(ISEPAParser.Names.ENDTOENDID.getValue())));
     u.setPurposeCode(StringUtils.trimToNull(prop.getProperty(ISEPAParser.Names.PURPOSECODE.getValue())));
 
+    setBicFromIbanIfAbsent(u);
+
     u.store();
     Application.getMessagingFactory().sendMessage(new ObjectChangedMessage(ueb));
 

--- a/src/de/willuhn/jameica/hbci/io/SepaUeberweisungImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/SepaUeberweisungImporter.java
@@ -56,6 +56,8 @@ public class SepaUeberweisungImporter extends AbstractSepaImporter
     u.setPmtInfId(StringUtils.trimToNull(prop.getProperty(ISEPAParser.Names.PMTINFID.getValue())));
     u.setPurposeCode(StringUtils.trimToNull(prop.getProperty(ISEPAParser.Names.PURPOSECODE.getValue())));
 
+    setBicFromIbanIfAbsent(u);
+
     u.store();
     Application.getMessagingFactory().sendMessage(new ImportMessage(u));
   }

--- a/src/de/willuhn/jameica/hbci/rmi/SepaBooking.java
+++ b/src/de/willuhn/jameica/hbci/rmi/SepaBooking.java
@@ -42,4 +42,11 @@ public interface SepaBooking extends Transfer
    */
   public void setPurposeCode(String code) throws RemoteException;
 
+  /**
+   * Speichert die BLZ des Gegenkontos.
+   * @param blz
+   * @throws RemoteException
+   */
+  public void setGegenkontoBLZ(String blz) throws RemoteException;
+
 }

--- a/src/de/willuhn/jameica/hbci/rmi/SepaSammelTransferBuchung.java
+++ b/src/de/willuhn/jameica/hbci/rmi/SepaSammelTransferBuchung.java
@@ -34,13 +34,6 @@ public interface SepaSammelTransferBuchung<T extends SepaSammelTransfer> extends
    * @throws RemoteException
    */
   public void setGegenkontoNummer(String kontonummer) throws RemoteException;
-	
-	/**
-	 * Speichert die BLZ des Gegenkontos.
-   * @param blz
-   * @throws RemoteException
-   */
-  public void setGegenkontoBLZ(String blz) throws RemoteException;
 
 	/**
 	 * Speichert den Namen des Kontoinhabers des Gegenkontos.


### PR DESCRIPTION
Dieser PR ist erstmal ein Proof of Concept als Diskussionsgrundlage. Aktuell können IBAN-Only-Sepa-Dateien nicht importiert werden. Die Änderung besteht darin, eine potentiell fehlende BIC auf dieselbe Weise zu ergänzen, wie es bei einer manuellen Eingabe der Buchung geschehen würde.

Mögliche weitere Verbesserungen:
- Nutzerfeedback, dass eine automatische Ergänzung stattgefunden hat (Monitor in AbstractImporter#importObject mitgeben)
- Separate "Importformate" mit/ohne automatische Ergänzung, damit der Nutzer unter Kontrolle hat, dass eine fehlende BIC zum Fehler führt
## Generelle Verbesserung der Fehlerbehandlung beim Import

Ich finde den Teilimport fehlerhafter Dateien sehr unglücklich - alles oder nichts mit genauerer Beschreibung, in welchem Datensatz es einen Fehler gibt (die Nummer allein reicht - mir zumindest - nicht), wäre wesentlich sauberer um Doppelbuchungen zu vermeiden (nochmaliger Import nach Korrektur, schon importierte Datensätze wurden aber nicht gelöscht). Es ist auch nicht ganz logisch, warum nur fehlerfreie Buchungen vor dem ersten Fehler übernommen werden, aber keine dann folgenden fehlerfreien. Auch das spricht für einen ganz-oder-garnicht-Ansatz.
