### PR TITLE
Performance-Analyse Einnahmen/Ausgaben

### DIFF
--- a/src/de/willuhn/jameica/hbci/server/KontoUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/KontoUtil.java
@@ -273,6 +273,14 @@ public class KontoUtil
     java.sql.Date start = datum != null ? new java.sql.Date(DateUtil.startOfDay(datum).getTime()) : null;
 
     DBIterator list = UmsatzUtil.getUmsaetze();
+    //eins der Performance-Probleme ist, dass hier scheinbar schon die gesamte Liste instantiiert wird,
+    //obwohl nur der erste (relevante) Inhalt interessiert.
+    //Mit dem Setzen eines Limits kann man die Anzahl der Datensätze einschränken,
+    //kann sich aber bei keinem Limit sicher sein, ob der relevante Eintrag dabei ist.
+    //Typischerweise könnten 100 Einträge ausreichen, was aber wenn erst der 101. einer ohne Vormerkung ist.
+    //Perfekt wäre, wenn Paging unterstützt wäre, dann könnte man die Pagegröße einschränken
+    //und es werden nicht schon alle Umsätze instantiiert, obwohl man nur einen benötigt
+//    list.setLimit(100);
     list.addFilter("konto_id = " + konto.getID());
     
     if (start != null)
@@ -289,6 +297,8 @@ public class KontoUtil
     // Im angegebenen Zeitraum waren keine Umsätze zu finden. Deshalb suchen wir
     // frühere Umsätze.
     list = UmsatzUtil.getUmsaetzeBackwards();
+    //dito
+//  list.setLimit(100);
     list.addFilter("konto_id = " + konto.getID());
     
     if (start != null)
@@ -319,6 +329,8 @@ public class KontoUtil
     java.sql.Date end = datum != null ? new java.sql.Date(DateUtil.endOfDay(datum).getTime()) : null;
 
     DBIterator list = UmsatzUtil.getUmsaetzeBackwards();
+    //dito
+//    list.setLimit(100);
     list.addFilter("konto_id = " + konto.getID());
     
     if (end != null)
@@ -336,6 +348,8 @@ public class KontoUtil
     // BUGZILLA 1682 Wir checken mal, ob wir eine Buchung direkt dahinter finden. Dann nehmen
     // wir diese und generieren aus Zwischensumme und Betrag den Endsaldo
     list = UmsatzUtil.getUmsaetze();
+    //dito
+//  list.setLimit(100);
     list.addFilter("konto_id = " + konto.getID());
     
     if (end != null)


### PR DESCRIPTION
Dieser PR dient erstmal nur einer kurzen Diskussion zur Grundproblematik und der Frage ob und wie man das angehen kann.

Ich habe die Performance des Einnahmen/Ausgaben-View nochmal genauer angeschaut. Die Probleme fallen insb. bei monatlicher Gruppierung auf (für mehrere Konten wird es dann auch nicht besser). Eine Auffälligkeit war, dass auch bei Konten ohne Umsätze (z.B. gekündigt, aber noch in einer Auswertungs-Gruppe) der Aufbau der Daten extrem lange dauert.

Es sind insb. die Anfangs- und Endsaldo-Ermittlungen, die lange dauern. Je nachdem ob der Zeitraum am Anfang oder Ende des Kontolebenszyklus liegt Faktor bei 10 (Buchungssummen 300ms, Saldo 4s; das Konto hat über 1000 Buchungen). Die Gründe sind im Code ja auch schon beschrieben - dediziertes SQL nicht möglich. In der aktuellen Implementierung führt das aber dazu, dass sämtliche Umsätze 12x (Analysezeitraum 1 Jahr, monatliche Gruppierung) instantiiert werden. Da wäre es bei einer Gruppierung effizienter, sich alle Umsätze des Kontos einmal zu holen und alles selbst auszurechnen anstatt 12x(4+X) SQL-Statements über das Konto-Util abzusetzen.

Die im PR verwendete Vorgängerzeitraums-Map-Änderung beschleunigt erstmal nur den Fall, dass es für ein oder mehrere Konten keine Umsätze in einem Zeitraum gibt, ist aber nur Symptombekämpfung (Vermeidung unnötiger langsamer Zugriffe) und hilft nicht für den Standardfall.
Final die beste Lösung wäre meiner Ansicht nach, wenn man beim DbIterator nicht nur ein limit angeben könnte, sondern auch eine Page-Size - es werden immer nur so viele Objekte instantiiert und wenn die Page zuende ist, wird beim nächsten next() wieder an die Datenbank gegangen.
Wenn das prinzipiell nicht machbar ist, wäre mein Vorschlag, das Zusammenbauen der EinnahmenAusgaben-Objekte für den gruppierten Fall komplett in Java zu machen - es werden ohnehin praktisch alle Umsätze des Kontos instantiiert (für Ermittlung des Anfangssaldo und Endsaldo müssen auch die Umsätze vor und nach dem Zeitraum geholt werden).

Das Einführen des aktuell auskommentierten Limits im Konto-Util bringt schon eine drastische Beschleunigung. Leider kennt man das korrekte Limit nicht - zu klein und das Ergebnis ist falsch, zu groß und die Performanceverbesserung ist suboptimal. Hinweis selbst bei Limit 1000, war die Beschleunigung bei mir schon deutlich spürbar: Saldoberechnung 300ms statt 3 s.

Wie siehst Du das?
* paging umsetzbar
* vieleicht doch irgendwie Flag-Auswertung im SQL möglich (Division/Rest-Berechungn auf Spalte)
* Berechnung im Java bei Gruppierung
* limit 1000 OK
* Es gibt gar kein Problem.