### PR TITLE
Github Actions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,3 +45,9 @@ jobs:
         distribution: 'adopt'
     - name: Build with Gradle
       run: gradle build
+    - name: upload package
+      uses: actions/upload-artifact@master
+      with:
+        name: pkg
+        path: 'jameica/build/gradle/distributions/*.zip'
+

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         submodules: recursive
         repository: ruderphilipp/jmc.git
+        ref: main
     - name: Check out the triggering repository
       run: |
          declare -A SUBMODULES=( \

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,6 @@ jobs:
       with:
         submodules: recursive
         repository: ruderphilipp/jmc.git
-        ref: main
     - name: Check out the triggering repository
       run: |
          declare -A SUBMODULES=( \
@@ -38,10 +37,10 @@ jobs:
             git -C ${SUBMODULES[$REPONAME]} fetch action_repo ${GITHUB_SHA}
             git -C ${SUBMODULES[$REPONAME]} checkout ${GITHUB_SHA}
          fi
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'adopt'
     - name: Build with Gradle
       run: gradle build
@@ -49,5 +48,5 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: pkg
-        path: 'jameica/build/gradle/distributions/*.zip'
+        path: 'plugins/hibiscus/build/target/*.jar'
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,47 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: '*'
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out this repo
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        repository: ruderphilipp/jmc.git
+        ref: main
+    - name: Check out the triggering repository
+      run: |
+         declare -A SUBMODULES=( \
+            [jameica]=jameica \
+            [datasource]=lib/datasource \
+            [util]=lib/util \
+            [example]=plugins/example \
+            [hibiscus]=plugins/hibiscus \
+            )
+
+         set -x
+         REPONAME=${GITHUB_REPOSITORY#*/}
+         if [ ${REPONAME} = "jmc" ]; then
+            echo "Github Actions run started from this repository"
+         else
+            git -C ${SUBMODULES[$REPONAME]} remote add action_repo git@github.com:${GITHUB_REPOSITORY}
+            git -C ${SUBMODULES[$REPONAME]} fetch action_repo ${GITHUB_SHA}
+            git -C ${SUBMODULES[$REPONAME]} checkout ${GITHUB_SHA}
+         fi
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Build with Gradle
+      run: gradle build


### PR DESCRIPTION
Wie in https://github.com/ruderphilipp/jmc/issues/1 skizziert, habe ich eine Beispielkonfiguration für Github Actions erstellt. Da die anderen Projekte (datasource etc.) ebenfalls mit kompiliert werden müssen, holt das Skript das Hauptrepository (mit den Submodulen) und checkt dann im auslösendes Repository (hier: hibiscus) den jeweiligen Commit aus.
Der Inhalt von `jameica/build/gradle/distributions` wird dann noch hochgeladen, momentan ist das Archiv aber noch nicht komplett (beispielsweise fehlen die Plugins und ein paar Dateien).

An sich müsste das auch für PRs und private Forks funktionieren, getestet ist es aber noch nicht.