### PR TITLE
remove the need for private keys in development build

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -239,7 +239,7 @@
 
   <target depends="init,compile,tag,signzip,javadoc,src,sign,clean" description="build an official release" name="all" />
 
-  <target depends="init,compile,signzip,src,clean" description="build inofficial release" name="fast" />
+  <target depends="init,compile,zip,src,clean" description="build inofficial release" name="fast" />
 
   <target depends="init,compile,zip,javadoc,src" description="build nightly build" name="nightly">
     <mkdir dir="${project.nightly}" />


### PR DESCRIPTION
In your mail from september 12th you wrote my removal of your keys in the build file should not have been necessary because they were only required for target "all". Unfortunately, fast requires signzip, which requires signjar and IMO should only be zip.