### PR TITLE
Sammler auflösen

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/AuslandsUeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/AuslandsUeberweisungNew.java
@@ -104,21 +104,7 @@ public class AuslandsUeberweisungNew implements Action
       {
         try
         {
-          SepaSammelUeberweisungBuchung b = (SepaSammelUeberweisungBuchung) context;
-          SepaSammelUeberweisung st = (SepaSammelUeberweisung) b.getSammelTransfer();
-          u = (AuslandsUeberweisung) Settings.getDBService().createObject(AuslandsUeberweisung.class,null);
-          u.setBetrag(b.getBetrag());
-          u.setGegenkontoBLZ(b.getGegenkontoBLZ());
-          u.setGegenkontoName(b.getGegenkontoName());
-          u.setGegenkontoNummer(b.getGegenkontoNummer());
-          u.setZweck(b.getZweck());
-          u.setEndtoEndId(b.getEndtoEndId());
-          
-          if (st != null)
-          {
-            u.setKonto(st.getKonto());
-            u.setTermin(st.getTermin());
-          }
+          u=cloneFromSammelUeberweisungBuchung((SepaSammelUeberweisungBuchung)context);
         }
         catch (RemoteException re)
         {
@@ -146,6 +132,26 @@ public class AuslandsUeberweisungNew implements Action
     }
 
     GUI.startView(de.willuhn.jameica.hbci.gui.views.AuslandsUeberweisungNew.class,u);
+  }
+
+  @SuppressWarnings("javadoc")
+  public static AuslandsUeberweisung cloneFromSammelUeberweisungBuchung(SepaSammelUeberweisungBuchung context) throws RemoteException{
+    SepaSammelUeberweisungBuchung b = (SepaSammelUeberweisungBuchung) context;
+    SepaSammelUeberweisung st = (SepaSammelUeberweisung) b.getSammelTransfer();
+    AuslandsUeberweisung u = (AuslandsUeberweisung) Settings.getDBService().createObject(AuslandsUeberweisung.class,null);
+    u.setBetrag(b.getBetrag());
+    u.setGegenkontoBLZ(b.getGegenkontoBLZ());
+    u.setGegenkontoName(b.getGegenkontoName());
+    u.setGegenkontoNummer(b.getGegenkontoNummer());
+    u.setZweck(b.getZweck());
+    u.setEndtoEndId(b.getEndtoEndId());
+    
+    if (st != null)
+    {
+      u.setKonto(st.getKonto());
+      u.setTermin(st.getTermin());
+    }
+    return u;
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaLastschriftNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaLastschriftNew.java
@@ -82,28 +82,7 @@ public class SepaLastschriftNew implements Action
       {
         try
         {
-          SepaSammelLastBuchung b = (SepaSammelLastBuchung) context;
-          SepaSammelLastschrift st = (SepaSammelLastschrift) b.getSammelTransfer();
-          u = (SepaLastschrift) Settings.getDBService().createObject(SepaLastschrift.class,null);
-          u.setBetrag(b.getBetrag());
-          u.setGegenkontoBLZ(b.getGegenkontoBLZ());
-          u.setGegenkontoName(b.getGegenkontoName());
-          u.setGegenkontoNummer(b.getGegenkontoNummer());
-          u.setZweck(b.getZweck());
-          u.setCreditorId(b.getCreditorId());
-          u.setEndtoEndId(b.getEndtoEndId());
-          u.setMandateId(b.getMandateId());
-          u.setSignatureDate(b.getSignatureDate());
-          
-          if (st != null)
-          {
-            u.setKonto(st.getKonto());
-            u.setTermin(st.getTermin());
-            
-            u.setSequenceType(st.getSequenceType());
-            u.setTargetDate(st.getTargetDate());
-            u.setType(st.getType());
-          }
+         u=cloneFromSammelLastBuchung((SepaSammelLastBuchung)context);
         }
         catch (RemoteException re)
         {
@@ -121,6 +100,33 @@ public class SepaLastschriftNew implements Action
     }
 
     GUI.startView(de.willuhn.jameica.hbci.gui.views.SepaLastschriftNew.class,u);
+  }
+
+  @SuppressWarnings("javadoc")
+  public static SepaLastschrift cloneFromSammelLastBuchung(SepaSammelLastBuchung context) throws RemoteException{
+    SepaSammelLastBuchung b = (SepaSammelLastBuchung) context;
+    SepaSammelLastschrift st = (SepaSammelLastschrift) b.getSammelTransfer();
+    SepaLastschrift u = (SepaLastschrift) Settings.getDBService().createObject(SepaLastschrift.class,null);
+    u.setBetrag(b.getBetrag());
+    u.setGegenkontoBLZ(b.getGegenkontoBLZ());
+    u.setGegenkontoName(b.getGegenkontoName());
+    u.setGegenkontoNummer(b.getGegenkontoNummer());
+    u.setZweck(b.getZweck());
+    u.setCreditorId(b.getCreditorId());
+    u.setEndtoEndId(b.getEndtoEndId());
+    u.setMandateId(b.getMandateId());
+    u.setSignatureDate(b.getSignatureDate());
+    
+    if (st != null)
+    {
+      u.setKonto(st.getKonto());
+      u.setTermin(st.getTermin());
+      
+      u.setSequenceType(st.getSequenceType());
+      u.setTargetDate(st.getTargetDate());
+      u.setType(st.getType());
+    }
+    return u;
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelTransferSplit.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelTransferSplit.java
@@ -1,0 +1,66 @@
+/**********************************************************************
+ *
+ * Copyright (c) by Olaf Willuhn
+ * All rights reserved
+ *
+ **********************************************************************/
+package de.willuhn.jameica.hbci.gui.action;
+
+import java.rmi.RemoteException;
+import java.util.List;
+
+import de.willuhn.datasource.rmi.Changeable;
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.rmi.SepaSammelLastBuchung;
+import de.willuhn.jameica.hbci.rmi.SepaSammelTransfer;
+import de.willuhn.jameica.hbci.rmi.SepaSammelTransferBuchung;
+import de.willuhn.jameica.hbci.rmi.SepaSammelUeberweisungBuchung;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+/**
+ * Action zum Auflösen einer Sepa-Sammelbuchung in Einzelbuchungen.
+ */
+public class SepaSammelTransferSplit implements Action
+{
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  
+  /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  public void handleAction(Object context) throws ApplicationException
+  {
+    if(!(context instanceof SepaSammelTransfer)){
+      throw new ApplicationException(i18n.tr("Bitte wählen Sie einen Sammler aus"));
+    }
+    try
+    {
+      SepaSammelTransfer sammler = (SepaSammelTransfer)context;
+      List<SepaSammelTransferBuchung> buchungen = sammler.getBuchungen();
+      for (SepaSammelTransferBuchung sammelTransferBuchung : buchungen)
+      {
+        if(!(sammelTransferBuchung instanceof SepaSammelLastBuchung) &&!(sammelTransferBuchung instanceof SepaSammelUeberweisungBuchung)){
+          Logger.error("unexpected booking type "+ sammelTransferBuchung.getClass().getName());
+          throw new ApplicationException(i18n.tr("Sammler enthält unerwarteten Vorgangstyp"));
+        }
+      }
+      for (SepaSammelTransferBuchung sammelTransferBuchung : buchungen)
+      {
+        Changeable clone=null;
+        if(sammelTransferBuchung instanceof SepaSammelLastBuchung){
+          clone = SepaLastschriftNew.cloneFromSammelLastBuchung((SepaSammelLastBuchung)sammelTransferBuchung);
+        }else if(sammelTransferBuchung instanceof SepaSammelUeberweisungBuchung){
+          clone = AuslandsUeberweisungNew.cloneFromSammelUeberweisungBuchung((SepaSammelUeberweisungBuchung)sammelTransferBuchung);
+        }
+        clone.store();
+      }
+      sammler.delete();
+    } catch (RemoteException e)
+    {
+      Logger.error("Error while splitting", e);
+    }
+  }
+}

--- a/src/de/willuhn/jameica/hbci/gui/menus/SepaSammelLastschriftList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/SepaSammelLastschriftList.java
@@ -21,6 +21,7 @@ import de.willuhn.jameica.hbci.gui.action.SepaSammelLastschriftExecute;
 import de.willuhn.jameica.hbci.gui.action.SepaSammelLastschriftExport;
 import de.willuhn.jameica.hbci.gui.action.SepaSammelLastschriftImport;
 import de.willuhn.jameica.hbci.gui.action.SepaSammelLastschriftNew;
+import de.willuhn.jameica.hbci.gui.action.SepaSammelTransferSplit;
 import de.willuhn.jameica.hbci.gui.action.TerminableMarkExecuted;
 import de.willuhn.jameica.hbci.io.print.PrintSupportSepaSammelLastschrift;
 import de.willuhn.jameica.hbci.rmi.SepaSammelLastschrift;
@@ -46,6 +47,7 @@ public class SepaSammelLastschriftList extends ContextMenu
 	{
 		addItem(new SingleItem(i18n.tr("Öffnen"), new SepaSammelLastschriftNew(),"document-open.png"));
     addItem(new ContextMenuItem(i18n.tr("Neue SEPA-Sammellastschrift..."), new SNeu(),"text-x-generic.png"));
+    addItem(new CheckedContextMenuItem(i18n.tr("Sammler auflösen"), new SepaSammelTransferSplit(), null));
     addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."), new DBObjectDelete(),"user-trash-full.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SingleItem(i18n.tr("Duplizieren..."), new Duplicate(),"edit-copy.png"));

--- a/src/de/willuhn/jameica/hbci/gui/menus/SepaSammelUeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/SepaSammelUeberweisungList.java
@@ -17,6 +17,7 @@ import de.willuhn.jameica.gui.parts.ContextMenuItem;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.action.DBObjectDelete;
 import de.willuhn.jameica.hbci.gui.action.Duplicate;
+import de.willuhn.jameica.hbci.gui.action.SepaSammelTransferSplit;
 import de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungExecute;
 import de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungExport;
 import de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungImport;
@@ -46,6 +47,7 @@ public class SepaSammelUeberweisungList extends ContextMenu
 	{
 		addItem(new SingleItem(i18n.tr("Öffnen"), new SepaSammelUeberweisungNew(),"document-open.png"));
     addItem(new ContextMenuItem(i18n.tr("Neue SEPA-Sammelüberweisung..."), new SNeu(),"text-x-generic.png"));
+    addItem(new CheckedContextMenuItem(i18n.tr("Sammler auflösen"), new SepaSammelTransferSplit(), null));
     addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."), new DBObjectDelete(),"user-trash-full.png"));
     addItem(ContextMenuItem.SEPARATOR);
     addItem(new SingleItem(i18n.tr("Duplizieren..."), new Duplicate(),"edit-copy.png"));


### PR DESCRIPTION
Es gibt schon die Möglichkeit, aus Einzelbuchungen einen Sammler zu erstellen. Es wäre auch schön, die Rückrichtung zu haben - Sammler wieder aufzulösen. Man kann zwar einzelne Buchungen aus einem Sammler duplizieren, müsste bei mehreren aber jede Buchung einzeln duplizieren, speichern und dann aus dem Sammler löschen, wenn man sie herauslösen will.

Der PR ist ein Proof of Concept zur Diskussion der Funktionalität, da ich nicht sicher bin, welche Attribute für eine erfolgreiche Ausführung kopiert werden müssen. Auch wird noch nicht abgefragt, ob die Aktion wirklich ausgeführt werden soll (da der Sammler hinterher weg ist).

Zudem funktioniert die Aktualisierung der Buchungsanzahl in der Baumansicht nicht - das ist allerdings auch beim Zusammenfassen von Buchungen zu einem Sammler "kaputt".