### PR TITLE
Zeitraumauswahl einschränkbar

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.TreeItem;
 
 import com.google.common.base.Joiner;
@@ -154,7 +157,7 @@ public class EinnahmeAusgabeControl extends AbstractControl
     if (this.start != null)
       return this.start;
 
-    this.start = new DateFromInput(null,"umsatzlist.filter.from");
+    this.start = new DateFromInput(null, "auswertungen.einnahmeausgabe.filter.from");
     this.start.setName(i18n.tr("Von"));
     this.start.setComment(null);
     return this.start;
@@ -169,8 +172,19 @@ public class EinnahmeAusgabeControl extends AbstractControl
     if (this.onlyActive != null)
       return this.onlyActive;
     
-    this.onlyActive = new CheckboxInput(settings.getBoolean("umsatzlist.filter.active",false));
+    this.onlyActive = new CheckboxInput(settings.getBoolean("auswertungen.einnahmeausgabe.filter.active",false));
     this.onlyActive.setName(i18n.tr("Nur aktive Konten"));
+    this.onlyActive.addListener(new org.eclipse.swt.widgets.Listener() {
+
+      @Override
+      public void handleEvent(Event event)
+      {
+        if (event.type == SWT.Selection)
+        {
+          settings.setAttribute("auswertungen.einnahmeausgabe.filter.active", (Boolean) onlyActive.getValue());
+        }
+      }
+    });
     return this.onlyActive;
   }
   
@@ -184,7 +198,7 @@ public class EinnahmeAusgabeControl extends AbstractControl
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(),this.getEnd(),"umsatzlist.filter.range");
+    this.range = new RangeInput(this.getStart(), this.getEnd(), "auswertungen.einnahmeausgabe.filter.range");
     return this.range;
   }
 
@@ -197,7 +211,7 @@ public class EinnahmeAusgabeControl extends AbstractControl
     if (this.end != null)
       return this.end;
 
-    this.end = new DateToInput(null,"umsatzlist.filter.to");
+    this.end = new DateToInput(null, "auswertungen.einnahmeausgabe.filter.to");
     this.end.setName(i18n.tr("bis"));
     this.end.setComment(null);
     return this.end;
@@ -209,11 +223,24 @@ public class EinnahmeAusgabeControl extends AbstractControl
    * */
   public SelectInput getInterval()
   {
-    if(this.interval !=null)
+    if (this.interval != null)
       return this.interval;
-    
-    this.interval = new SelectInput(Interval.values(), Interval.MONTH);
+
+    this.interval = new SelectInput(Interval.values(), Interval.valueOf(settings.getString("auswertungen.einnahmeausgabe.filter.interval", "MONTH")));
     this.interval.setName(i18n.tr("Gruppierung nach"));
+    this.interval.addListener(new Listener() {
+
+      @Override
+      public void handleEvent(Event event)
+      {
+        if (event.type == SWT.Selection)
+        {
+          Interval value = (Interval) interval.getValue();
+          settings.setAttribute("auswertungen.einnahmeausgabe.filter.interval", value.name());
+        }
+      }
+
+    });
     return this.interval;
   }
   

--- a/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
@@ -56,6 +56,7 @@ import de.willuhn.jameica.hbci.rmi.Umsatz;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabeTreeNode;
 import de.willuhn.jameica.hbci.server.KontoUtil;
+import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.hbci.server.UmsatzUtil;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
@@ -198,7 +199,7 @@ public class EinnahmeAusgabeControl extends AbstractControl
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(), this.getEnd(), "auswertungen.einnahmeausgabe.filter.range");
+    this.range = new RangeInput(this.getStart(), this.getEnd(), Range.CATEGORY_AUSWERTUNG, "auswertungen.einnahmeausgabe.filter.range");
     return this.range;
   }
 

--- a/src/de/willuhn/jameica/hbci/gui/controller/SettingsControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SettingsControl.java
@@ -35,6 +35,7 @@ import de.willuhn.jameica.hbci.experiments.FeatureService;
 import de.willuhn.jameica.hbci.gui.DialogFactory;
 import de.willuhn.jameica.hbci.gui.action.UmsatzTypNew;
 import de.willuhn.jameica.hbci.gui.parts.UmsatzTypTree;
+import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.services.BeanService;
 import de.willuhn.jameica.system.Application;
@@ -61,6 +62,7 @@ public class SettingsControl extends AbstractControl
 	private Input buchungHabenFg    				= null;
 
   private UmsatzTypTree umsatzTypTree     = null;
+  private List<CheckboxInput> ranges      = new ArrayList<CheckboxInput>();
 
   private Input ueberweisungLimit         = null;
 
@@ -85,6 +87,27 @@ public class SettingsControl extends AbstractControl
     if (umsatzTypTree == null)
       umsatzTypTree = new UmsatzTypTree(new UmsatzTypNew());
     return umsatzTypTree;
+  }
+
+  /**
+   * @param category Zeitraumkagegorie (Range.CATEGORY_ZAHLUNGSVERKEHR oder Range.CATEGORY_AUSWERTUNG)
+   * @return Liste mit Checkboxen für die Zeiträume der gegebenen Kategorie
+   * @throws RemoteException 
+   * */
+  public List<CheckboxInput> getRanges(String category) throws RemoteException
+  {
+    List<CheckboxInput> ranges = new ArrayList<CheckboxInput>();
+    List<Range> activeRangse = Range.getActiveRanges(category);
+    for (Range range : Range.KNOWN)
+    {
+      CheckboxInput b = new CheckboxInput(activeRangse.contains(range));
+      b.setName(range.toString());
+      ranges.add(b);
+      b.setData("id", category+"."+range.getId());
+      ranges.add(b);
+    }
+    this.ranges.addAll(ranges);
+    return ranges;
   }
 
   /**
@@ -376,6 +399,14 @@ public class SettingsControl extends AbstractControl
       catch (Exception e)
       {
         Logger.error("unable to reload view",e);
+      }
+    }
+
+    de.willuhn.jameica.system.Settings rangeSettings = new de.willuhn.jameica.system.Settings(Range.class);
+    for (CheckboxInput range : ranges)
+    {
+      if(range.hasChanged()) {
+        rangeSettings.setAttribute((String) range.getData("id"), (Boolean) range.getValue());
       }
     }
 

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
@@ -42,6 +42,7 @@ import de.willuhn.jameica.hbci.gui.input.RangeInput;
 import de.willuhn.jameica.hbci.gui.parts.UmsatzTree;
 import de.willuhn.jameica.hbci.gui.parts.UmsatzTypVerlauf;
 import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.hbci.server.UmsatzTreeNode;
 import de.willuhn.jameica.hbci.server.UmsatzUtil;
 import de.willuhn.jameica.messaging.StatusBarMessage;
@@ -153,7 +154,7 @@ public class UmsatzTypTreeControl extends AbstractControl
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(),this.getEnd(), "auswertungen.umsatztree.filter.range");
+    this.range = new RangeInput(this.getStart(),this.getEnd(), Range.CATEGORY_AUSWERTUNG, "auswertungen.umsatztree.filter.range");
     this.range.addListener(this.changedListener(this.range));
     
     return this.range;

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
@@ -153,7 +153,7 @@ public class UmsatzTypTreeControl extends AbstractControl
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(),this.getEnd(),"umsatzlist.filter.range");
+    this.range = new RangeInput(this.getStart(),this.getEnd(), "auswertungen.umsatztree.filter.range");
     this.range.addListener(this.changedListener(this.range));
     
     return this.range;
@@ -169,7 +169,7 @@ public class UmsatzTypTreeControl extends AbstractControl
     if (this.start != null)
       return this.start;
 
-    this.start = new DateFromInput(null,"umsatzlist.filter.from");
+    this.start = new DateFromInput(null, "auswertungen.umsatztree.filter.from");
     this.start.setName(i18n.tr("Von"));
     this.start.setComment(null);
     this.start.addListener(this.changedListener(this.start));
@@ -186,7 +186,7 @@ public class UmsatzTypTreeControl extends AbstractControl
     if (this.end != null)
       return this.end;
 
-    this.end = new DateToInput(null,"umsatzlist.filter.to");
+    this.end = new DateToInput(null, "auswertungen.umsatztree.filter.to");
     this.end.setName(i18n.tr("bis"));
     this.end.setComment(null);
     this.end.addListener(this.changedListener(this.end));

--- a/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
@@ -47,18 +47,19 @@ public class RangeInput extends SelectInput
    */
   public RangeInput(final Input from, final Input to)
   {
-    this(from,to,null);
+    this(from, to, Range.CATEGORY_ZAHLUNGSVERKEHR, null);
   }
 
   /**
    * ct.
    * @param from Input-Feld, in das das Start-Datum nach der Auswahl uebernommen werden soll.
    * @param to Input-Feld, in das das End-Datum nach der Auswahl uebernommen werden soll.
+   * @param category Kategorie der anzuzeigenden Zeiträume (Range.CATEGORY_ZAHLUNGSVERKEHR oder Range.CATEGORY_AUSWERTUNG)
    * @param parameter Schluessel-Name, unter dem die Auswahl gespeichert wird.
    */
-  public RangeInput(final Input from, final Input to, final String parameter)
+  public RangeInput(final Input from, final Input to, final String category, final String parameter)
   {
-    this(Range.KNOWN,from,to,parameter);
+    this(Range.getActiveRanges(category),from,to,parameter);
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -354,7 +354,7 @@ public class KontoauszugList extends UmsatzList
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(),this.getEnd(),"umsatzlist.filter.range");
+    this.range = new RangeInput(this.getStart(),this.getEnd(),Range.CATEGORY_ZAHLUNGSVERKEHR,"umsatzlist.filter.range");
     this.range.addListener(new Listener()
     {
       public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugPdfList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugPdfList.java
@@ -60,6 +60,7 @@ import de.willuhn.jameica.hbci.messaging.ObjectMessage;
 import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.rmi.Kontoauszug;
 import de.willuhn.jameica.hbci.server.KontoauszugPdfUtil;
+import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
 import de.willuhn.jameica.messaging.StatusBarMessage;
@@ -286,7 +287,7 @@ public class KontoauszugPdfList extends TablePart
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getFrom(),this.getTo(),"kontoauszuege.filter.range");
+    this.range = new RangeInput(this.getFrom(),this.getTo(),Range.CATEGORY_ZAHLUNGSVERKEHR,"kontoauszuege.filter.range");
     this.range.addListener(new Listener()
     {
       public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
@@ -154,7 +154,7 @@ public class SaldoChart implements Part
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(),this.getEnd(),"umsatzlist.filter.range");
+    this.range = new RangeInput(this.getStart(),this.getEnd(), "auswertungen.saldochart.filter.range");
     this.range.addListener(this.reloadListener);
     return this.range;
   }
@@ -168,7 +168,7 @@ public class SaldoChart implements Part
     if (this.start != null)
       return this.start;
 
-    this.start = new DateFromInput(null,"umsatzlist.filter.from");
+    this.start = new DateFromInput(null, "auswertungen.saldochart.filter.from");
     this.start.setName(i18n.tr("Von"));
     this.start.setComment(null);
     this.start.addListener(new DelayedListener(300,this.reloadListener));
@@ -184,7 +184,7 @@ public class SaldoChart implements Part
     if (this.end != null)
       return this.end;
 
-    this.end = new DateToInput(null,"umsatzlist.filter.to");
+    this.end = new DateToInput(null, "auswertungen.saldochart.filter.to");
     this.end.setName(i18n.tr("bis"));
     this.end.setComment(null);
     this.end.addListener(new DelayedListener(300,this.reloadListener));

--- a/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
@@ -49,6 +49,7 @@ import de.willuhn.jameica.hbci.gui.input.KontoInput;
 import de.willuhn.jameica.hbci.gui.input.RangeInput;
 import de.willuhn.jameica.hbci.gui.input.UmsatzDaysInput;
 import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.hbci.server.UmsatzUtil;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
@@ -154,7 +155,7 @@ public class SaldoChart implements Part
     if (this.range != null)
       return this.range;
     
-    this.range = new RangeInput(this.getStart(),this.getEnd(), "auswertungen.saldochart.filter.range");
+    this.range = new RangeInput(this.getStart(),this.getEnd(),Range.CATEGORY_AUSWERTUNG, "auswertungen.saldochart.filter.range");
     this.range.addListener(this.reloadListener);
     return this.range;
   }

--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -240,7 +240,7 @@ public class SparQuote implements Part
     
     // Wir wollen hier nur die Zeitraume haben, die mindestens 2 Monate umfassen
     List<Range> ranges = new ArrayList<Range>();
-    for (Range r:Range.KNOWN)
+    for (Range r:Range.getActiveRanges(Range.CATEGORY_AUSWERTUNG))
     {
       if(r.getStart() == null) {
         ranges.add(r);

--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -242,10 +242,14 @@ public class SparQuote implements Part
     List<Range> ranges = new ArrayList<Range>();
     for (Range r:Range.KNOWN)
     {
-      // Wir ueberschlagen das nur grob
-      long diff = r.getEnd().getTime() - r.getStart().getTime();
-      if (diff > (2 * 30 * 24 * 60 * 60 * 1000L))
+      if(r.getStart() == null) {
         ranges.add(r);
+      } else {
+        // Wir ueberschlagen das nur grob
+        long diff = r.getEnd().getTime() - r.getStart().getTime();
+        if (diff > (2 * 30 * 24 * 60 * 60 * 1000L))
+          ranges.add(r);
+      }
     }
     
     this.range = new RangeInput(ranges,this.getFrom(),this.getTo(),"auswertungen.spartquote.filter.range");
@@ -404,7 +408,8 @@ public class SparQuote implements Part
     
     ////////////////////////////////////////////////////////////////////////////
     // Wir iterieren erstmal ueber den Zeitraum und erzeugen die passenden Time-Boxen
-    Date from     = DateUtil.startOfDay(start != null ? start : new Date());
+    Date from = start != null ? start : UmsatzUtil.getOldest(getKontoAuswahl().getValue());
+    from          = DateUtil.startOfDay(from != null ? from : new Date());
     final Date to = DateUtil.endOfDay(end != null ? end : new Date());
     
     for (int i=0;i<1000;++i) // Wir machen keine Endlosschleife sondern hoeren bei maximal 1000 auf
@@ -442,10 +447,14 @@ public class SparQuote implements Part
     //Dummy-Eintrag für das nächste Intervall, da das letzte reguläre sonst
     //aufgrund der Normalisierung auf den ersten Tag des Intervalls
     //ggf. gar nicht angezeigt wird
-    UmsatzEntry lastEntry = new UmsatzEntry();
-    lastEntry.start=new Date(end.getTime()+1);
-    lastEntry.end=lastEntry.start;
-    this.data.add(lastEntry);
+    if (!this.data.isEmpty())
+    {
+      UmsatzEntry lastEntry = new UmsatzEntry();
+      long time = this.data.get(this.data.size() - 1).getEnd().getTime();
+      lastEntry.start = new Date(time + 1);
+      lastEntry.end = lastEntry.start;
+      this.data.add(lastEntry);
+    }
     //
     ////////////////////////////////////////////////////////////////////////////
 

--- a/src/de/willuhn/jameica/hbci/gui/views/Settings.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/Settings.java
@@ -9,6 +9,8 @@
  **********************************************************************/
 package de.willuhn.jameica.hbci.gui.views;
 
+import java.util.List;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.TabFolder;
@@ -24,6 +26,7 @@ import de.willuhn.jameica.gui.util.TabGroup;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.gui.action.UmsatzTypNew;
 import de.willuhn.jameica.hbci.gui.controller.SettingsControl;
+import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.util.ApplicationException;
 import de.willuhn.util.I18N;
@@ -79,7 +82,18 @@ public class Settings extends AbstractView implements Extendable
     ButtonArea umsatzButtons = new ButtonArea();
     umsatzButtons.addButton(i18n.tr("Neue Umsatz-Kategorie..."),new UmsatzTypNew(),null,false,"text-x-generic.png");
     umsatztypes.addButtonArea(umsatzButtons);
-    
+
+    // anzuzeigende Zeiträume in der Vorauswahl
+    TabGroup ranges = new TabGroup(getTabFolder(),i18n.tr("Zeiträume"), true, 4);
+    ranges.addHeadline(i18n.tr("für Zahlungsverkehr"));
+    ranges.addHeadline(i18n.tr("für Auswertung"));
+    List<CheckboxInput> zvRanges = control.getRanges(Range.CATEGORY_ZAHLUNGSVERKEHR);
+    List<CheckboxInput> auswertungRanges = control.getRanges(Range.CATEGORY_AUSWERTUNG);
+    for(int i=0; i<zvRanges.size(); i++) {
+      ranges.addInput(zvRanges.get(i));
+      ranges.addInput(auswertungRanges.get(i));
+    }
+
     TabGroup extended = new TabGroup(getTabFolder(),"Erweitert",true);
     extended.addHeadline(i18n.tr("Experimentelle Funktionen"));
     extended.addText(i18n.tr("Wenn die experimentellen Funktionen nicht aktiviert sind, gelten die Vorgabewerte.") + "\n",true);

--- a/src/help/de_de/de.willuhn.jameica.hbci.gui.views.Settings.txt
+++ b/src/help/de_de/de.willuhn.jameica.hbci.gui.views.Settings.txt
@@ -31,5 +31,9 @@
 		eingeben. Umsätze werden dann bereits dieser Kategorie zugeordnet, wenn nur
 		einer der angegebenen Suchbegriffe gefunden wurde.
 	</li>
-	
+
+	<li>
+		<b>Zeiträume:</b> Sie können jeweils für die Kategorien Zahlungsverkehr und Auswertungen
+		festlegen, welche Einträge Ihnen in der Zeitraum-Vorauswahl Vorauswahl angeboten werden.
+	</li>
 </form>


### PR DESCRIPTION
Diese Serie von Commits ist ein Ergebnis der Diskussion nach der Vereinheitlichung der Zeiträume aus PR #63.
Im Ergebnis war das Speichern der Vorauswahl uneinheitlich. Während das gewählte Konto pro View gespeichert war, wurden die vorausgewählten Zeiträume zwischen den Views "geteilt", ein paar Werte wurden gar nicht gespeichert und immer wieder zurückgesetzt. Das ist nun korrigiert.

Das Verhalten der Sparquote bei einem nicht gesetzten Anfangsdatum wurde angepasst. Während das in anderen Views als "alles bis" interpretiert wurde, wurden in der Sparquote keine Daten aufgesammelt. Nun wird nach der ersten Buchung der gewählten Kontos gesucht.

Die weitreichendste Änderung dürfte die Erweiterung der Zeitraumauswahl sowie die Möglichkeit sein, diese Auswahl über die Einstellungen einzuschränken. Unterschieden wird hier nach Zahlungsverkehr und Auswertung. Die GUI für die Einstellungen ist ziemlich minimalistisch und nicht allzu schön. Die Abstände zwischen den Checkboxen sind für die eigentlich zusammengehörigen Werte etwas groß und es gibt keine Scrollbalken.

Bei dieser Gelegenheit ist mir auch aufgefallen, dass Nutzer die Zeiträume "letzte ..." anders interpretieren könnten. Bei letzte 7 Tage fände ich "(gleicher Wochentag wie) heute vor einer Woche bis gestern" und "morgen vor einer Woche bis heute" einleuchtend. Dann sind es nämlich 7 Tage, in der aktuellen Implementierung sind es 8 Tage.
Ich denke nicht unbedingt, dass das geändert werden muss. Ich weise nur darauf hin, da ich bei der Implementierung neuen Zeiträume für die letzten Jahre den einen Tag rausrechne.