### PR TITLE
MT940 exporter: use system lineSeparator

### DIFF
--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -49,7 +49,7 @@ public class MT940UmsatzExporter implements Exporter
 {
   protected final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  protected final static String NL            = "\r\n";
+  protected final static String NL            = System.getProperty("line.separator","\r\n");
   protected final static DateFormat DF_YYMMDD = new SimpleDateFormat("yyMMdd");
   protected final static DateFormat DF_MMDD   = new SimpleDateFormat("MMdd");
   


### PR DESCRIPTION
Changed to use EOL from current system instead of fixed windows EOL. Fallback to previous windows EOL if system property is not available.