### PR TITLE
Empfänger Name 2 bei CAMT importieren und anzeigen

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -64,6 +64,7 @@ public class UmsatzDetailControl extends AbstractControl
 	// Eingabe-Felder
 	private Input konto				 		= null;
 	private Input empfaengerName  = null;
+	private Input empfaengerName2 = null;
 	private Input empfaengerKonto = null;
   private Input empfaengerBlz   = null;
 	private Input datum						= null;
@@ -175,6 +176,22 @@ public class UmsatzDetailControl extends AbstractControl
       this.empfaengerName.setEnabled(false);
     }
     return this.empfaengerName;
+  }
+  
+  /**
+   * Liefert ein Eingabe-Feld mit dem Namen des ultimativen Empfaengers.
+   * @return Eingabe-Feld.
+   * @throws RemoteException
+   */
+  public Input getEmpfaengerName2() throws RemoteException
+  {
+    if (this.empfaengerName2 == null)
+    {
+      this.empfaengerName2 = new TextInput(getUmsatz().getGegenkontoName2());
+      this.empfaengerName2.setName(i18n.tr("Name 2"));
+      this.empfaengerName2.setEnabled(false);
+    }
+    return this.empfaengerName2;
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
@@ -75,6 +75,17 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
   }
   
   /**
+   * @see de.willuhn.jameica.hbci.gui.controller.UmsatzDetailControl#getEmpfaengerName2()
+   */
+  public Input getEmpfaengerName2() throws RemoteException
+  {
+    Input input = super.getEmpfaengerName2();
+    if (!input.isEnabled())
+      input.setEnabled(true);
+    return input;
+  }
+  
+  /**
    * @see de.willuhn.jameica.hbci.gui.controller.UmsatzDetailControl#getEmpfaengerKonto()
    */
   public Input getEmpfaengerKonto() throws RemoteException
@@ -328,6 +339,7 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
       u.setUmsatzTyp((UmsatzTyp)getUmsatzTyp().getValue());
       
       u.setGegenkontoName(((AddressInput)getEmpfaengerName()).getText());
+      u.setGegenkontoName2((String) getEmpfaengerName2().getValue());
       u.setGegenkontoNummer((String) getEmpfaengerKonto().getValue());
       u.setGegenkontoBLZ((String) getEmpfaengerBLZ().getValue());
       u.setZweck((String) getZweck().getValue());

--- a/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
@@ -66,7 +66,9 @@ public abstract class AbstractUmsatzDetail extends AbstractView
 		// BUGZILLA 23 http://www.willuhn.de/bugzilla/show_bug.cgi?id=23
     left.addHeadline(i18n.tr("Gegenkonto"));
     left.addLabelPair(i18n.tr("Inhaber"),                       control.getEmpfaengerName());
-    left.addInput(control.getEmpfaengerName2());
+    if (control.getUmsatz().getGegenkontoName2() != null) {
+      left.addInput(control.getEmpfaengerName2());
+    }
     left.addInput(control.getEmpfaengerKonto());
     left.addInput(control.getEmpfaengerBLZ());
 

--- a/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
@@ -66,6 +66,7 @@ public abstract class AbstractUmsatzDetail extends AbstractView
 		// BUGZILLA 23 http://www.willuhn.de/bugzilla/show_bug.cgi?id=23
     left.addHeadline(i18n.tr("Gegenkonto"));
     left.addLabelPair(i18n.tr("Inhaber"),                       control.getEmpfaengerName());
+    left.addInput(control.getEmpfaengerName2());
     left.addInput(control.getEmpfaengerKonto());
     left.addInput(control.getEmpfaengerBLZ());
 

--- a/src/de/willuhn/jameica/hbci/rmi/Umsatz.java
+++ b/src/de/willuhn/jameica/hbci/rmi/Umsatz.java
@@ -255,6 +255,7 @@ public interface Umsatz extends HibiscusTransfer, HibiscusDBObject, Checksum, Fl
 
   /**
    * Liefert den Namen des ultimativen Empfaengers.
+   * Nur bei Umsaetzen vorhanden, die per CAMT abgerufen wurden.
    * @return Name des ultimativen Empfaengers
    * @throws RemoteException
    */

--- a/src/de/willuhn/jameica/hbci/rmi/Umsatz.java
+++ b/src/de/willuhn/jameica/hbci/rmi/Umsatz.java
@@ -253,4 +253,18 @@ public interface Umsatz extends HibiscusTransfer, HibiscusDBObject, Checksum, Fl
    */
   public void setMandateId(String id) throws RemoteException;
 
+  /**
+   * Liefert den Namen des ultimativen Empfaengers.
+   * @return Name des ultimativen Empfaengers
+   * @throws RemoteException
+   */
+  public String getGegenkontoName2() throws RemoteException;
+
+  /**
+   * Setzt den Namen des ultimativen Empfaengers.
+   * @param name Name des ultimativen Empfaengers
+   * @throws RemoteException
+   */
+  public void setGegenkontoName2(String name) throws RemoteException;
+
 }

--- a/src/de/willuhn/jameica/hbci/server/Converter.java
+++ b/src/de/willuhn/jameica/hbci/server/Converter.java
@@ -166,8 +166,12 @@ public class Converter
     ////////////////////////////////////////////////////////////////////////////
     // Gegenkonto
     // und jetzt noch der Empfaenger (wenn er existiert)
-    if (u.other != null) 
+    if (u.other != null)
+    {
       umsatz.setGegenkonto(HBCIKonto2Address(u.other,u.isCamt));
+      if (u.isCamt)
+        umsatz.setGegenkontoName2(u.other.name2);
+    }
 
     if (!HBCIProperties.HBCI_SEPA_PARSE_TAGS)
       return umsatz;

--- a/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
@@ -851,4 +851,22 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   {
     this.setAttribute("mandateid",id);
   }
+  
+  /**
+   * @see de.willuhn.jameica.hbci.rmi.Umsatz#getGegenkontoName2()
+   */
+  @Override
+  public String getGegenkontoName2() throws RemoteException
+  {
+    return (String) this.getAttribute("empfaenger_name2");
+  }
+  
+  /**
+   * @see de.willuhn.jameica.hbci.rmi.Umsatz#setGegenkontoName2(java.lang.String)
+   */
+  @Override
+  public void setGegenkontoName2(String name) throws RemoteException
+  {
+    this.setAttribute("empfaenger_name2",name);
+  }
 }


### PR DESCRIPTION
Siehe https://homebanking-hilfe.de/forum/topic.php?t=24305

Ich habe versucht minimal-invasiv vorzugehen, daher importiere ich name2 nur bei CAMT-Umsätzen.
Ansonsten hat der Converter den ja bereits an den Namen selbst gehängt. Da weiß ich nicht was das für Fälle sind und ob es sinnvoll wäre, da auch name2 zu nutzen.

Das zusätzliche Feld "Name 2" erscheint jetzt nur bei Umsätzen wo dies auch gesetzt ist. Das erscheint mir sinnvoll, da es ansonsten eher verwirrt. Etwas merkwürdig wird es dann aber beim Bearbeiten, da man keinen Name2 setzen kann wenn nicht schon einer vorhanden war, ich wüsste aber auch nicht warum man das möchte.

Daumen hoch übrigens für das Eclipse-Setup-Script. Damit war es echt super einfach sich das Projekt aufzusetzen!