### PR TITLE
persist job's checked state in SynchronizeList

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
@@ -99,7 +99,7 @@ public class SynchronizeList extends TablePart
   }
   
   private String getCheckedSettingsKey(SynchronizeJob job) throws RemoteException, ApplicationException{
-    return job.getKonto().getID()+"."+job.getName()+".synchChecked";
+    return job.getKonto().getID()+".synchChecked";
   }
   
   /**


### PR DESCRIPTION
Es sollte über die Sessiongrenze hinweg gespeichert werden, ob ein Synchronisationsjob abgewählt wurde. 
In der täglichen Nutzung muss ich immer ein Sparkonto deaktivieren.