### PR TITLE
validate line length for "Verwendungszweck"

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -12,6 +12,7 @@ import java.rmi.RemoteException;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Text;
 
 import de.willuhn.datasource.BeanUtil;
 import de.willuhn.jameica.gui.AbstractControl;
@@ -43,6 +44,7 @@ import de.willuhn.jameica.hbci.server.VerwendungszweckUtil;
 import de.willuhn.jameica.hbci.server.VerwendungszweckUtil.Tag;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.I18N;
@@ -397,10 +399,31 @@ public class UmsatzDetailControl extends AbstractControl
 	{
 	  if (this.zweck == null)
 	  {
-      this.zweck = new TextAreaInput("");
+      this.zweck = new TextAreaInput(""){
+        @Override
+        protected void update() throws OperationCanceledException
+        {
+          super.update();
+          checkZweckLineMaxLength(text);
+        }
+      };
       this.zweck.setEnabled(false);
 	  }
 	  return this.zweck;
+	}
+
+	private void checkZweckLineMaxLength(Text zweckTextWidget){
+	  String[] splitText = zweckTextWidget.getText().split("\n");
+	  for (int i = 0; i < splitText.length; i++)
+    {
+      String line = splitText[i];
+      if(line.length()>35){
+        zweckTextWidget.setBackground(Color.ERROR.getSWTColor());
+        Application.getMessagingFactory().sendMessage(new StatusBarMessage("Jede Zeile des Verwendungszwecks darf maximal 35 Zeichen lang sein." ,StatusBarMessage.TYPE_ERROR));
+        return;
+      }
+    }
+	  zweckTextWidget.setBackground(Color.WHITE.getSWTColor());
 	}
 	
 	/**

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -413,17 +413,17 @@ public class UmsatzDetailControl extends AbstractControl
 	}
 
 	private void checkZweckLineMaxLength(Text zweckTextWidget){
-	  String[] splitText = zweckTextWidget.getText().split("\n");
+	  String[] splitText = VerwendungszweckUtil.split(zweckTextWidget.getText());
+	  int lineMaxLength=35;
 	  for (int i = 0; i < splitText.length; i++)
     {
-      String line = splitText[i];
-      if(line.length()>35){
-        zweckTextWidget.setBackground(Color.ERROR.getSWTColor());
-        Application.getMessagingFactory().sendMessage(new StatusBarMessage("Jede Zeile des Verwendungszwecks darf maximal 35 Zeichen lang sein." ,StatusBarMessage.TYPE_ERROR));
-        return;
+        String line = splitText[i];
+        if(line.length()>lineMaxLength){
+          zweckTextWidget.setBackground(Color.MANDATORY_BG.getSWTColor());
+          Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Jede Zeile des Verwendungszwecks darf maximal {0} Zeichen lang sein. Zeile {1} ist {2} Zeichen lang.", ""+lineMaxLength, ""+(i+1), ""+line.length()) ,StatusBarMessage.TYPE_ERROR));
+          return;
       }
     }
-	  zweckTextWidget.setBackground(Color.WHITE.getSWTColor());
 	}
 	
 	/**


### PR DESCRIPTION
Der Commit ist ein Proof of Concept für die Validierung der Zeilenlängen für den Verwendungszweck. Aktuell fliegt erst beim Speichern eine Exception, die den Nutzer auf eine zu lange Eingabe hinweist.

Mit einer expliziten Validierung des TextArea-Inhalts könnte man den Nutzer darauf hinweisen, dass eine mehrzeilige Eingabe möglich ist und ggf. nicht nur wie im Commit, dass die Zeilen max. 35 Zeichen lang sein dürfen, sondern auch, welche Zeile wieviel zu lang ist.

Da ich nicht weiter darüber nachgedacht habe, habe ich in der Vergangenheit gar keine mehrzeiligen Eingaben gemacht, sondern versucht alles in 35 Zeichen zu packen - wegen der generischen Fehlermeldung beim Speichern.

Wenn diese Art der Validierung grundsätzlich (auf diese Weise) erwünscht ist, könnte ich den Fehlertext noch entsprechend erweitern.