### PR TITLE
Reduce number of summary calculations

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -833,6 +833,7 @@ public class KontoauszugList extends UmsatzList
   {
     try
     {
+      activateSummary(false);
       removeAll();
       
       List<Umsatz> list = getUmsaetze();
@@ -842,6 +843,7 @@ public class KontoauszugList extends UmsatzList
       
       // Zum Schluss Sortierung aktualisieren
       sort();
+      activateSummary(true);
     }
     catch (Exception e)
     {
@@ -1075,6 +1077,4 @@ public class KontoauszugList extends UmsatzList
     }
     
   }
-  
-  
 }

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
@@ -41,6 +41,7 @@ import de.willuhn.jameica.gui.formatter.TableFormatter;
 import de.willuhn.jameica.gui.parts.Column;
 import de.willuhn.jameica.gui.parts.TableChangeListener;
 import de.willuhn.jameica.gui.parts.TablePart;
+import de.willuhn.jameica.gui.parts.table.Feature;
 import de.willuhn.jameica.gui.parts.table.FeatureShortcut;
 import de.willuhn.jameica.gui.util.Color;
 import de.willuhn.jameica.gui.util.Container;
@@ -92,6 +93,8 @@ public class UmsatzList extends TablePart implements Extendable
   private boolean disposed          = false;
   
   private List<Umsatz> umsaetze     = null;
+
+  private boolean noSummary       = false;
   
   /**
    * @param konto
@@ -245,6 +248,9 @@ public class UmsatzList extends TablePart implements Extendable
   @Override
   protected String getSummary()
   {
+    if(noSummary){
+      return "";
+    }
     try
     {
       Object o = this.getSelection();
@@ -343,7 +349,9 @@ public class UmsatzList extends TablePart implements Extendable
     if (this.filter || this.konto != null)
       kl.process(true);
 
+    activateSummary(false);
     super.paint(parent);
+    activateSummary(true);
 
     // Machen wir explizit nochmal, weil wir die paint()-Methode ueberschrieben haben
     restoreState();
@@ -434,6 +442,7 @@ public class UmsatzList extends TablePart implements Extendable
 
             if (konto != null)
             {
+              activateSummary(false);
               // Umsaetze vom Konto neu laden
               removeAll();
               GenericIterator<Umsatz> list = konto.getUmsaetze(t);
@@ -479,6 +488,7 @@ public class UmsatzList extends TablePart implements Extendable
             }
             
             sort();
+            activateSummary(true);
           }
           catch (Exception e)
           {
@@ -680,6 +690,17 @@ public class UmsatzList extends TablePart implements Extendable
   {
     return UmsatzList.class.getName();
   }
-  
-  
+
+  protected void activateSummary(boolean activate)
+  {
+    if (activate)
+    {
+      noSummary = false;
+      featureEvent(Feature.Event.REFRESH, null);
+    } else
+    {
+      noSummary = true;
+    }
+  }
+
 }


### PR DESCRIPTION
Dieser PR soll auf ein Performance-Problem beim TablePart hinweisen. Wie in der Commit-Nachricht beschrieben wird getSummary für jeden der Tabelle hinzufügten Eintrag aufgerufen. Da es im TablePart aber kein setItems für alle Einträge auf einaml gibt, müssen sie immer einzeln hinzgefügt werden. Und das dann zweimal, da beim sort auch wieder alles geleert und neu aufgebaut wird.

Die Performance der Summenberechnung ist dabei wahrscheinlich nicht einmal entscheidend (für den Nutzer wahrnehmbar). Was man bei großen Tabellen aber schon merkt, ist das zweimalige "Wachsen" des Scrollbalkens.