### PR TITLE
delay updating table, prevent locking import

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
@@ -583,6 +583,15 @@ public class UmsatzList extends TablePart implements Extendable
       };
     }
 
+    DelayedListener updateKontoListListener=new DelayedListener(new Listener() {
+      
+      @Override
+      public void handleEvent(Event event)
+      {
+        kl.process(true);
+      }
+    });
+
     /**
      * @see de.willuhn.jameica.messaging.MessageConsumer#handleMessage(de.willuhn.jameica.messaging.Message)
      */
@@ -623,7 +632,7 @@ public class UmsatzList extends TablePart implements Extendable
             umsaetze.add(newUmsatz);
             
             if (filter && kl != null)
-              kl.process(true);
+              updateKontoListListener.handleEvent(null);
             else
             {
               addItem(newUmsatz);


### PR DESCRIPTION
Wenn man Umsätze importiert, führt die aktuelle handleMessage-Implementierung dafür, dass nach jedem Datensatz die Umsatztabelle aktualisiert wird, was bei vielen Umsätzen eine Weile dauern kann. Dadurch dauert der Import viel länger als nötig.

Die vorgeschlagene Änderung verwendet den DelayedListener, um das Update erst ganz am Ende zu machen.