### PR TITLE
Beim Speichern eines Kontos weiche statt harte Längenbeschränkung prüfen

### DIFF
--- a/src/de/willuhn/jameica/hbci/server/KontoImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/KontoImpl.java
@@ -97,7 +97,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       // BUGZILLA 280
       HBCIProperties.checkChars(getBLZ(), HBCIProperties.HBCI_BLZ_VALIDCHARS);
       HBCIProperties.checkChars(getKontonummer(),HBCIProperties.HBCI_KTO_VALIDCHARS);
-      HBCIProperties.checkLength(getKontonummer(), HBCIProperties.HBCI_KTO_MAXLENGTH_HARD);
+      HBCIProperties.checkLength(getKontonummer(), HBCIProperties.HBCI_KTO_MAXLENGTH_SOFT);
       HBCIProperties.checkLength(getUnterkonto(), HBCIProperties.HBCI_ID_MAXLENGTH);
 
       if (getKundennummer() == null || getKundennummer().length() == 0)


### PR DESCRIPTION
Manche Banken melden Kreditkartenkonten, die aufgrund der Prüfung der harten Begrenzung nicht gespeichert werden können. Die Option für die weiche Begrenzung ist so nicht verwendbar. 