### PR TITLE
allow grouping revenue by interval

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/EinnahmeAusgabeExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/EinnahmeAusgabeExport.java
@@ -9,10 +9,17 @@
  **********************************************************************/
 package de.willuhn.jameica.hbci.gui.action;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.dialogs.ExportDialog;
+import de.willuhn.jameica.hbci.gui.dialogs.ExportDialog.ExpotFormat;
+import de.willuhn.jameica.hbci.io.XMLExporter;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
+import de.willuhn.jameica.hbci.server.EinnameAusgabeTreeNode;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.jameica.system.OperationCanceledException;
@@ -33,13 +40,19 @@ public class EinnahmeAusgabeExport implements Action
    */
   public void handleAction(Object context) throws ApplicationException
   {
-    if (context == null || !(context instanceof EinnahmeAusgabe[]))
-      throw new ApplicationException(i18n.tr("Bitte wählen Sie die zu exportierenden Daten aus"));
-
     try
     {
-      ExportDialog d = new ExportDialog((EinnahmeAusgabe[]) context,EinnahmeAusgabe.class);
-      d.open();
+      if(context instanceof EinnahmeAusgabe[])
+      {
+        ExportDialog d = new ExportDialog((EinnahmeAusgabe[]) context,EinnahmeAusgabe.class);
+        filterFormatsAndOpenDialog(d);
+        
+      }else if(context instanceof EinnameAusgabeTreeNode[]){
+        ExportDialog d = new ExportDialog((EinnameAusgabeTreeNode[]) context,EinnameAusgabeTreeNode.class);
+        filterFormatsAndOpenDialog(d);
+      }else{
+        throw new ApplicationException(i18n.tr("Bitte wählen Sie die zu exportierenden Daten aus"));
+      }
     }
     catch (OperationCanceledException oce)
     {
@@ -57,6 +70,25 @@ public class EinnahmeAusgabeExport implements Action
     }
   }
 
+  //da die Objekte (angeblich) GenericObject implementieren, wird der XML-Export angeboten
+  //das wollen wir nicht, vielleicht geht das auch eleganter
+  private void filterFormatsAndOpenDialog(ExportDialog d) throws Exception
+  {
+    List exportFormatList = ((SelectInput)d.getExporterList()).getList();
+    List filtered=new ArrayList();
+    for (Object object : exportFormatList)
+    {
+      if(object instanceof ExpotFormat)
+      {
+        ExpotFormat f=(ExpotFormat)object;
+        if(!(f.getExporter() instanceof XMLExporter)){
+          filtered.add(object);
+        }
+      }
+    }
+    ((SelectInput)d.getExporterList()).setList(filtered);
+    d.open();
+  }
 }
 
 /*******************************************************************************

--- a/src/de/willuhn/jameica/hbci/gui/views/EinnahmenAusgaben.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/EinnahmenAusgaben.java
@@ -30,6 +30,7 @@ import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.action.EinnahmeAusgabeExport;
 import de.willuhn.jameica.hbci.gui.controller.EinnahmeAusgabeControl;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
+import de.willuhn.jameica.hbci.server.EinnameAusgabeTreeNode;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
@@ -61,6 +62,7 @@ public class EinnahmenAusgaben extends AbstractView
       
       Container left = new SimpleContainer(cols.getComposite());
       left.addInput(control.getKontoAuswahl());
+      left.addInput(control.getGranularity());
       
       Container right = new SimpleContainer(cols.getComposite());
         
@@ -77,8 +79,14 @@ public class EinnahmenAusgaben extends AbstractView
       {
         try
         {
-          List data = control.getTable().getItems();
-          new EinnahmeAusgabeExport().handleAction(data.toArray(new EinnahmeAusgabe[data.size()]));
+          List data = control.getTree().getItems();
+          if(data.size()>0 && data.get(0) instanceof EinnameAusgabeTreeNode)
+          {
+            new EinnahmeAusgabeExport().handleAction(data.toArray(new EinnameAusgabeTreeNode[data.size()]));
+          }else
+          {
+            new EinnahmeAusgabeExport().handleAction(data.toArray(new EinnahmeAusgabe[data.size()]));
+          }
         }
         catch (RemoteException re)
         {
@@ -100,6 +108,6 @@ public class EinnahmenAusgaben extends AbstractView
     },null,true,"view-refresh.png");
     buttons.paint(getParent());
     
-    control.getTable().paint(this.getParent());
+    control.getTree().paint(this.getParent());
   }
 }

--- a/src/de/willuhn/jameica/hbci/io/EinnahmeAusgabeExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/EinnahmeAusgabeExporter.java
@@ -16,9 +16,14 @@ import java.rmi.RemoteException;
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
+import com.itextpdf.text.Font;
+import com.itextpdf.text.pdf.PdfPCell;
 
+import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.GenericObject;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
+import de.willuhn.jameica.hbci.server.EinnameAusgabeTreeNode;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.ApplicationException;
@@ -37,23 +42,17 @@ public class EinnahmeAusgabeExporter implements Exporter
    */
   public void doExport(Object[] objects, IOFormat format, OutputStream os, ProgressMonitor monitor) throws RemoteException, ApplicationException
   {
-    if (objects == null || !(objects instanceof EinnahmeAusgabe[]))
+    if (objects == null || (!(objects instanceof EinnahmeAusgabe[]) && !(objects instanceof EinnameAusgabeTreeNode[])))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie die zu exportierenden Daten aus"));
 
-    EinnahmeAusgabe[] ea = (EinnahmeAusgabe[]) objects;
-    if (ea.length == 0)
+    if (objects.length == 0)
       throw new ApplicationException(i18n.tr("Bitte wählen Sie die zu exportierenden Daten aus"));
 
     Reporter reporter = null;
 
     try
     {
-      String sub = "";
-
-      if (ea[0].getStartdatum() != null && ea[0].getEnddatum() != null)
-        sub = i18n.tr("Zeitraum {0} - {1}", new String[]{HBCI.DATEFORMAT.format(ea[0].getStartdatum()),HBCI.DATEFORMAT.format(ea[0].getEnddatum())});
-
-      reporter = new Reporter(os, monitor, i18n.tr("Einnahmen/Ausgaben"), sub,ea.length);
+      reporter = new Reporter(os, monitor, i18n.tr("Einnahmen/Ausgaben"), getZeitraum(objects), objects.length);
       reporter.addHeaderColumn(i18n.tr("Konto"),        Element.ALIGN_CENTER, 100, BaseColor.LIGHT_GRAY);
       reporter.addHeaderColumn(i18n.tr("Anfangssaldo"), Element.ALIGN_CENTER,  60, BaseColor.LIGHT_GRAY);
       reporter.addHeaderColumn(i18n.tr("Einnahmen"),    Element.ALIGN_CENTER,  60, BaseColor.LIGHT_GRAY);
@@ -63,17 +62,14 @@ public class EinnahmeAusgabeExporter implements Exporter
       reporter.addHeaderColumn(i18n.tr("Differenz"),    Element.ALIGN_CENTER,  60, BaseColor.LIGHT_GRAY);
       reporter.createHeader();
 
-      // Iteration ueber Umsaetze
-      for (int i=0;i<ea.length; ++i)
+      if(objects instanceof EinnahmeAusgabe[])
       {
-        reporter.addColumn(reporter.getDetailCell(ea[i].getText(), Element.ALIGN_LEFT));
-        reporter.addColumn(reporter.getDetailCell(ea[i].getAnfangssaldo()));
-        reporter.addColumn(reporter.getDetailCell(ea[i].getEinnahmen()));
-        reporter.addColumn(reporter.getDetailCell(ea[i].getAusgaben()));
-        reporter.addColumn(reporter.getDetailCell(ea[i].getEndsaldo()));
-        reporter.addColumn(reporter.getDetailCell(ea[i].getPlusminus()));
-        reporter.addColumn(reporter.getDetailCell(ea[i].getDifferenz()));
-        reporter.setNextRecord();
+        for (int i=0;i<objects.length; ++i)
+          report((EinnahmeAusgabe)objects[i], reporter, 0);
+      } else
+      {
+        for (int i=0;i<objects.length; ++i)
+          report((EinnameAusgabeTreeNode)objects[i], reporter);
       }
       if (monitor != null)
         monitor.setStatus(ProgressMonitor.STATUS_DONE);
@@ -101,6 +97,43 @@ public class EinnahmeAusgabeExporter implements Exporter
       }
     }
   }
+
+  private String getZeitraum(Object[] objects){
+    if(objects instanceof EinnahmeAusgabe[])
+    {
+      EinnahmeAusgabe[] ea = (EinnahmeAusgabe[]) objects;
+      if (ea[0].getStartdatum() != null && ea[0].getEnddatum() != null)
+        return i18n.tr("Zeitraum {0} - {1}", new String[]{HBCI.DATEFORMAT.format(ea[0].getStartdatum()),HBCI.DATEFORMAT.format(ea[0].getEnddatum())});
+    }
+    return "";
+  }
+
+  private void report(EinnameAusgabeTreeNode treeNode, Reporter reporter) throws RemoteException{
+    String range=HBCI.DATEFORMAT.format(treeNode.getFrom())+" - "+HBCI.DATEFORMAT.format(treeNode.getTo());
+    PdfPCell cell = reporter.getDetailCell(range, Element.ALIGN_LEFT, null, null, Font.BOLD);
+    cell.setColspan(7);
+    reporter.addColumn(cell);
+    reporter.setNextRecord();
+    GenericIterator eas = treeNode.getChildren();
+    while(eas.hasNext()){
+      GenericObject ea = eas.next();
+      report((EinnahmeAusgabe)ea, reporter,5);
+    }
+  }
+
+  private void report(EinnahmeAusgabe ea, Reporter reporter, float indent)
+  {
+    PdfPCell cell = reporter.getDetailCell(ea.getText(), Element.ALIGN_LEFT);
+    cell.setPaddingLeft(indent);
+    reporter.addColumn(cell);
+    reporter.addColumn(reporter.getDetailCell(ea.getAnfangssaldo()));
+    reporter.addColumn(reporter.getDetailCell(ea.getEinnahmen()));
+    reporter.addColumn(reporter.getDetailCell(ea.getAusgaben()));
+    reporter.addColumn(reporter.getDetailCell(ea.getEndsaldo()));
+    reporter.addColumn(reporter.getDetailCell(ea.getPlusminus()));
+    reporter.addColumn(reporter.getDetailCell(ea.getDifferenz()));
+    reporter.setNextRecord();
+  }
   
   /**
    * @see de.willuhn.jameica.hbci.io.Exporter#suppportsExtension(java.lang.String)
@@ -117,7 +150,7 @@ public class EinnahmeAusgabeExporter implements Exporter
   public IOFormat[] getIOFormats(Class objectType)
   {
     // Wir unterstuetzen nur Umsatz-Trees
-    if (!EinnahmeAusgabe.class.equals(objectType))
+    if (!EinnahmeAusgabe.class.equals(objectType) && !EinnameAusgabeTreeNode.class.equals(objectType))
       return null;
 
     IOFormat myFormat = new IOFormat()

--- a/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabe.java
+++ b/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabe.java
@@ -14,13 +14,15 @@ import java.math.BigDecimal;
 import java.rmi.RemoteException;
 import java.util.Date;
 
+import de.willuhn.datasource.BeanUtil;
+import de.willuhn.datasource.GenericObject;
 import de.willuhn.jameica.hbci.rmi.Konto;
 
 /**
  * Container fuer die EinnahmeAusgabe-Daten.
  */
-
-public class EinnahmeAusgabe
+//für die Anzeige im Baum implementieren wir das absolute Minimum aus GenericObject 
+public class EinnahmeAusgabe implements GenericObject
 {
   private String text;
   private double anfangssaldo;
@@ -230,6 +232,45 @@ public class EinnahmeAusgabe
   public void setIsSumme(boolean b)
   {
     this.isSumme = b;
+  }
+
+  @Override
+  public boolean equals(GenericObject arg0) throws RemoteException
+  {
+    return arg0==this;
+  }
+
+  @Override
+  public Object getAttribute(String arg0) throws RemoteException
+  {
+    try
+    {
+      //TODO typischerweise wird de nicht zu viele Zeilen in der Tabelle geben
+      //so dass sich der Reflection-Overhead in Grenzen hält
+      //besser wäre ein explizites Mapping...
+      return BeanUtil.invoke(this, BeanUtil.toGetMethod(arg0), new Object[]{});
+    } catch (Exception e)
+    {
+      throw new RemoteException("no property with name "+arg0,e);
+    }
+  }
+
+  @Override
+  public String[] getAttributeNames() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getID() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getPrimaryAttribute() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
   }
 }
 

--- a/src/de/willuhn/jameica/hbci/server/EinnameAusgabeTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/EinnameAusgabeTreeNode.java
@@ -1,0 +1,116 @@
+package de.willuhn.jameica.hbci.server;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+import java.util.List;
+
+import de.willuhn.datasource.GenericIterator;
+import de.willuhn.datasource.GenericObject;
+import de.willuhn.datasource.GenericObjectNode;
+import de.willuhn.datasource.pseudo.PseudoIterator;
+import de.willuhn.jameica.util.DateUtil;
+
+/**
+ * Container für die EinnahmenAusgaben-Liste eines bestimmten Zeitraums
+ */
+//GenericObjectNode wird für die Anzeige im Baum minimal implementiert
+public class EinnameAusgabeTreeNode implements GenericObjectNode
+{
+
+  private Date from;
+  private Date to;
+  private List<EinnahmeAusgabe> children;
+
+  /**
+   * @param from Startdatum des Zeitraums
+   * @param to Enddatum des Zeitraums
+   * @param children Liste der EinnameAusgabe-Daten für diesen Zeitraum
+   */
+  public EinnameAusgabeTreeNode(Date from, Date to, List<EinnahmeAusgabe> children)
+  {
+    this.from=from;
+    this.to=to;
+    this.children=children;
+  }
+
+  /**
+   * @return Startdatum des Zeitraums
+   */
+  public Date getFrom()
+  {
+    return from;
+  }
+
+  /**
+   * @return Enddatum des Zeitraums
+   */
+  public Date getTo()
+  {
+    return to;
+  }
+
+  @Override
+  public boolean equals(GenericObject arg0) throws RemoteException
+  {
+    return arg0==this;
+  }
+
+  @Override
+  public Object getAttribute(String arg0) throws RemoteException
+  {
+    //wir liefern ausschließlich für die erste Spalte Daten
+    if("text".equals(arg0))
+    {
+      return DateUtil.DEFAULT_FORMAT.format(from)+"-"+DateUtil.DEFAULT_FORMAT.format(to);
+    }
+    return null;
+  }
+
+  @Override
+  public String[] getAttributeNames() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getID() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getPrimaryAttribute() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public GenericIterator getChildren() throws RemoteException
+  {
+    return PseudoIterator.fromArray((EinnahmeAusgabe[])children.toArray(new EinnahmeAusgabe[children.size()]));
+  }
+
+  @Override
+  public GenericObjectNode getParent() throws RemoteException
+  {
+    return null;
+  }
+
+  @Override
+  public GenericIterator getPath() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public GenericIterator getPossibleParents() throws RemoteException
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasChild(GenericObjectNode arg0) throws RemoteException
+  {
+    return true;
+  }
+}


### PR DESCRIPTION
Mit dieser Änderung ist es möglich die Einnahmen-Ausgaben-Übersicht nach Zeitraum zu gruppieren. Interessant finde ich das für den Verlauf über mehrere Jahre (Plus/Minus der einzelnen Jahre vergleichen) oder über die Monate innerhalb eines Jahres.

Wenn in einem Zeitraum eine Differenz gibt, kann man außerdem leichter einschränken, genau wann die Differenz(en) aufgetreten sind.

Die Idee war, das Tabellenformat so wenig wie möglich zu ändern. Deshalb wird beim Gesamtzeitraum (wie bisher) kein Elternknoten angezeigt, ist eine Aufschlüsselung erwünscht, werden die Gruppen durch den aufklappbaren Zeitraum optisch getrennt.
Da ich die Code-Anpassungen so gering wie möglich halten wollte, ist die Aufschlüsselung nicht bei offenen Intervallen möglich (sonst müsste man hier entweder über alle Umsätze iterieren und wie bei den Kategorien Eimerchen füllen, oder zunächst den frühesten/spätesten Umsatz der gewählten Konten ermitteln).

Beim Anpassen des Exports ist mir aufgefallen, dass im PDF der Betrag 0,00 standardmäßig rot eingefärbt ist. Ist das nicht eher die Farbe für einen (echt) negativen Betrag?