### PR TITLE
Add barchart for income-expenses-difference in analytics view

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/chart/VergleichPlusMinusBarChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/VergleichPlusMinusBarChart.java
@@ -1,0 +1,266 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2019 Tobias Amon
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci.gui.chart;
+
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.RGB;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.swtchart.IAxis;
+import org.swtchart.IAxisTick;
+import org.swtchart.IBarSeries;
+import org.swtchart.IGrid;
+import org.swtchart.ILegend;
+import org.swtchart.ISeries.SeriesType;
+import org.swtchart.ISeriesLabel;
+import org.swtchart.ITitle;
+import org.swtchart.LineStyle;
+import org.swtchart.ext.InteractiveChart;
+
+import de.willuhn.jameica.gui.GUI;
+import de.willuhn.jameica.gui.util.Font;
+import de.willuhn.jameica.gui.util.SWTUtil;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.Settings;
+import de.willuhn.jameica.hbci.rmi.EinnahmeAusgabeZeitraum;
+import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
+
+/**
+ * Chart zum Anzeigen der Differenz aus Einnahmen und Ausgaben.
+ */
+public class VergleichPlusMinusBarChart extends AbstractChart
+{
+  private Composite comp = null;
+  private List<EinnahmeAusgabeZeitraum> data = null;
+
+  /**
+   * @see de.willuhn.jameica.hbci.gui.chart.Chart#redraw()
+   */
+  @Override
+  public void redraw() throws RemoteException
+  {
+    // redraw ohne paint() Weia ;)
+    if (this.comp == null || this.comp.isDisposed())
+      return;
+    
+    // Cleanup
+    SWTUtil.disposeChildren(this.comp);
+    this.comp.setLayout(SWTUtil.createGrid(1,false));
+    
+    setChart(new InteractiveChart(this.comp,SWT.BORDER));
+    getChart().setLayoutData(new GridData(GridData.FILL_BOTH));
+    getChart().getLegend().setVisible(false);
+    getChart().setOrientation(SWT.HORIZONTAL);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Farben des Charts
+    getChart().setBackground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+    getChart().setBackgroundInPlotArea(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+    //
+    ////////////////////////////////////////////////////////////////////////////
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Titel des Charts
+    {
+      ITitle title = getChart().getTitle();
+      title.setText(this.getTitle());
+      title.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+      title.setFont(Font.BOLD.getSWTFont());
+    }
+    //
+    ////////////////////////////////////////////////////////////////////////////
+    
+    ////////////////////////////////////////////////////////////////////////////
+    // Legende
+    {
+      ILegend legend = getChart().getLegend();
+      legend.setFont(Font.SMALL.getSWTFont());
+      legend.setVisible(true);
+      legend.setPosition(SWT.RIGHT);
+      legend.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+    }
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Layout der Achsen
+    Color gray = getColor(new RGB(234,234,234));
+    
+    // X-Achse
+    {
+      IAxis axis = getChart().getAxisSet().getXAxis(0);
+      axis.getTitle().setFont(Font.SMALL.getSWTFont());
+      axis.getTitle().setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE)); // wenn wir den auch ausblenden, geht die initiale Skalierung kaputt. Scheint ein Bug zu sein
+
+      IGrid grid = axis.getGrid();
+      grid.setStyle(LineStyle.DOT);
+      grid.setForeground(gray);
+
+      IAxisTick tick = axis.getTick();
+      tick.setFormat(HBCI.DATEFORMAT);
+      tick.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+      
+      axis.setCategorySeries(this.getCategoryNames());
+      axis.enableCategory(true);
+    }
+    
+    // Y-Achse
+    {
+      IAxis axis = getChart().getAxisSet().getYAxis(0);
+      axis.getTitle().setVisible(false);
+
+      IGrid grid = axis.getGrid();
+      grid.setStyle(LineStyle.DOT);
+      grid.setForeground(gray);
+      
+      IAxisTick tick = axis.getTick();
+      tick.setFormat(HBCI.DECIMALFORMAT);
+      tick.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+    }
+    //
+    ////////////////////////////////////////////////////////////////////////////
+
+    {
+      IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,"plus");
+      barSeries.setYSeries(getPlusMinusSeries(true));
+      barSeries.setDescription(i18n.tr("Plus"));
+      barSeries.setBarColor(Settings.getBuchungHabenForeground());
+      ISeriesLabel label = barSeries.getLabel();
+      label.setFont(Font.SMALL.getSWTFont());
+      label.setFormat(HBCI.DECIMALFORMAT.toPattern());
+      label.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+      label.setVisible(true);
+    }
+    
+    {
+      IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,"minus");
+      barSeries.setYSeries(getPlusMinusSeries(false));
+      barSeries.setDescription(i18n.tr("Minus"));
+      barSeries.setBarColor(Settings.getBuchungSollForeground());
+      ISeriesLabel label = barSeries.getLabel();
+      label.setFont(Font.SMALL.getSWTFont());
+      label.setFormat(HBCI.DECIMALFORMAT.toPattern());
+      label.setForeground(GUI.getDisplay().getSystemColor(SWT.COLOR_WHITE));
+      label.setVisible(true);
+    }
+
+    getChart().getAxisSet().adjustRange();
+    this.comp.layout(true);
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.Part#paint(org.eclipse.swt.widgets.Composite)
+   */
+  public void paint(Composite parent) throws RemoteException
+  {
+    if (this.comp != null)
+      return;
+    
+    this.comp = new Composite(parent,SWT.NONE);
+    this.comp.setLayoutData(new GridData(GridData.FILL_BOTH));
+    
+    redraw();
+    super.paint(parent);
+  }
+
+  /**
+   * Setter für die anzuzeigenden Daten
+   * @param items Liste mit den Daten.
+   * @throws RemoteException 
+   */
+  public void setData(List<EinnahmeAusgabeZeitraum> items) throws RemoteException
+  {
+    this.data = items;
+  }
+
+  /**
+   * Liefert die Namen der Kategorien.
+   * @return die Namen der Kategorien.
+   */
+  private String[] getCategoryNames()
+  {
+    if (data == null)
+      return new String[] {i18n.tr("Keine Daten")};
+    
+    final List<String> result = new ArrayList<String>();
+    for (EinnahmeAusgabeZeitraum n : this.data)
+    {
+      result.add(this.getLabel(n));
+    }
+    return result.toArray(new String[result.size()]);
+  }
+  
+  /**
+   * Liefert das Label fuer das Element.
+   * @param node das Element.
+   * @return das Label.
+   */
+  private String getLabel(EinnahmeAusgabeZeitraum node)
+  {
+    if (node instanceof EinnahmeAusgabe)
+      return node.getText(); // Gesamtzeitraum
+    
+    final Calendar cal = Calendar.getInstance();
+    cal.setTime(node.getStartdatum());
+    final int sm = cal.get(Calendar.MONTH);
+    final int sy = cal.get(Calendar.YEAR);
+    
+    cal.setTime(node.getEnddatum());
+    final int em = cal.get(Calendar.MONTH);
+    final int ey = cal.get(Calendar.YEAR);
+
+    // Gruppiert nach Monat
+    if (sm == em && sy == ey)
+      return String.format("%02d",sm+1) + "/" + sy; // Monat beginnt im Calendar bei 0
+    
+    // Gruppiert nach Jahr
+    if (sy == ey)
+      return Integer.toString(sy);
+
+    // Gruppierung unbekannt
+    return node.getText();
+  }
+  
+  /**
+   * Liefert die Datenreihe mit der Differenz aus Einnahmen und Ausgaben.
+   * @return Datenreihe mit der Differenz aus Einnahmen und Ausgaben.
+   * @throws RemoteException
+   */
+  private double[] getPlusMinusSeries(boolean plus) throws RemoteException
+  {
+    if (data == null)
+      return new double[] {0.0};
+    
+    double[] serie = new double[this.data.size()];
+    for (int i = 0; i < this.data.size(); i++)
+    {
+      EinnahmeAusgabeZeitraum e = this.data.get(i);
+      //TODO Bug hier und in VergleichBarChart
+      //Wenn genau ein Konto ausgewählt ist und eine Gruppierung nach Jahr oder Monat aktiv ist
+      //werden keine Daten angezeigt
+      //Ursache ist, dass dann im Baum zwar eine Unterteilung erfolgt, aber keine Summenzeile existiert
+      //dadurch ist e.getEinnahme/getAusgabe immer 0
+      double diff=e.getEinnahmen()-e.getAusgaben();
+      serie[i] = 0.0;
+      if(plus&&diff>0 ||!plus &&diff<0){
+        serie[i] = diff;
+      }
+    }
+    return serie;
+  }
+
+}

--- a/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
@@ -39,6 +39,7 @@ import de.willuhn.jameica.hbci.gui.input.DateToInput;
 import de.willuhn.jameica.hbci.gui.input.KontoInput;
 import de.willuhn.jameica.hbci.gui.input.RangeInput;
 import de.willuhn.jameica.hbci.gui.parts.EinnahmenAusgabenVerlauf;
+import de.willuhn.jameica.hbci.gui.parts.PlusMinusVerlauf;
 import de.willuhn.jameica.hbci.rmi.EinnahmeAusgabeZeitraum;
 import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
@@ -66,7 +67,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
   private SelectInput interval     = null;
 
   private TreePart tree            = null;
-  private EinnahmenAusgabenVerlauf chart = null;
+  private EinnahmenAusgabenVerlauf einnahmenAusgabenChart = null;
+  private PlusMinusVerlauf plusMinusChart = null;
 
   /**
    * Gruppierung der Einnahmen/Ausgaben nach Zeitraum.
@@ -211,13 +213,27 @@ public class EinnahmeAusgabeControl extends AbstractControl
    * @return Balkendiagramm
    * @throws RemoteException 
    */
-  public EinnahmenAusgabenVerlauf getChart() throws RemoteException
+  public EinnahmenAusgabenVerlauf getEinnahmenAusgabenChart() throws RemoteException
   {
-    if(this.chart != null)
-      return this.chart;
+    if(this.einnahmenAusgabenChart != null)
+      return this.einnahmenAusgabenChart;
     
-    this.chart = new EinnahmenAusgabenVerlauf(getWerte());
-    return chart;
+    this.einnahmenAusgabenChart = new EinnahmenAusgabenVerlauf(getWerte());
+    return einnahmenAusgabenChart;
+  }
+
+  /**
+   * Liefert ein Balkendiagramm mit den Differenen aus Einahmen und Ausgaben 
+   * @return Balkendiagramm
+   * @throws RemoteException 
+   */
+  public PlusMinusVerlauf getPlusMinusChart() throws RemoteException
+  {
+    if(this.plusMinusChart != null)
+      return this.plusMinusChart;
+    
+    this.plusMinusChart = new PlusMinusVerlauf(getWerte());
+    return plusMinusChart;
   }
 
   /**
@@ -416,9 +432,12 @@ public class EinnahmeAusgabeControl extends AbstractControl
 
       tree.setList(this.getWerte());
       
-      EinnahmenAusgabenVerlauf chart = getChart();
-      chart.setList(this.getWerte());
-    }
+      EinnahmenAusgabenVerlauf einnahmenAusgabenChart = getEinnahmenAusgabenChart();
+      einnahmenAusgabenChart.setList(this.getWerte());
+
+      PlusMinusVerlauf plusMinusChart = getPlusMinusChart();
+      plusMinusChart.setList(this.getWerte());
+}
     catch (RemoteException re)
     {
       Logger.error("unable to redraw table",re);

--- a/src/de/willuhn/jameica/hbci/gui/parts/PlusMinusVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PlusMinusVerlauf.java
@@ -1,0 +1,67 @@
+package de.willuhn.jameica.hbci.gui.parts;
+
+import java.rmi.RemoteException;
+import java.util.List;
+
+import org.eclipse.swt.widgets.Composite;
+
+import de.willuhn.jameica.gui.Part;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.gui.chart.VergleichPlusMinusBarChart;
+import de.willuhn.jameica.hbci.rmi.EinnahmeAusgabeZeitraum;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.I18N;
+
+/**
+ * Zeigt die Differenz von Ein- und Ausnahmen im zeitlichen Verlauf.
+ */
+public class PlusMinusVerlauf implements Part
+{
+  
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  private VergleichPlusMinusBarChart chart   = null;
+  private List<EinnahmeAusgabeZeitraum> data = null;
+
+  /**
+   * Konstruktor mit anzuzeigenden Werten
+   * @param werte
+   */
+  public PlusMinusVerlauf(List<EinnahmeAusgabeZeitraum> werte)
+  {
+    this.data = werte;
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.Part#paint(org.eclipse.swt.widgets.Composite)
+   */
+  @Override
+  public void paint(Composite parent) throws RemoteException
+  {
+    try
+    {
+      this.chart = new VergleichPlusMinusBarChart();
+      this.chart.setTitle(i18n.tr("Plus/Minus"));
+      this.chart.setData(this.data);
+      this.chart.paint(parent);
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to create chart",e);
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Fehler beim Erzeugen des Diagramms"),StatusBarMessage.TYPE_ERROR));
+    }
+  }
+
+  /**
+   * Setzt die anzuzeigenden Werte
+   * @param werte die Werte.
+   * @throws RemoteException 
+   */
+  public void setList(List<EinnahmeAusgabeZeitraum> werte) throws RemoteException
+  {
+    this.data = werte;
+    this.chart.setData(werte);
+    this.chart.redraw();
+  }
+}

--- a/src/de/willuhn/jameica/hbci/gui/views/EinnahmenAusgaben.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/EinnahmenAusgaben.java
@@ -31,6 +31,7 @@ import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.action.EinnahmeAusgabeExport;
 import de.willuhn.jameica.hbci.gui.controller.EinnahmeAusgabeControl;
 import de.willuhn.jameica.hbci.gui.parts.EinnahmenAusgabenVerlauf;
+import de.willuhn.jameica.hbci.gui.parts.PlusMinusVerlauf;
 import de.willuhn.jameica.hbci.rmi.EinnahmeAusgabeZeitraum;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
@@ -110,9 +111,13 @@ public class EinnahmenAusgaben extends AbstractView
     TreePart tree = control.getTree();
     tree.paint(tg1.getComposite());
     
-    final TabGroup tg2 = new TabGroup(folder,i18n.tr("Grafische Auswertung"),true,1);
-    final EinnahmenAusgabenVerlauf chart = control.getChart();
-    chart.paint(tg2.getComposite());
+    final TabGroup tg2 = new TabGroup(folder,i18n.tr("Diagramm Einnahmen/Ausgaben"),true,1);
+    final EinnahmenAusgabenVerlauf einnahmenAusgabenChart = control.getEinnahmenAusgabenChart();
+    einnahmenAusgabenChart.paint(tg2.getComposite());
+    
+    final TabGroup tg3 = new TabGroup(folder,i18n.tr("Diagramm Plus/Minus"),true,1);
+    final PlusMinusVerlauf plusMinusChart = control.getPlusMinusChart();
+    plusMinusChart.paint(tg3.getComposite());
     
     folder.setLayoutData(new GridData(GridData.FILL_BOTH));
   }


### PR DESCRIPTION
Ich finde die funktionale Erweiterung, die mit #53 dazukommt, toll. Mit der Erweiterung aus diesem Pull Request kommt zusätzlich die Möglichkeit einer grafischen Auswertung der *Differenz* aus Einnahmen und Ausgaben hinzu, die ich für ebenso sinnvoll halte wie das Gegenüberstellen der Einnahmen und Ausgaben.

Die Umsetzung könnte ggf. noch verbessert werden, insb. nicht zwei Datenreihen zu haben, sondern eine, bei der aber positive Werte blau und negative rot erscheinen, wobei ich noch nicht versucht habe, ob das umsetzbar ist.

Zudem gibt es in der aktuellen Implementierung beider Diagramme einen Bug. Ist ein einzelnes Konto ausgewählt und eine Zeitraumgruppierung vorgenommen, werden in den Diagrammen gar keine Daten angezeigt. Da in der Baumansicht dann zwar eine Baumunterteilung erfolgt, es aber keine Summenzeile gibt, liefert EinnahmeAusgabeTreeNode#get<EinnahmeAusgabe> immer 0.
Ein Hinzufügen der Summenzeile in der Baumansicht halte ich aber definitiv nicht für sinnvoll.

Da VergleichPlusMinusBarChart.java praktisch eine 1:1-Kopie des zuvor eingeführten Charts ist, habe ich das Copyright unverändert gelassen.