### PR TITLE
Remove the deprecated .cvsignore file

### DIFF
--- a/.cvsignore
+++ b/.cvsignore
@@ -1,3 +1,0 @@
-bin
-releases
-rdhnew.rdh


### PR DESCRIPTION
This is not needed anymore as the project is stored in Git now.