### PR TITLE
bugzilla 1782 add comment to transaction type

### DIFF
--- a/sql/h2-create.sql
+++ b/sql/h2-create.sql
@@ -206,6 +206,7 @@ CREATE TABLE umsatztyp (
   parent_id int(5) NULL,
   color varchar(11) NULL,
   customcolor int(1) NULL,
+  kommentar varchar(1000) NULL,
   UNIQUE (id),
   PRIMARY KEY (id)
 );

--- a/sql/mysql-create.sql
+++ b/sql/mysql-create.sql
@@ -96,6 +96,7 @@ CREATE TABLE umsatztyp (
      , parent_id int(10)
      , color VARCHAR(11)
      , customcolor int(1)
+     , kommentar TEXT
      , UNIQUE (id)
      , PRIMARY KEY (id)
 ) ENGINE=InnoDB;

--- a/sql/postgresql-create.sql
+++ b/sql/postgresql-create.sql
@@ -183,7 +183,8 @@ CREATE TABLE umsatztyp (
   umsatztyp integer NULL,
   parent_id integer NULL,
   color varchar(11) NULL,
-  customcolor integer NULL
+  customcolor integer NULL,
+  kommentar varchar(1000) NULL
 );
 
 CREATE TABLE dauerauftrag (

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
@@ -59,6 +59,7 @@ public class UmsatzTypControl extends AbstractControl
   private CheckboxInput regex   = null;
   private SelectInput art       = null;
   private UmsatzTypInput parent = null;
+  private TextInput kommentar        = null;
   
   private ColorInput color          = null;
   private CheckboxInput customColor = null;
@@ -106,6 +107,20 @@ public class UmsatzTypControl extends AbstractControl
   }
 
   /**
+   * Erzeugt das Eingabe-Feld fuer den Kommentar.
+   * @return Eingabe-Feld.
+   * @throws RemoteException
+   */
+  public TextInput getKommentar() throws RemoteException
+  {
+    if (this.kommentar == null)
+    {
+      this.kommentar = new TextInput(getUmsatzTyp().getKommentar());
+    }
+    return this.kommentar;
+  }
+
+  /**
    * Erzeugt das Eingabe-Feld fuer die Nummer.
    * @return Eingabe-Feld.
    * @throws RemoteException
@@ -120,6 +135,7 @@ public class UmsatzTypControl extends AbstractControl
     }
     return this.nummer;
   }
+
   
   /**
    * Erzeugt das Eingabe-Feld fuer den Such-Pattern.
@@ -273,6 +289,7 @@ public class UmsatzTypControl extends AbstractControl
       UmsatzTyp ut = getUmsatzTyp();
       ut.setTyp(t == null ? UmsatzTyp.TYP_EGAL : t.typ);
       ut.setName((String)getName().getValue());
+      ut.setKommentar((String)getKommentar().getValue());
       ut.setNummer((String)getNummer().getValue());
       ut.setPattern((String)getPattern().getValue());
       ut.setRegex(((Boolean)getRegex().getValue()).booleanValue());

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
@@ -178,6 +178,7 @@ public class UmsatzTypListDialog extends AbstractDialog
     this.table = new TablePart(this.list,new Apply());
     this.table.setSummary(false);
     this.table.addColumn(i18n.tr("Bezeichnung"),"indented");
+    this.table.addColumn(i18n.tr("Kommentar"),"kommentar");
     this.table.setFormatter(new TableFormatter()
     {
       /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypList.java
@@ -74,7 +74,8 @@ public class UmsatzTypList extends TablePart implements Part
         return UmsatzTypUtil.getNameForType(((Integer) o).intValue());
       }
     });
-    
+    addColumn(i18n.tr("Kommentar"),"kommentar");
+
     this.setFormatter(new TableFormatter()
     {
       /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypTree.java
@@ -81,6 +81,7 @@ public class UmsatzTypTree extends TreePart
         return UmsatzTypUtil.getNameForType(((Integer) o).intValue());
       }
     });
+    addColumn(i18n.tr("Kommentar"),"kommentar");
     
     this.setFormatter(new TreeFormatter()
     {

--- a/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypDetail.java
@@ -54,6 +54,7 @@ public class UmsatzTypDetail extends AbstractView
     group.addLabelPair(i18n.tr("Reihenfolge"), control.getNummer());
     group.addLabelPair(i18n.tr("Suchbegriff"), control.getPattern());
     group.addCheckbox(control.getRegex(),i18n.tr("Suchbegriff ist ein regulärer Ausdruck"));
+    group.addLabelPair(i18n.tr("Kommentar"), control.getKommentar());
     group.addSeparator();
     group.addLabelPair(i18n.tr("Art des Umsatzes"), control.getArt());
 

--- a/src/de/willuhn/jameica/hbci/rmi/UmsatzTyp.java
+++ b/src/de/willuhn/jameica/hbci/rmi/UmsatzTyp.java
@@ -81,12 +81,26 @@ public interface UmsatzTyp extends DBObjectNode
   public String getPattern() throws RemoteException;
 
   /**
+   * Speichert den Kommentar fuer den Umsatztyp.
+   * @param kommentar der Kommentar.
+   * @throws RemoteException
+   */
+  public void setKommentar(String kommentar) throws RemoteException;
+
+  /**
+   * Liefert den Kommentar fuer den Umsatztyp.
+   * @return Kommentar.
+   * @throws RemoteException
+   */
+  public String getKommentar() throws RemoteException;
+
+  /**
    * Speichert das Suchmuster fuer den Umsatztyp.
    * @param pattern das Suchmuster.
    * @throws RemoteException
    */
   public void setPattern(String pattern) throws RemoteException;
-  
+
 	/**
 	 * Liefert eine Liste von Umsaetzen, die diesem Umsatz-Typ entsprechen.
    * @return Umsatz-Liste.

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypImpl.java
@@ -360,6 +360,19 @@ public class UmsatzTypImpl extends AbstractDBObjectNode implements UmsatzTyp, Du
     setAttribute("isregex", new Integer(regex ? 1 : 0));
   }
 
+  @Override
+  public void setKommentar(String kommentar) throws RemoteException
+  {
+    setAttribute("kommentar", kommentar);
+    
+  }
+
+  @Override
+  public String getKommentar() throws RemoteException
+  {
+    return (String) getAttribute("kommentar");
+  }
+
   /**
    * @see de.willuhn.jameica.hbci.rmi.UmsatzTyp#getUmsatz()
    */
@@ -643,11 +656,10 @@ public class UmsatzTypImpl extends AbstractDBObjectNode implements UmsatzTyp, Du
     t.setParent((DBObjectNode) this.getParent());
     t.setPattern(this.getPattern());
     t.setRegex(this.isRegex());
+    t.setKommentar(this.getKommentar());
     t.setTyp(this.getTyp());
     return t;
   }
-  
-  
 }
 
 /*******************************************************************************

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypUtil.java
@@ -326,7 +326,7 @@ public class UmsatzTypUtil
     @Override
     public String[] getAttributeNames() throws RemoteException
     {
-      return new String[]{"name","indented"};
+      return new String[]{"name","indented","kommentar"};
     }
 
     /**
@@ -689,6 +689,17 @@ public class UmsatzTypUtil
     @Override
     public void setCustomColor(boolean b) throws RemoteException
     {
+    }
+
+    @Override
+    public void setKommentar(String kommentar) throws RemoteException
+    {
+    }
+
+    @Override
+    public String getKommentar() throws RemoteException
+    {
+      return null;
     };
   }
 }

--- a/updates/update0060.java
+++ b/updates/update0060.java
@@ -23,16 +23,16 @@ import de.willuhn.util.I18N;
 
 
 /**
- * Erweitert die Tabelle "umsatztyp" um die Spalten "kommentar" und TODO deaktiviert
+ * Erweitert die Tabelle "umsatztyp" um die Spalten "kommentar"
  */
-public class update60 implements Update
+public class update0060 implements Update
 {
   private Map statements = new HashMap();
   
   /**
    * ct
    */
-  public update60()
+  public update0060()
   {
     statements.put(DBSupportH2Impl.class.getName(),         "ALTER TABLE umsatztyp ADD kommentar varchar(1000) NULL;");
     statements.put(DBSupportMySqlImpl.class.getName(),      "ALTER TABLE umsatztyp ADD kommentar TEXT;");

--- a/updates/update60.java
+++ b/updates/update60.java
@@ -1,0 +1,79 @@
+/**********************************************************************
+ *
+ * Copyright (c) by Olaf Willuhn
+ * All rights reserved
+ *
+ **********************************************************************/
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+import de.willuhn.jameica.hbci.rmi.HBCIDBService;
+import de.willuhn.jameica.hbci.server.DBSupportH2Impl;
+import de.willuhn.jameica.hbci.server.DBSupportMySqlImpl;
+import de.willuhn.jameica.hbci.server.DBSupportPostgreSQLImpl;
+import de.willuhn.jameica.hbci.server.HBCIUpdateProvider;
+import de.willuhn.logging.Logger;
+import de.willuhn.sql.ScriptExecutor;
+import de.willuhn.sql.version.Update;
+import de.willuhn.sql.version.UpdateProvider;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+
+/**
+ * Erweitert die Tabelle "umsatztyp" um die Spalten "kommentar" und TODO deaktiviert
+ */
+public class update60 implements Update
+{
+  private Map statements = new HashMap();
+  
+  /**
+   * ct
+   */
+  public update60()
+  {
+    statements.put(DBSupportH2Impl.class.getName(),         "ALTER TABLE umsatztyp ADD kommentar varchar(1000) NULL;");
+    statements.put(DBSupportMySqlImpl.class.getName(),      "ALTER TABLE umsatztyp ADD kommentar TEXT;");
+    statements.put(DBSupportPostgreSQLImpl.class.getName(), "ALTER TABLE umsatztyp ADD kommentar varchar(1000) NULL;");
+  }
+
+  /**
+   * @see de.willuhn.sql.version.Update#execute(de.willuhn.sql.version.UpdateProvider)
+   */
+  public void execute(UpdateProvider provider) throws ApplicationException
+  {
+    HBCIUpdateProvider myProvider = (HBCIUpdateProvider) provider;
+    I18N i18n = myProvider.getResources().getI18N();
+
+    String driver = HBCIDBService.SETTINGS.getString("database.driver",DBSupportH2Impl.class.getName());
+    String sql = (String) statements.get(driver);
+    if (sql == null)
+      throw new ApplicationException(i18n.tr("Datenbank {0} nicht wird unterstützt",driver));
+    
+    try
+    {
+      ScriptExecutor.execute(new StringReader(sql),myProvider.getConnection(),myProvider.getProgressMonitor());
+      myProvider.getProgressMonitor().log(i18n.tr("Tabelle aktualisiert"));
+    }
+    catch (ApplicationException ae)
+    {
+      throw ae;
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to execute update",e);
+      throw new ApplicationException(i18n.tr("Fehler beim Ausführen des Updates"),e);
+    }
+  }
+
+  /**
+   * @see de.willuhn.sql.version.Update#getName()
+   */
+  public String getName()
+  {
+    return "Datenbank-Update für Erweiterung des Umsatztyp um Kommentar.";
+  }
+
+}


### PR DESCRIPTION
An einer Umsatzkategorie kann ein Kommentar konfiguriert werden. Dieser wird in der Tabelle bei der Kategoriezuordnung und in der Auswertung nach Kategorien angezeigt.

Wahrscheinlich sollte noch der eine TODO-Kommentar aus dem update-java entfernt werden.
In den Create-Skripten steht unten noch eine Versionszahl (59) drin. Muss das jetzt die 60 sein?

Ich hatte überlegt, ob dieses Ticket gleich zusammen mit bugzilla 1268 bearbeitet werden sollte, war mir dann aber nicht sicher, ob ein zusätzliches Feld inactive oder flags (analog Konto) verwendet werden sollte. Schließlich gibt es aktuell schon 2 zwei Felder, die auch mit einem generischen flags-Feld ersetzt werden könnten...