### PR TITLE
exception handling in sepa import

### DIFF
--- a/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
@@ -49,8 +49,13 @@ public abstract class AbstractImporter implements Importer
       {
         monitor.setPercentComplete((int)((i) * factor));
         monitor.log(i18n.tr("Lese Datensatz {0}",Integer.toString(i+1)));
-        
-        this.importObject(objects[i],i,ctx);
+        try{
+          this.importObject(objects[i],i,ctx);
+        }catch(ApplicationException ae){
+          monitor.setStatus(ProgressMonitor.STATUS_ERROR);
+          monitor.log(objects[i].toString());
+          monitor.log("Fehler: "+ae.getMessage());
+        }
       }
       this.commit(objects,format,is,monitor);
       Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Daten importiert"),StatusBarMessage.TYPE_SUCCESS));

--- a/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
@@ -94,8 +94,9 @@ public abstract class AbstractSepaImporter extends AbstractImporter
   /**
    * @see de.willuhn.jameica.hbci.io.AbstractImporter#commit(java.lang.Object[], de.willuhn.jameica.hbci.io.IOFormat, java.io.InputStream, de.willuhn.util.ProgressMonitor)
    */
+  //final, damit Subklassen zukünftig nichts komisches machen können (siehe Exception-Handling in AbstractImporter#doImport)
   @Override
-  void commit(Object[] objects, IOFormat format, InputStream is, ProgressMonitor monitor) throws Exception
+  final void commit(Object[] objects, IOFormat format, InputStream is, ProgressMonitor monitor) throws Exception
   {
     kontenCache.clear();
     super.commit(objects,format,is,monitor);


### PR DESCRIPTION
Der zusätzlichen try-catch ermöglicht die Verarbeitung weiterer Datensätze nach einem fehlerhaften. In der aktuellen Form bin ich mit der Fehlerausgabe noch nicht zufrieden.
* durch das automatische Ausblenden kann man ggf. die Fehler gar nicht nachvollziehen (Nichtausblenden bei Status Error wäre ein Ausweg, der aber ggf. im Konflikt mit https://www.willuhn.de/bugzilla/show_bug.cgi?id=432 steht)
* (generisches) Loggen des Fehlers ins Applikationslog gibt ggf. sensible Daten der Transaktion nach außen

