### PR TITLE
category chart - grouping description

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypVerlauf.java
@@ -28,8 +28,6 @@ import org.eclipse.swt.widgets.MenuItem;
 
 import de.willuhn.datasource.GenericObject;
 import de.willuhn.jameica.gui.Part;
-import de.willuhn.jameica.gui.parts.NotificationPanel;
-import de.willuhn.jameica.gui.parts.NotificationPanel.Type;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.chart.LineChart;
 import de.willuhn.jameica.hbci.gui.chart.LineChartData;
@@ -168,12 +166,6 @@ public class UmsatzTypVerlauf implements Part
       }
       this.chart.paint(parent);
       addGroupingMenu();
-
-      NotificationPanel info = new NotificationPanel();
-      info.paint(parent);
-      info.setBorder(0);
-      info.setBackground(false);
-      info.setText(Type.INFO,i18n.tr("Klicken Sie mit der rechten Maustaste in die Grafik und wählen Sie \"Gruppierung nach\", um nach Jahr, Monat oder Woche zu gruppieren."));
     }
     catch (RemoteException re)
     {

--- a/src/help/de_de/de.willuhn.jameica.hbci.gui.views.UmsatzTypTree.txt
+++ b/src/help/de_de/de.willuhn.jameica.hbci.gui.views.UmsatzTypTree.txt
@@ -20,5 +20,8 @@
     Mit einem Rechtsklick auf die Legende kann ein Kontext-Menü zum Ein- oder
     Ausblenden aller Datenreihen geöffnet werden.
   </p>
-  	
+	<p>
+		Außerdem kann über das Kontextmenu des Diagramms das
+		Gruppierungsintervall (Jahr, Monat, Woche) gewählt werden.
+	</p>
 </form>


### PR DESCRIPTION
Ich hatte im Code für die Anpassungen (#41) die Einführung des NotificationPanels für die Beschreibung der Gruppierungsfunktion gesehen. Beim Ausprobieren hat es aber lange gedauert, bis mir die kurz auftauchende Beschreibung unterhalb des Charts überhaupt das erste Mal aufgefallen ist.

Wäre es nicht sinnvoller, diese Beschreibung stattdessen in den schon vorhandenen Hilfetext (Tipp: Im Reiter "Im Verlauf"...) zu integrieren?

Vorteile: Der Text verschwindet nicht, der (für die meiste Zeit ungenutzte) Platz für das NotificationPanel bleibt frei. Oder gibt es einen anderen Grund, auf diese Weise auf die Gruppierungsfunktion hinzuweisen?