### PR TITLE
handle type "egal" as equal with all types for sorting

### DIFF
--- a/src/de/willuhn/jameica/hbci/server/UmsatzTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTreeNode.java
@@ -286,7 +286,7 @@ public class UmsatzTreeNode implements GenericObjectNode, Comparable
       // Erst Ausgaben, dann Einnahmen, dann Rest
       int thisType  = this.typ.getTyp();
       int otherType = other.typ.getTyp();
-      if (thisType != otherType)
+      if (thisType != otherType && thisType != UmsatzTyp.TYP_EGAL && otherType != UmsatzTyp.TYP_EGAL)
         return thisType < otherType ? -1 : 1;
       
       String n1  = this.typ.getNummer();  if (n1  == null) n1  = "";


### PR DESCRIPTION
Die Kategoriesortierung verwirrt mich etwas. Wenn man allen Kategorien einen Sortierungsstring verpasst, werden sie zwar in der Konfigurationsübersicht in dieser Reihenfolge angezeigt, nicht aber in Umsätze nach Kategorien.

Dort ist der Umsatztyp das Erstkriterium. Das ist fachlich auch sinnvoll, aber wenn der Typ "egal" ist, sollte meiner Ansicht nach das Zweitkriterium gewinnen. Begründung: Ich gebe einer Kategorie den Typ "egal" wenn es eine Ausgabe ist, es ausnahmsweise aber auch mal Einnahmen geben kann (Bsp. Essen - man bekommt mal was zurück, wenn man was ausgelegt hat).

Aktuell steht Essen also am Ende der Liste und nicht bei den anderen Haushaltsausgaben. Mit der Änderung, ist die Reihenfolge intuitiver - insb. wenn bei allen Kategorien ein Sortierstring definiert ist.