### PR TITLE
PDF-Umsatz-Export um zwei Optionen erweitert: "Summen-Zeile hinzufügen" und "SVWZ extrahieren"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -111,6 +111,8 @@
   
   <extensions>
     <extension extends="de.willuhn.jameica.hbci.gui.dialogs.ExportDialog" class="de.willuhn.jameica.hbci.gui.ext.ExportSaldoExtension"/>
+    <extension extends="de.willuhn.jameica.hbci.gui.dialogs.ExportDialog" class="de.willuhn.jameica.hbci.gui.ext.ExportSVWZExtractorExtension"/>
+    <extension extends="de.willuhn.jameica.hbci.gui.dialogs.ExportDialog" class="de.willuhn.jameica.hbci.gui.ext.ExportAddSumRowExtension"/>
   </extensions>
 
 </plugin>

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
@@ -1,0 +1,68 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2017 by Ferenc Hechler
+ * All rights reserved
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci.gui.ext;
+
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.willuhn.jameica.gui.extension.Extendable;
+import de.willuhn.jameica.gui.extension.Extension;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.util.Container;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.gui.dialogs.ExportDialog;
+import de.willuhn.jameica.hbci.io.Exporter;
+import de.willuhn.jameica.hbci.rmi.Umsatz;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.I18N;
+
+/**
+ * Erweitert den Export-Dialog um eine zusaetzliche Option mit der ausgewaehlt
+ * werden kann, ob eine Summenzeile ausgegeben werden soll.
+ */
+public class ExportAddSumRowExtension implements Extension
+{
+  /**
+   * Der Context-Schluessel fuer die Option zum Ausblenden des Saldo im Export.
+   */
+  public final static String KEY_SUMROW_ADD = "sumrow.add";
+  
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  
+  /**
+   * @see de.willuhn.jameica.gui.extension.Extension#extend(de.willuhn.jameica.gui.extension.Extendable)
+   */
+  public void extend(Extendable extendable)
+  {
+    if (!(extendable instanceof ExportDialog))
+      return;
+    
+    ExportDialog e = (ExportDialog) extendable;
+    
+    Class type = e.getType();
+    if (!type.isAssignableFrom(Umsatz.class))
+      return;
+    
+    // Erstmal per Default nicht ausblenden
+    Exporter.SESSION.put(KEY_SUMROW_ADD,false);
+    
+    final CheckboxInput check = new CheckboxInput(false);
+    check.setName(i18n.tr("Zeile  \"Summe\" in Export anfügen"));
+    check.addListener(new Listener() {
+      public void handleEvent(Event event)
+      {
+        Exporter.SESSION.put(KEY_SUMROW_ADD,check.getValue());
+      }
+    });
+    
+    final Container c = e.getContainer();
+    c.addInput(check);
+  }
+}
+
+

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportSVWZExtractorExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportSVWZExtractorExtension.java
@@ -1,0 +1,68 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2017 by Ferenc Hechler
+ * All rights reserved
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci.gui.ext;
+
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+
+import de.willuhn.jameica.gui.extension.Extendable;
+import de.willuhn.jameica.gui.extension.Extension;
+import de.willuhn.jameica.gui.input.CheckboxInput;
+import de.willuhn.jameica.gui.util.Container;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.gui.dialogs.ExportDialog;
+import de.willuhn.jameica.hbci.io.Exporter;
+import de.willuhn.jameica.hbci.rmi.Umsatz;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.I18N;
+
+/**
+ * Erweitert den Export-Dialog um eine zusaetzliche Option mit der ausgewaehlt
+ * werden kann, ob eine Summenzeile ausgegeben werden soll.
+ */
+public class ExportSVWZExtractorExtension implements Extension
+{
+  /**
+   * Der Context-Schluessel fuer die Option zum Ausblenden des Saldo im Export.
+   */
+  public final static String KEY_SVWZ_EXTRACT = "svwz.extract";
+  
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  
+  /**
+   * @see de.willuhn.jameica.gui.extension.Extension#extend(de.willuhn.jameica.gui.extension.Extendable)
+   */
+  public void extend(Extendable extendable)
+  {
+    if (!(extendable instanceof ExportDialog))
+      return;
+    
+    ExportDialog e = (ExportDialog) extendable;
+    
+    Class type = e.getType();
+    if (!type.isAssignableFrom(Umsatz.class))
+      return;
+    
+    // Erstmal per Default nicht ausblenden
+    Exporter.SESSION.put(KEY_SVWZ_EXTRACT,false);
+    
+    final CheckboxInput check = new CheckboxInput(false);
+    check.setName(i18n.tr("Im Verwendungszweck \"SVWZ+\" extrahieren"));
+    check.addListener(new Listener() {
+      public void handleEvent(Event event)
+      {
+        Exporter.SESSION.put(KEY_SVWZ_EXTRACT,check.getValue());
+      }
+    });
+    
+    final Container c = e.getContainer();
+    c.addInput(check);
+  }
+}
+
+


### PR DESCRIPTION
Der PDF-Umsatz-Export wird (via GUI Extension) in der plugin.xml um zwei neue Optionen erweitert. Die erste Option fügt dem PDF-Dokument am Ende eine Summenzeile hinzu. Die zweite Option gibt nicht den gesamten Verwendungszweck, sondern nur das SVWZ-Tag aus. Beide Optionen werden nur vom PDFUmsatzExporter ausgewertet. Auf andere Exporter hat diese Änderung keinen Einfluss.