### PR TITLE
proof of concept - range validation

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
@@ -10,6 +10,8 @@
 
 package de.willuhn.jameica.hbci.gui.input;
 
+import java.util.Date;
+
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
@@ -17,6 +19,7 @@ import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.server.Range;
+import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.Settings;
 import de.willuhn.util.I18N;
@@ -82,6 +85,7 @@ public class RangeInput extends SelectInput
           
           setValue(null);
           settings.setAttribute(param,(String)null);
+          checkInvalidRange(from, to);
         }
       };
       
@@ -103,7 +107,19 @@ public class RangeInput extends SelectInput
       }
     });
   }
-  
+
+  private void checkInvalidRange(Input from, Input to){
+    if(from!=null && to!=null){
+      Object fromValue = from.getValue();
+      Object toValue = to.getValue();
+      if(fromValue instanceof Date && toValue instanceof Date){
+        if(((Date)toValue).before((Date)fromValue)){
+          Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Bitte prüfen Sie den Zeitraum - das Ende sollte nicht vor dem Anfang liegen."), StatusBarMessage.TYPE_ERROR));
+        }
+      }
+    }
+  }
+
   /**
    * Wendet den Range auf die Von- und Bis-Felder an.
    * @param range der Range. Kann null sein.


### PR DESCRIPTION
In diesem PR geht es um die grundsätzliche Frage, ob für Zeiträume eine Plausibilitätsprüfung gemacht werden sollte. Ist ein Zeitraum invalid (bis liegt vor von), wird es keine Treffer geben. Es ist aber nicht immer klar, ob dem Nutzer der Fehler auffällt. Ich halte diese Prüfung und eine entsprechende Rückmeldung an den Nutzer für sinnvoll.

In dieser Minimalumsetzung - wirklich nur proof of concept - wird eine Fehlernachricht eingeblendet (die aber natürlich nicht sofort verschwindet, wenn der Fehler behoben ist). Eine andere Möglichkeit wäre, den bis-Wert automatisch auf den von-Wert zu korrigieren oder das bis-Feld einzufärben (es sah aber ziemlich unschön aus, den background rot zu machen).