### PR TITLE
add license text

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
@@ -1,3 +1,13 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
 package de.willuhn.jameica.hbci.gui.chart;
 
 import java.util.ArrayList;

--- a/src/de/willuhn/jameica/hbci/gui/input/InputCompat.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/InputCompat.java
@@ -1,3 +1,13 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
 package de.willuhn.jameica.hbci.gui.input;
 
 import de.willuhn.jameica.gui.input.Input;

--- a/src/de/willuhn/jameica/hbci/gui/parts/EinnahmenAusgabenVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/EinnahmenAusgabenVerlauf.java
@@ -1,3 +1,13 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
 package de.willuhn.jameica.hbci.gui.parts;
 
 import java.rmi.RemoteException;

--- a/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabeTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabeTreeNode.java
@@ -1,3 +1,13 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
 package de.willuhn.jameica.hbci.server;
 
 import java.rmi.RemoteException;


### PR DESCRIPTION
Dank [Spotless](https://github.com/diffplug/spotless) fiel auf, dass in diesen vier Dateien kein Lizenztext vorhanden ist.