### PR TITLE
Codestil: korrigiere geschweifte Klammern

### DIFF
--- a/src/de/willuhn/jameica/hbci/HBCI.java
+++ b/src/de/willuhn/jameica/hbci/HBCI.java
@@ -134,7 +134,8 @@ public class HBCI extends AbstractPlugin
    */
   public void install() throws ApplicationException
   {
-    call(new ServiceCall() {
+    call(new ServiceCall()
+    {
     
       public void call(HBCIDBService service) throws ApplicationException, RemoteException
       {
@@ -284,9 +285,12 @@ public class HBCI extends AbstractPlugin
         {
           if (is != null)
           {
-            try {
+            try
+            {
               is.close();
-            } catch (Exception e) {
+            }
+            catch (Exception e)
+            {
               Logger.error("error while closing " + addonprops,e);
             }
           }

--- a/src/de/willuhn/jameica/hbci/HBCICallbackSWT.java
+++ b/src/de/willuhn/jameica/hbci/HBCICallbackSWT.java
@@ -145,7 +145,8 @@ public class HBCICallbackSWT extends AbstractHibiscusHBCICallback
     this.updateProgress();
     SynchronizeSession session = this.backend.getCurrentSession();
 
-    try {
+    try
+    {
       
       if (currentHandle != null && currentHandle.callback(passport,reason,msg,datatype,retData))
       {
@@ -155,7 +156,8 @@ public class HBCICallbackSWT extends AbstractHibiscusHBCICallback
 
 			AccountContainer container = accountCache.get(passport);
 			
-			switch (reason) {
+			switch (reason)
+			{
         
 			  // Hier kommen nur noch die PIN/TAN und DDV-Passports an. Die von RDH werden
 			  // im PassportHandle verarbeitet

--- a/src/de/willuhn/jameica/hbci/PassportRegistry.java
+++ b/src/de/willuhn/jameica/hbci/PassportRegistry.java
@@ -21,7 +21,8 @@ import de.willuhn.util.ClassFinder;
 /**
  * Sucht alle verfuegbaren Passports und prueft diese auf Verwendbarkeit.
  */
-public class PassportRegistry {
+public class PassportRegistry
+{
 
 	private static Hashtable passportsByName  = null;
 	private static Hashtable passportsByClass = null;
@@ -37,14 +38,16 @@ public class PassportRegistry {
     passportsByClass = new Hashtable();
     passportsByName  = new Hashtable();
 
-    try {
+    try
+    {
 			Logger.info("searching for available passports");
 	    BeanService service = Application.getBootLoader().getBootable(BeanService.class);
 			ClassFinder finder = Application.getPluginLoader().getManifest(HBCI.class).getClassLoader().getClassFinder();
 			Class[] found = finder.findImplementors(Passport.class);
 			for (Class c:found)
 			{
-				try {
+				try
+				{
 					Passport p = (Passport) service.get(c);
 					Application.getCallback().getStartupMonitor().setStatusText("init passport " + p.getName());
  				  passportsByName.put(p.getName(),c);

--- a/src/de/willuhn/jameica/hbci/Settings.java
+++ b/src/de/willuhn/jameica/hbci/Settings.java
@@ -51,7 +51,8 @@ public class Settings
   {
     if (db != null)
       return db;
-		try {
+		try
+		{
 			db = (HBCIDBService) Application.getServiceFactory().lookup(HBCI.class,"database");
 			return db;
 		}

--- a/src/de/willuhn/jameica/hbci/accounts/AccountService.java
+++ b/src/de/willuhn/jameica/hbci/accounts/AccountService.java
@@ -69,7 +69,8 @@ public class AccountService
       }
       
       // Wir sortieren die Provider so, dass der Primaer-Provider immer Vorrang hat
-      Collections.sort(this.providers,new Comparator<AccountProvider>() {
+      Collections.sort(this.providers, new Comparator<AccountProvider>()
+      {
         public int compare(AccountProvider o1, AccountProvider o2)
         {
           

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
@@ -95,7 +95,8 @@ public class HBCIAccountProvider implements AccountProvider
         }
       }
       
-      Collections.sort(this.variants,new Comparator<HBCIVariant>() {
+      Collections.sort(this.variants, new Comparator<HBCIVariant>()
+      {
         public int compare(HBCIVariant o1, HBCIVariant o2)
         {
           if (PRIMARY.isInstance(o1))

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/action/HBCIVariantPinTanTest.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/action/HBCIVariantPinTanTest.java
@@ -59,7 +59,8 @@ public class HBCIVariantPinTanTest implements Action
     
     final HBCIAccountPinTan account = (HBCIAccountPinTan) context;
 
-    BackgroundTask task = new BackgroundTask() {
+    BackgroundTask task = new BackgroundTask()
+    {
       
       private boolean stop = false;
       
@@ -92,7 +93,8 @@ public class HBCIVariantPinTanTest implements Action
           AbstractPlugin plugin = Application.getPluginLoader().getPlugin(HBCI.class);
           callback = ((HBCI)plugin).getHBCICallback();
           if (callback != null && (callback instanceof HBCICallbackSWT))
-            ((HBCICallbackSWT)callback).setCurrentHandle(new PassportHandleImpl((PinTanConfig)null) {
+            ((HBCICallbackSWT) callback).setCurrentHandle(new PassportHandleImpl((PinTanConfig) null)
+            {
               @Override
               public boolean callback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData) throws Exception
               {
@@ -209,7 +211,8 @@ public class HBCIVariantPinTanTest implements Action
         }
       }
 
-      public void interrupt() {
+      public void interrupt()
+      {
         this.stop = true;
       }
       public boolean isInterrupted()
@@ -228,7 +231,8 @@ public class HBCIVariantPinTanTest implements Action
   {
     if (t == null)
       return;
-    Thread thread = new Thread() {
+    Thread thread = new Thread()
+    {
       public void run()
       {
         Logger.removeTarget(t);

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/controller/HBCIAccountNewController.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/controller/HBCIAccountNewController.java
@@ -62,7 +62,8 @@ public class HBCIAccountNewController extends AbstractControl
     for (final HBCIVariant v:hbci.getVariants())
     {
       InfoPanel p = v.getInfo();
-      final Button button = new Button(i18n.tr("Verfahren auswählen..."),new Action() {
+      final Button button = new Button(i18n.tr("Verfahren auswählen..."), new Action()
+      {
         @Override
         public void handleAction(Object context) throws ApplicationException
         {

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/controller/HBCIVariantPinTanController.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/controller/HBCIVariantPinTanController.java
@@ -75,7 +75,8 @@ public class HBCIVariantPinTanController extends AbstractControl
     this.bank = new BankInfoInput(this.account.getBlz());
     if (this.bank.getValue() == null) // Falls es keine bekannte BLZ war
       this.bank.setValue(this.account.getBlz());
-    this.bank.addListener(new Listener() {
+    this.bank.addListener(new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -193,7 +194,8 @@ public class HBCIVariantPinTanController extends AbstractControl
     if (this.step1 != null)
       return this.step1;
     
-    this.step1 = new Button(i18n.tr("Weiter ..."),new Action() {
+    this.step1 = new Button(i18n.tr("Weiter ..."), new Action()
+    {
       @Override
       public void handleAction(Object context) throws ApplicationException
       {

--- a/src/de/willuhn/jameica/hbci/gui/action/BackupCreate.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/BackupCreate.java
@@ -92,7 +92,8 @@ public class BackupCreate implements Action
       return;
     
     final File file = new File(f);
-    Application.getController().start(new BackgroundTask() {
+    Application.getController().start(new BackgroundTask()
+    {
       private boolean cancel = false;
     
       /**
@@ -210,7 +211,10 @@ public class BackupCreate implements Action
               writer.close();
               Logger.info("backup created");
             }
-            catch (Exception e) {/*useless*/}
+            catch (Exception e)
+            {
+              /* useless */
+            }
           }
         }
       }

--- a/src/de/willuhn/jameica/hbci/gui/action/BackupRestore.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/BackupRestore.java
@@ -92,7 +92,8 @@ public class BackupRestore implements Action
     if (!file.exists())
       return;
 
-    Application.getController().start(new BackgroundTask() {
+    Application.getController().start(new BackgroundTask()
+    {
       private boolean cancel = false;
     
       /**
@@ -108,7 +109,8 @@ public class BackupRestore implements Action
         try
         {
           InputStream is = new BufferedInputStream(new FileInputStream(file));
-          reader = new XmlReader(is,new ObjectFactory() {
+          reader = new XmlReader(is, new ObjectFactory()
+          {
           
             public GenericObject create(String type, String id, Map values) throws Exception
             {
@@ -170,7 +172,10 @@ public class BackupRestore implements Action
               reader.close();
               Logger.info("backup imported");
             }
-            catch (Exception e) {/*useless*/}
+            catch (Exception e)
+            {
+              /* useless */
+            }
           }
         }
       }

--- a/src/de/willuhn/jameica/hbci/gui/action/DBObjectDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/DBObjectDelete.java
@@ -69,7 +69,8 @@ public class DBObjectDelete implements Action
       d.setTitle(i18n.tr("Daten löschen"));
       d.setText(i18n.tr("Wollen Sie diesen Datensatz wirklich löschen?"));
     }
-    try {
+    try
+    {
       Boolean choice = (Boolean) d.open();
       if (!choice.booleanValue())
         return;

--- a/src/de/willuhn/jameica/hbci/gui/action/Duplicate.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/Duplicate.java
@@ -40,7 +40,8 @@ public class Duplicate implements Action
 		if (context == null || !(context instanceof Duplicatable))
 			throw new ApplicationException(i18n.tr("Keine zu duplizierenden Daten angegeben"));
 
-		try {
+		try
+		{
 			Duplicatable o = (Duplicatable) context;
 			Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Dupliziert"),StatusBarMessage.TYPE_SUCCESS));
 			new Open().handleAction(o.duplicate());

--- a/src/de/willuhn/jameica/hbci/gui/action/EmpfaengerAdd.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/EmpfaengerAdd.java
@@ -60,7 +60,8 @@ public class EmpfaengerAdd implements Action
       throw new ApplicationException(i18n.tr("Bitte wählen Sie ein oder mehrere Aufträge aus"));
 
     List<HibiscusAddress> items = new ArrayList<HibiscusAddress>();
-		try {
+    try
+    {
 
       ///////////////////////////////////////////////////////////////
       // Transfers

--- a/src/de/willuhn/jameica/hbci/gui/action/FlaggableChange.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/FlaggableChange.java
@@ -84,7 +84,8 @@ public class FlaggableChange implements Action
     }
 		catch (Exception e)
 		{
-	    try {
+	    try
+	    {
 	      objects[0].transactionRollback();
 	    }
 	    catch (Exception e1) {

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoDelete.java
@@ -39,7 +39,8 @@ public class KontoDelete implements Action
 		if (context == null || !(context instanceof Konto))
 			throw new ApplicationException(i18n.tr("Kein Konto ausgewählt"));
 
-		try {
+    try
+    {
 
 			Konto k = (Konto) context;
 			if (k.isNewObject())
@@ -47,7 +48,8 @@ public class KontoDelete implements Action
 
 			KontoDeleteDialog d = new KontoDeleteDialog(k);
 			
-			try {
+			try
+			{
 				Boolean choice = (Boolean) d.open();
 				if (choice == null || !choice.booleanValue())
 					return;

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoDisable.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoDisable.java
@@ -79,10 +79,12 @@ public class KontoDisable implements Action
     }
     catch (Exception e)
     {
-      try {
+      try
+      {
         k.transactionRollback();
       }
-      catch (Exception e1) {
+      catch (Exception e1)
+      {
         Logger.error("unable to rollback transaction",e1);
       }
 

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoFetchFromPassport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoFetchFromPassport.java
@@ -86,8 +86,10 @@ public class KontoFetchFromPassport implements Action
 
 		GUI.startSync(new Runnable()
 		{
-			public void run() {
-				try {
+			public void run()
+			{
+				try
+				{
 
 					GUI.getStatusBar().startProgress();
 					GUI.getStatusBar().setSuccessText(i18n.tr("Bank-Zugang wird ausgelesen..."));

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoMerge.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoMerge.java
@@ -114,7 +114,8 @@ public class KontoMerge implements Action
         {
           // Konto neu anlegen
           Logger.info("saving new konto");
-          try {
+          try
+          {
             konto.store();
             created++;
             Logger.info("konto saved successfully");

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoSyncViaScripting.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoSyncViaScripting.java
@@ -42,7 +42,8 @@ public class KontoSyncViaScripting implements Action
 			throw new ApplicationException(i18n.tr("Bitte wählen Sie ein Konto aus"));
 
     final Konto k = (Konto) context;
-		try {
+    try
+    {
 	    if (!k.hasFlag(Konto.FLAG_OFFLINE))
 	      throw new ApplicationException(i18n.tr("Bitte wählen Sie ein Offline-Konto aus"));
 
@@ -57,7 +58,8 @@ public class KontoSyncViaScripting implements Action
 			
     final AbstractView currentView = GUI.getCurrentView();
       
-    Application.getController().start(new BackgroundTask() {
+    Application.getController().start(new BackgroundTask()
+    {
       
       public void run(ProgressMonitor monitor) throws ApplicationException
       {

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoauszugDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoauszugDelete.java
@@ -78,7 +78,8 @@ public class KontoauszugDelete implements Action
 	        
           final LabelInput warn = new LabelInput("");
           warn.setColor(Color.ERROR);
-          check.addListener(new Listener() {
+          check.addListener(new Listener()
+          {
             public void handleEvent(Event event)
             {
               // Warnhinweis anzeigen, dass der Auftrag nur lokal geloescht wird

--- a/src/de/willuhn/jameica/hbci/gui/action/NachrichtMarkRead.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/NachrichtMarkRead.java
@@ -48,7 +48,8 @@ public class NachrichtMarkRead implements Action
     else
       list = new Nachricht[]{(Nachricht)context}; // Array mit einem Element
 
-		try {
+    try
+    {
 
       for (int i=0;i<list.length;++i)
       {

--- a/src/de/willuhn/jameica/hbci/gui/action/PassportSync.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/PassportSync.java
@@ -50,17 +50,20 @@ public class PassportSync implements Action
 
     Logger.info("performing passport re-sync");
 
-		BackgroundTask task = new BackgroundTask() {
+    BackgroundTask task = new BackgroundTask()
+    {
       public void run(final ProgressMonitor monitor) throws ApplicationException
       {
         HBCIHandler handler = null;
         Target target       = null;
-        try {
+        try
+        {
           monitor.setStatusText(i18n.tr("Synchronisiere Bank-Zugang..."));
 
           // Log-Ausgaben temporaer auch mit im Progressbar-Fenster
           // ausgeben
-          target = new Target() {
+          target = new Target()
+          {
             public void write(Message msg) throws Exception
             {
               monitor.addPercentComplete(2);
@@ -170,7 +173,10 @@ public class PassportSync implements Action
         }
       }
 
-      public void interrupt() {}
+      public void interrupt()
+      {
+      }
+
       public boolean isInterrupted()
       {
         return false;
@@ -187,7 +193,8 @@ public class PassportSync implements Action
   {
     if (t == null)
       return;
-    Thread thread = new Thread() {
+    Thread thread = new Thread()
+    {
       public void run()
       {
         Logger.removeTarget(t);

--- a/src/de/willuhn/jameica/hbci/gui/action/PassportTest.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/PassportTest.java
@@ -55,7 +55,8 @@ public class PassportTest implements Action
       {
         HBCIHandler handler = null;
         Target target       = null;
-        try {
+        try
+        {
           monitor.setStatusText(i18n.tr("Teste Bank-Zugang..."));
           
           final Manifest mf = Application.getPluginLoader().getPlugin(HBCI.class).getManifest();
@@ -64,7 +65,8 @@ public class PassportTest implements Action
 
           // Log-Ausgaben temporaer auch mit im Progressbar-Fenster
           // ausgeben
-          target = new Target() {
+          target = new Target()
+          {
             public void write(Message msg) throws Exception
             {
               monitor.addPercentComplete(2);
@@ -169,7 +171,10 @@ public class PassportTest implements Action
         }
       }
 
-      public void interrupt() {}
+      public void interrupt()
+      {
+      }
+
       public boolean isInterrupted()
       {
         return false;
@@ -186,7 +191,8 @@ public class PassportTest implements Action
   {
     if (t == null)
       return;
-    Thread thread = new Thread() {
+    Thread thread = new Thread()
+    {
       public void run()
       {
         Logger.removeTarget(t);

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaDauerauftragDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaDauerauftragDelete.java
@@ -66,10 +66,12 @@ public class SepaDauerauftragDelete implements Action
 	      protected void extend(Container container) throws Exception
 	      {
           // Nur bei aktiven Dauerauftraegen anzeigen
-	        if (da.isActive()) {
+          if (da.isActive())
+          {
 	          final LabelInput warn = new LabelInput("");
 	          warn.setColor(Color.COMMENT);
-            check.addListener(new Listener() {
+            check.addListener(new Listener()
+            {
               public void handleEvent(Event event)
               {
                 // Warnhinweis anzeigen, dass der Auftrag nur lokal geloescht wird

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaDauerauftragNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaDauerauftragNew.java
@@ -47,7 +47,8 @@ public class SepaDauerauftragNew implements Action
 		}
 		else if (context instanceof Konto)
 		{
-			try {
+			try
+			{
 				Konto k = (Konto) context;
 				d = (SepaDauerauftrag) Settings.getDBService().createObject(SepaDauerauftrag.class,null);
 				if (!k.hasFlag(Konto.FLAG_DISABLED) && !k.hasFlag(Konto.FLAG_OFFLINE))
@@ -60,7 +61,8 @@ public class SepaDauerauftragNew implements Action
 		}
 		else if (context instanceof Address)
 		{
-			try {
+			try
+			{
 				Address e = (Address) context;
 				d = (SepaDauerauftrag) Settings.getDBService().createObject(SepaDauerauftrag.class,null);
 				d.setGegenkonto(e);

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelLastBuchungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelLastBuchungNew.java
@@ -40,7 +40,8 @@ public class SepaSammelLastBuchungNew implements Action
 		}
 		else
 		{
-			try {
+			try
+			{
         SepaSammelLastschrift s = (SepaSammelLastschrift) context;
         u = (SepaSammelLastBuchung) s.createBuchung();
 			}

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelLastschriftNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelLastschriftNew.java
@@ -44,7 +44,8 @@ public class SepaSammelLastschriftNew implements Action
 		}
 		else if (context instanceof Konto)
 		{
-			try {
+			try
+			{
 				Konto k = (Konto) context;
 				u = (SepaSammelLastschrift) Settings.getDBService().createObject(SepaSammelLastschrift.class,null);
 				if (!k.hasFlag(Konto.FLAG_DISABLED) && !k.hasFlag(Konto.FLAG_OFFLINE) && StringUtils.trimToNull(k.getIban()) != null)

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungBuchungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungBuchungNew.java
@@ -40,7 +40,8 @@ public class SepaSammelUeberweisungBuchungNew implements Action
 		}
 		else
 		{
-			try {
+			try
+			{
         SepaSammelUeberweisung s = (SepaSammelUeberweisung) context;
         u = (SepaSammelUeberweisungBuchung) s.createBuchung();
 			}

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungNew.java
@@ -44,7 +44,8 @@ public class SepaSammelUeberweisungNew implements Action
 		}
 		else if (context instanceof Konto)
 		{
-			try {
+			try
+			{
 				Konto k = (Konto) context;
 				u = (SepaSammelUeberweisung) Settings.getDBService().createObject(SepaSammelUeberweisung.class,null);
 				if (!k.hasFlag(Konto.FLAG_DISABLED) && !k.hasFlag(Konto.FLAG_OFFLINE) && StringUtils.trimToNull(k.getIban()) != null)

--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzExport.java
@@ -43,7 +43,8 @@ public class UmsatzExport implements Action
 			throw new ApplicationException(i18n.tr("Bitte wählen Sie mindestens einen Umsatz aus"));
 
     Umsatz[] u = null;
-		try {
+    try
+    {
 			if (context instanceof Umsatz)
 			{
 				u = new Umsatz[1];

--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzTypExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzTypExport.java
@@ -43,7 +43,8 @@ public class UmsatzTypExport implements Action
 			throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Umsatz-Kategorien aus"));
 
     Object[] u = null;
-		try {
+    try
+    {
 
 			if (context instanceof UmsatzTyp)
 			{

--- a/src/de/willuhn/jameica/hbci/gui/boxes/NachrichtBox.java
+++ b/src/de/willuhn/jameica/hbci/gui/boxes/NachrichtBox.java
@@ -81,7 +81,8 @@ public class NachrichtBox extends AbstractBox implements Box
     this.list.paint(parent);
     
     Application.getMessagingFactory().registerMessageConsumer(this.mc);
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       
       @Override
       public void widgetDisposed(DisposeEvent e)
@@ -155,7 +156,8 @@ public class NachrichtBox extends AbstractBox implements Box
       
       final Nachricht n = (Nachricht) o;
       
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         
         @Override
         public void run()

--- a/src/de/willuhn/jameica/hbci/gui/boxes/Overview.java
+++ b/src/de/willuhn/jameica/hbci/gui/boxes/Overview.java
@@ -95,7 +95,8 @@ public class Overview extends AbstractBox implements Box
     refresh();
     
     Application.getMessagingFactory().registerMessageConsumer(this.mc);
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -132,7 +133,8 @@ public class Overview extends AbstractBox implements Box
     this.kontoAuswahl = new KontoInput(konto != null && (konto instanceof Konto) && ((Konto) konto).getID() != null ? ((Konto) konto) : null,KontoFilter.ACTIVE);
     this.kontoAuswahl.setSupportGroups(true);
     this.kontoAuswahl.setPleaseChoose(i18n.tr("Alle Konten"));
-    this.kontoAuswahl.addListener(new Listener() {
+    this.kontoAuswahl.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         refresh();
@@ -172,7 +174,8 @@ public class Overview extends AbstractBox implements Box
     }
     
     this.start = new DateInput(DateUtil.startOfDay(startDate),HBCI.DATEFORMAT);
-    this.start.addListener(new Listener() {
+    this.start.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         refresh();
@@ -199,7 +202,8 @@ public class Overview extends AbstractBox implements Box
     }
 
     this.end = new DateInput(DateUtil.endOfDay(endDate),HBCI.DATEFORMAT);
-    this.end.addListener(new Listener() {
+    this.end.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         refresh();
@@ -354,7 +358,8 @@ public class Overview extends AbstractBox implements Box
      */
     public void handleMessage(Message message) throws Exception
     {
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           refresh();

--- a/src/de/willuhn/jameica/hbci/gui/chart/AbstractChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/AbstractChart.java
@@ -140,7 +140,8 @@ public abstract class AbstractChart<T extends ChartData> implements Chart<T>
   {
     MenuItem item = new MenuItem(m, SWT.PUSH);
     item.setText(text);
-    item.addSelectionListener(new SelectionAdapter() {
+    item.addSelectionListener(new SelectionAdapter()
+    {
       /**
        * @see org.eclipse.swt.events.SelectionAdapter#widgetSelected(org.eclipse.swt.events.SelectionEvent)
        */
@@ -273,7 +274,8 @@ public abstract class AbstractChart<T extends ChartData> implements Chart<T>
    */
   public void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       /**
        * @see org.eclipse.swt.events.DisposeListener#widgetDisposed(org.eclipse.swt.events.DisposeEvent)
        */

--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
@@ -80,7 +80,8 @@ public class ChartFeatureTooltip implements ChartFeature
       }
     });
 
-    control.addMouseMoveListener(new MouseMoveListener() {
+    control.addMouseMoveListener(new MouseMoveListener()
+    {
 
       @Override
       public void mouseMove(MouseEvent e)
@@ -101,7 +102,8 @@ public class ChartFeatureTooltip implements ChartFeature
       }
     });
 
-    control.addPaintListener(new PaintListener() {
+    control.addPaintListener(new PaintListener()
+    {
 
       @Override
       public void paintControl(PaintEvent event)
@@ -174,7 +176,8 @@ public class ChartFeatureTooltip implements ChartFeature
   protected void paintChartPoint(GC gc, int highlightX, int highlightY, ISeries series)
   {
     Color color = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
-    if (series instanceof ILineSeries) {
+    if (series instanceof ILineSeries)
+    {
       color = ((ILineSeries) series).getLineColor();
     }
     gc.setBackground(color);

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractBaseUeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractBaseUeberweisungControl.java
@@ -121,11 +121,14 @@ public abstract class AbstractBaseUeberweisungControl extends AbstractTransferCo
 		}
     catch (Exception e)
     {
-      if (bu != null) {
-        try {
+      if (bu != null)
+      {
+        try
+        {
           bu.transactionRollback();
         }
-        catch (Exception xe) {
+        catch (Exception xe)
+        {
           Logger.error("rollback failed",xe);
         }
       }

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractSammelTransferBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractSammelTransferBuchungControl.java
@@ -163,7 +163,8 @@ public abstract class AbstractSammelTransferBuchungControl extends AbstractContr
       return zweck2;
     final String buttonText = "weitere Zeilen ({0})...";
     this.zweckDialog = new VerwendungszweckDialog(getBuchung(),VerwendungszweckDialog.POSITION_MOUSE);
-    this.zweckDialog.addCloseListener(new Listener() {
+    this.zweckDialog.addCloseListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         try
@@ -264,13 +265,15 @@ public abstract class AbstractSammelTransferBuchungControl extends AbstractContr
 		/**
 		 * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
 		 */
-		public void handleEvent(Event event) {
+		public void handleEvent(Event event)
+		{
 			if (event == null)
 				return;
 			gegenKonto = (Address) event.data;
 			if (gegenKonto == null)
 				return;
-			try {
+			try
+			{
 				getGegenKonto().setValue(gegenKonto.getKontonummer());
 				getGegenkontoBLZ().setValue(gegenKonto.getBlz());
 				getGegenkontoName().setText(gegenKonto.getName());

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractSammelTransferControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractSammelTransferControl.java
@@ -199,11 +199,14 @@ public abstract class AbstractSammelTransferControl<T extends SammelTransfer> ex
     }
     catch (Exception e)
     {
-      if (t != null) {
-        try {
+      if (t != null)
+      {
+        try
+        {
           t.transactionRollback();
         }
-        catch (Exception xe) {
+        catch (Exception xe)
+        {
           Logger.error("rollback failed",xe);
         }
       }
@@ -230,9 +233,11 @@ public abstract class AbstractSammelTransferControl<T extends SammelTransfer> ex
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-      try {
+      try
+      {
         Object o = getKontoAuswahl().getValue();
         if (o == null || !(o instanceof Konto))
           return;
@@ -260,7 +265,8 @@ public abstract class AbstractSammelTransferControl<T extends SammelTransfer> ex
      */
     public DeleteMenuItem()
     {
-      super(i18n.tr("Buchung(en) löschen..."),new Action() {
+      super(i18n.tr("Buchung(en) löschen..."), new Action()
+      {
         public void handleAction(Object context) throws ApplicationException
         {
           new DBObjectDelete().handleAction(context);
@@ -306,7 +312,8 @@ public abstract class AbstractSammelTransferControl<T extends SammelTransfer> ex
      */
     public CreateMenuItem(final Action action)
     {
-      super(i18n.tr("Neue Buchung..."),new Action() {
+      super(i18n.tr("Neue Buchung..."), new Action()
+      {
         public void handleAction(Object context) throws ApplicationException
         {
           if (handleStore())

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractSepaSammelTransferBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractSepaSammelTransferBuchungControl.java
@@ -330,7 +330,8 @@ public abstract class AbstractSepaSammelTransferBuchungControl<T extends SepaSam
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
       if (event == null)
         return;
       
@@ -340,7 +341,8 @@ public abstract class AbstractSepaSammelTransferBuchungControl<T extends SepaSam
       Address a = (Address) event.data;
       aUpdate.setAddress(a);
 
-      try {
+      try
+      {
         getEmpfaengerName().setText(a.getName());
         getEmpfaengerKonto().setValue(a.getIban());
         getEmpfaengerBic().setValue(a.getBic());

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractSepaSammelTransferControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractSepaSammelTransferControl.java
@@ -296,9 +296,11 @@ public abstract class AbstractSepaSammelTransferControl<T extends SepaSammelTran
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-      try {
+      try
+      {
         Object o = getKontoAuswahl().getValue();
         if (o == null || !(o instanceof Konto))
           return;
@@ -364,7 +366,8 @@ public abstract class AbstractSepaSammelTransferControl<T extends SepaSammelTran
      */
     public CreateMenuItem(final Action action)
     {
-      super(i18n.tr("Neue Buchung..."),new Action() {
+      super(i18n.tr("Neue Buchung..."), new Action()
+      {
         public void handleAction(Object context) throws ApplicationException
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractTransferControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractTransferControl.java
@@ -331,11 +331,14 @@ public abstract class AbstractTransferControl extends AbstractControl
 		}
 		catch (Exception e)
 		{
-		  if (t != null) {
-		    try {
+		  if (t != null)
+		  {
+		    try
+		    {
 		      t.transactionRollback();
 		    }
-	      catch (Exception xe) {
+	      catch (Exception xe)
+	      {
 	        Logger.error("rollback failed",xe);
 	      }
 		  }
@@ -361,9 +364,11 @@ public abstract class AbstractTransferControl extends AbstractControl
 		/**
 		 * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
 		 */
-		public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-			try {
+      try
+      {
         Object o = getKontoAuswahl().getValue();
         if (o == null || !(o instanceof Konto))
           return;
@@ -419,13 +424,15 @@ public abstract class AbstractTransferControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
     	if (event == null)
     		return;
 			gegenkonto = (Address) event.data;
 			if (gegenkonto == null)
 				return;
-			try {
+      try
+      {
         getEmpfaengerName().setText(gegenkonto.getName());
 				getEmpfaengerKonto().setValue(gegenkonto.getKontonummer());
 				getEmpfaengerBlz().setValue(gegenkonto.getBlz());

--- a/src/de/willuhn/jameica/hbci/gui/controller/AccountNewController.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AccountNewController.java
@@ -62,7 +62,8 @@ public class AccountNewController extends AbstractControl
     for (final AccountProvider p:list)
     {
       final InfoPanel panel = p.getInfo();
-      final Button button = new Button(i18n.tr("Bank-Zugang anlegen..."),new Action() {
+      final Button button = new Button(i18n.tr("Bank-Zugang anlegen..."), new Action()
+      {
         @Override
         public void handleAction(Object context) throws ApplicationException
         {

--- a/src/de/willuhn/jameica/hbci/gui/controller/AuslandsUeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AuslandsUeberweisungControl.java
@@ -314,7 +314,8 @@ public class AuslandsUeberweisungControl extends AbstractControl
     
     this.termin = new TerminInput((Terminable) getTransfer());
     this.termin.setName(this.termin.getName() + "  "); // ein kleines bisschen extra Platz lassen, damit auch "Ausführungstermin" hin passt
-    this.termin.addListener(new Listener() {
+    this.termin.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         try
@@ -413,7 +414,8 @@ public class AuslandsUeberweisungControl extends AbstractControl
     this.typ.setName(i18n.tr("Auftragstyp"));
     this.typ.setAttribute("name");
     this.typ.setEnabled(!u.ausgefuehrt());
-    this.typ.addListener(new Listener() {
+    this.typ.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Wir muessen die Entscheidung, ob es eine Termin-Ueberweisung ist,
@@ -500,11 +502,14 @@ public class AuslandsUeberweisungControl extends AbstractControl
     }
     catch (Exception e)
     {
-      if (t != null) {
-        try {
+      if (t != null)
+      {
+        try
+        {
           t.transactionRollback();
         }
-        catch (Exception xe) {
+        catch (Exception xe)
+        {
           Logger.error("rollback failed",xe);
         }
       }
@@ -552,9 +557,11 @@ public class AuslandsUeberweisungControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-      try {
+      try
+      {
         Object o = getKontoAuswahl().getValue();
         if (o == null || !(o instanceof Konto))
         {
@@ -583,7 +590,8 @@ public class AuslandsUeberweisungControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
       if (event == null)
         return;
       
@@ -593,7 +601,8 @@ public class AuslandsUeberweisungControl extends AbstractControl
       Address a = (Address) event.data;
       aUpdate.setAddress(a);
 
-      try {
+      try
+      {
         getEmpfaengerName().setText(a.getName());
         getEmpfaengerKonto().setValue(a.getIban());
         getEmpfaengerBic().setValue(a.getBic());
@@ -644,7 +653,8 @@ public class AuslandsUeberweisungControl extends AbstractControl
     {
       // BUGZILLA 1778 - Das Label wurde unter Ubuntu nicht sofort aktualisiert.
       // Eventuell hilft die asynchrone Ausfuehrung.
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         @Override
         public void run()
         {

--- a/src/de/willuhn/jameica/hbci/gui/controller/DauerauftragControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/DauerauftragControl.java
@@ -204,7 +204,8 @@ public class DauerauftragControl extends AbstractTransferControl {
     letzteZahlung.setComment("");
     letzteZahlung.setTitle(i18n.tr("Datum der letzten Zahlung"));
     letzteZahlung.setText(i18n.tr("Bitte geben Sie das Datum der letzten Zahlung ein"));
-    letzteZahlung.addListener(new Listener() {
+    letzteZahlung.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Nur, um den Parser zu triggern

--- a/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
@@ -184,7 +184,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
     
     this.onlyActive = new CheckboxInput(settings.getBoolean("auswertungen.einnahmeausgabe.filter.active",false));
     this.onlyActive.setName(i18n.tr("Nur aktive Konten"));
-    this.onlyActive.addListener(new org.eclipse.swt.widgets.Listener() {
+    this.onlyActive.addListener(new org.eclipse.swt.widgets.Listener()
+    {
 
       @Override
       public void handleEvent(Event event)
@@ -235,7 +236,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
 
     this.interval = new SelectInput(Interval.values(), Interval.valueOf(settings.getString("auswertungen.einnahmeausgabe.filter.interval", "MONTH")));
     this.interval.setName(i18n.tr("Gruppierung nach"));
-    this.interval.addListener(new Listener() {
+    this.interval.addListener(new Listener()
+    {
 
       @Override
       public void handleEvent(Event event)
@@ -365,7 +367,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
     {
       // Es gibt nur einen Zweig - da reichen uns die darunterliegenden Elemente
       this.werte.addAll(getChildren(result.get(0)));
-    } else
+    }
+    else
     {
       this.werte.addAll(result);
     }
@@ -518,10 +521,12 @@ public class EinnahmeAusgabeControl extends AbstractControl
           summeEinnahmen += ea.getEinnahmen();
           summeAusgaben += ea.getAusgaben();
           summeEndsaldo += ea.getEndsaldo();
-        } else if (sumElement != null)
+        }
+        else if (sumElement != null)
         {
           throw new IllegalStateException("implementation error - there must be only one sum element");
-        } else
+        }
+        else
         {
           sumElement = ea;
         }
@@ -554,7 +559,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
     if (o instanceof Konto)
     {
       result.add((Konto) o);
-    } else if (o == null || (o instanceof String))
+    }
+    else if (o == null || (o instanceof String))
     {
       boolean onlyActive = ((Boolean) this.getActiveOnly().getValue()).booleanValue();
       String group = o != null && (o instanceof String) ? (String) o : null;
@@ -582,10 +588,12 @@ public class EinnahmeAusgabeControl extends AbstractControl
       List<EinnahmeAusgabe> kontoNodes = getEmptyNodes(start, end, konten);
       EinnahmeAusgabeTreeNode node = new EinnahmeAusgabeTreeNode(start, end, kontoNodes);
       result.add(node);
-    } else if (start == null || end == null)
+    }
+    else if (start == null || end == null)
     {
       throw new IllegalStateException("programming error - if there is grouping, there must be transactions and hence both dates are set");
-    } else
+    }
+    else
     {
       Calendar calendar = Calendar.getInstance();
       calendar.setTime(DateUtil.startOfDay(start));
@@ -669,7 +677,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
    * @param d2
    * @return
    */
-  private long getDifferenceDays(Date d1, Date d2) {
+  private long getDifferenceDays(Date d1, Date d2)
+  {
     java.time.LocalDate date1 = DateUtil.startOfDay(toUtilDate(d1)).toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate();
     java.time.LocalDate date2 = DateUtil.endOfDay(toUtilDate(d2)).toInstant().atZone(java.time.ZoneId.systemDefault()).toLocalDate();
     return java.time.temporal.ChronoUnit.DAYS.between(date1, date2);

--- a/src/de/willuhn/jameica/hbci/gui/controller/EmpfaengerControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EmpfaengerControl.java
@@ -313,7 +313,8 @@ public class EmpfaengerControl extends AbstractControl
     this.iban.setEnabled(enabled);
     if (enabled)
     {
-      this.iban.addListener(new Listener() {
+      this.iban.addListener(new Listener()
+      {
         public void handleEvent(Event event)
         {
           // BUGZILLA 1605 Wenn wir eine IBAN haben aber noch keine
@@ -370,7 +371,8 @@ public class EmpfaengerControl extends AbstractControl
     this.bic.setEnabled(enabled);
     if (enabled)
     {
-      this.bic.addListener(new Listener() {
+      this.bic.addListener(new Listener()
+      {
         public void handleEvent(Event event)
         {
           // BUGZILLA 1605 Wenn wir eine BIC haben aber noch keine
@@ -489,7 +491,8 @@ public class EmpfaengerControl extends AbstractControl
    */
   public synchronized void handleStore()
   {
-    try {
+    try
+    {
 
       if (isHibiscusAdresse())
       {

--- a/src/de/willuhn/jameica/hbci/gui/controller/KontoControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/KontoControl.java
@@ -237,7 +237,8 @@ public class KontoControl extends AbstractControl
     this.offline = new CheckboxInput(this.getKonto().hasFlag(Konto.FLAG_OFFLINE));
     this.offline.setName(i18n.tr("Offline-Konto"));
     
-    this.offline.addListener(new Listener() {
+    this.offline.addListener(new Listener()
+    {
       @Override
       public void handleEvent(Event event)
       {
@@ -277,7 +278,8 @@ public class KontoControl extends AbstractControl
     if (this.synchronizeOptions != null)
       return this.synchronizeOptions;
 
-    this.synchronizeOptions = new Button(i18n.tr("Synchronisierungsoptionen"),new Action() {
+    this.synchronizeOptions = new Button(i18n.tr("Synchronisierungsoptionen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try
@@ -419,7 +421,8 @@ public class KontoControl extends AbstractControl
       return backendAuswahl;
     
     backendAuswahl = new BackendInput(getKonto());
-    backendAuswahl.addListener(new Listener() {
+    backendAuswahl.addListener(new Listener()
+    {
       @Override
       public void handleEvent(Event event)
       {
@@ -551,7 +554,8 @@ public class KontoControl extends AbstractControl
       return this.iban;
     
     this.iban = new IBANInput(getKonto().getIban(),this.getBic());
-    this.iban.addListener(new Listener() {
+    this.iban.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // BUGZILLA 1605 Wenn wir eine IBAN haben aber noch keine
@@ -602,7 +606,8 @@ public class KontoControl extends AbstractControl
       return this.bic;
     
     this.bic = new BICInput(getKonto().getBic());
-    this.bic.addListener(new Listener() {
+    this.bic.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // BUGZILLA 1605 Wenn wir eine BIC haben aber noch keine
@@ -836,7 +841,8 @@ public class KontoControl extends AbstractControl
    */
   public void handleReload()
   {
-    GUI.startSync(new Runnable() {
+    GUI.startSync(new Runnable()
+    {
       public void run()
       {
         try
@@ -893,7 +899,8 @@ public class KontoControl extends AbstractControl
      */
     public void handleMessage(final Message message) throws Exception
     {
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         
         public void run()
         {

--- a/src/de/willuhn/jameica/hbci/gui/controller/KontoauszugPdfControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/KontoauszugPdfControl.java
@@ -344,7 +344,8 @@ public class KontoauszugPdfControl extends AbstractControl
           super.customize(fd);
         }
       };
-      this.datei.addListener(new Listener() {
+      this.datei.addListener(new Listener()
+      {
         
         @Override
         public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/controller/LicenseControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/LicenseControl.java
@@ -28,7 +28,8 @@ import de.willuhn.util.I18N;
 /**
  * Controller fuer den Dialog Lizenzinformationen.
  */
-public class LicenseControl extends AbstractControl {
+public class LicenseControl extends AbstractControl
+{
 
   private Part libList = null;
   private I18N i18n = null;
@@ -37,7 +38,8 @@ public class LicenseControl extends AbstractControl {
    * ct.
    * @param view
    */
-  public LicenseControl(AbstractView view) {
+  public LicenseControl(AbstractView view)
+  {
     super(view);
     i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   }
@@ -57,7 +59,8 @@ public class LicenseControl extends AbstractControl {
     buffer.append("<form>");
 
     Manifest manifest = null;
-    try {
+    try
+    {
       manifest = Application.getPluginLoader().getManifest(HBCI.class);
     }
     catch (Exception e)
@@ -88,7 +91,8 @@ public class LicenseControl extends AbstractControl {
         continue;
       }
 
-      try {
+      try
+      {
         InfoReader ir = new InfoReader(new FileInputStream(infos[i]));
         buffer.append("<p>");
         buffer.append("<b>" + ir.getName() + "</b>");

--- a/src/de/willuhn/jameica/hbci/gui/controller/NachrichtControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/NachrichtControl.java
@@ -21,14 +21,16 @@ import de.willuhn.jameica.hbci.rmi.Nachricht;
 /**
  * Controller fuer die System-Nachrichten.
  */
-public class NachrichtControl extends AbstractControl {
+public class NachrichtControl extends AbstractControl
+{
 
   private Part list = null;
 
   /**
    * @param view
    */
-  public NachrichtControl(AbstractView view) {
+  public NachrichtControl(AbstractView view)
+  {
     super(view);
   }
   

--- a/src/de/willuhn/jameica/hbci/gui/controller/SammelLastBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SammelLastBuchungControl.java
@@ -124,7 +124,8 @@ public class SammelLastBuchungControl extends AbstractSammelTransferBuchungContr
 		}
 		catch (ApplicationException e)
 		{
-			try {
+			try
+			{
 				getBuchung().transactionRollback();
 			}
 			catch (RemoteException re)
@@ -135,7 +136,8 @@ public class SammelLastBuchungControl extends AbstractSammelTransferBuchungContr
 		}
 		catch (Exception e2)
 		{
-			try {
+			try
+			{
 				getBuchung().transactionRollback();
 			}
 			catch (RemoteException re)

--- a/src/de/willuhn/jameica/hbci/gui/controller/SammelLastschriftControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SammelLastschriftControl.java
@@ -82,7 +82,8 @@ public class SammelLastschriftControl extends AbstractSammelTransferControl<Samm
     if (this.buchungen != null)
       return this.buchungen;
     
-    Action a = new Action() {
+    Action a = new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new SammelLastBuchungNew().handleAction(context);

--- a/src/de/willuhn/jameica/hbci/gui/controller/SammelUeberweisungBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SammelUeberweisungBuchungControl.java
@@ -68,7 +68,8 @@ public class SammelUeberweisungBuchungControl extends AbstractSammelTransferBuch
 	 */
 	public synchronized void handleStore(boolean next)
 	{
-		try {
+		try
+		{
   		
 			getBuchung().transactionBegin();
 
@@ -125,7 +126,8 @@ public class SammelUeberweisungBuchungControl extends AbstractSammelTransferBuch
 		}
 		catch (ApplicationException e)
 		{
-			try {
+			try
+			{
 				getBuchung().transactionRollback();
 			}
 			catch (RemoteException re)
@@ -136,7 +138,8 @@ public class SammelUeberweisungBuchungControl extends AbstractSammelTransferBuch
 		}
 		catch (Exception e2)
 		{
-			try {
+			try
+			{
 				getBuchung().transactionRollback();
 			}
 			catch (RemoteException re)

--- a/src/de/willuhn/jameica/hbci/gui/controller/SammelUeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SammelUeberweisungControl.java
@@ -82,7 +82,8 @@ public class SammelUeberweisungControl extends AbstractSammelTransferControl<Sam
     if (this.buchungen != null)
       return this.buchungen;
     
-    Action a = new Action() {
+    Action a = new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new SammelUeberweisungBuchungNew().handleAction(context);

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaDauerauftragControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaDauerauftragControl.java
@@ -165,8 +165,10 @@ public class SepaDauerauftragControl extends AbstractControl
 			return turnus;
 
 		TurnusDialog td = new TurnusDialog(TurnusDialog.POSITION_MOUSE);
-		td.addCloseListener(new Listener() {
-			public void handleEvent(Event event) {
+		td.addCloseListener(new Listener()
+		{
+			public void handleEvent(Event event)
+			{
 				if (event == null || event.data == null)
 					return;
 				Turnus choosen = (Turnus) event.data;
@@ -273,7 +275,8 @@ public class SepaDauerauftragControl extends AbstractControl
     letzteZahlung.setComment("");
     letzteZahlung.setTitle(i18n.tr("Datum der letzten Zahlung"));
     letzteZahlung.setText(i18n.tr("Bitte geben Sie das Datum der letzten Zahlung ein"));
-    letzteZahlung.addListener(new Listener() {
+    letzteZahlung.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Nur, um den Parser zu triggern
@@ -556,11 +559,14 @@ public class SepaDauerauftragControl extends AbstractControl
     }
     catch (Exception e)
     {
-      if (t != null) {
-        try {
+      if (t != null)
+      {
+        try
+        {
           t.transactionRollback();
         }
-        catch (Exception xe) {
+        catch (Exception xe)
+        {
           Logger.error("rollback failed",xe);
         }
       }
@@ -642,9 +648,11 @@ public class SepaDauerauftragControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-      try {
+      try
+      {
         Object o = getKontoAuswahl().getValue();
         if (o == null || !(o instanceof Konto))
         {
@@ -673,7 +681,8 @@ public class SepaDauerauftragControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
       if (event == null)
         return;
       
@@ -683,7 +692,8 @@ public class SepaDauerauftragControl extends AbstractControl
       Address a = (Address) event.data;
       aUpdate.setAddress(a);
 
-      try {
+      try
+      {
         getEmpfaengerName().setText(a.getName());
         getEmpfaengerKonto().setValue(a.getIban());
         getEmpfaengerBic().setValue(a.getBic());

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaLastschriftControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaLastschriftControl.java
@@ -561,11 +561,14 @@ public class SepaLastschriftControl extends AbstractControl
     }
     catch (Exception e)
     {
-      if (t != null) {
-        try {
+      if (t != null)
+      {
+        try
+        {
           t.transactionRollback();
         }
-        catch (Exception xe) {
+        catch (Exception xe)
+        {
           Logger.error("rollback failed",xe);
         }
       }
@@ -613,9 +616,11 @@ public class SepaLastschriftControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-      try {
+      try
+      {
         Object o = getKontoAuswahl().getValue();
         if (o == null || !(o instanceof Konto))
         {
@@ -649,7 +654,8 @@ public class SepaLastschriftControl extends AbstractControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
       if (event == null)
         return;
       
@@ -659,7 +665,8 @@ public class SepaLastschriftControl extends AbstractControl
       Address a = (Address) event.data;
       aUpdate.setAddress(a);
 
-      try {
+      try
+      {
         getEmpfaengerName().setText(a.getName());
         getEmpfaengerKonto().setValue(a.getIban());
         getEmpfaengerBic().setValue(a.getBic());

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelLastBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelLastBuchungControl.java
@@ -231,11 +231,14 @@ public class SepaSammelLastBuchungControl extends AbstractSepaSammelTransferBuch
     }
     catch (Exception e)
     {
-      if (t != null) {
-        try {
+      if (t != null)
+      {
+        try
+        {
           t.transactionRollback();
         }
-        catch (Exception xe) {
+        catch (Exception xe)
+        {
           Logger.error("rollback failed",xe);
         }
       }
@@ -262,7 +265,8 @@ public class SepaSammelLastBuchungControl extends AbstractSepaSammelTransferBuch
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
       if (event == null)
         return;
       
@@ -271,7 +275,8 @@ public class SepaSammelLastBuchungControl extends AbstractSepaSammelTransferBuch
       
       Address a = (Address) event.data;
 
-      try {
+      try
+      {
 
         // Checken, ob wir in der Adresse Mandats-Daten haben
         if (a instanceof HibiscusAddress)

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelLastschriftControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelLastschriftControl.java
@@ -212,7 +212,8 @@ public class SepaSammelLastschriftControl extends AbstractSepaSammelTransferCont
     if (this.buchungen != null)
       return this.buchungen;
     
-    Action a = new Action() {
+    Action a = new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new SepaSammelLastBuchungNew().handleAction(context);

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelUeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelUeberweisungControl.java
@@ -106,7 +106,8 @@ public class SepaSammelUeberweisungControl extends AbstractSepaSammelTransferCon
     this.typ.setName(i18n.tr("Auftragstyp"));
     this.typ.setAttribute("name");
     this.typ.setEnabled(!u.ausgefuehrt());
-    this.typ.addListener(new Listener() {
+    this.typ.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Wir muessen die Entscheidung, ob es eine Termin-Ueberweisung ist,
@@ -140,7 +141,8 @@ public class SepaSammelUeberweisungControl extends AbstractSepaSammelTransferCon
     
     this.termin = super.getTermin();
     this.termin.setName(this.termin.getName() + "  "); // ein kleines bisschen extra Platz lassen, damit auch "Ausführungstermin" hin passt
-    this.termin.addListener(new Listener() {
+    this.termin.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         try
@@ -225,7 +227,8 @@ public class SepaSammelUeberweisungControl extends AbstractSepaSammelTransferCon
     if (this.buchungen != null)
       return this.buchungen;
     
-    Action a = new Action() {
+    Action a = new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new SepaSammelUeberweisungBuchungNew().handleAction(context);
@@ -273,7 +276,8 @@ public class SepaSammelUeberweisungControl extends AbstractSepaSammelTransferCon
     @Override
     public void handleEvent(Event event)
     {
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         @Override
         public void run()
         {

--- a/src/de/willuhn/jameica/hbci/gui/controller/SettingsControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SettingsControl.java
@@ -142,7 +142,8 @@ public class SettingsControl extends AbstractControl
     if (kontoCheck == null)
     {
       kontoCheck = new CheckboxInput(Settings.getKontoCheck());
-      Listener l = new Listener() {
+      Listener l = new Listener()
+      {
         public void handleEvent(Event event)
         {
           getKontoCheckExcludeAddressbook().setEnabled(((Boolean)kontoCheck.getValue()).booleanValue());
@@ -176,7 +177,8 @@ public class SettingsControl extends AbstractControl
     if (this.cachePin != null)
       return this.cachePin;
 
-    Listener l = new Listener() {
+    Listener l = new Listener()
+    {
       public void handleEvent(Event event)
       {
         boolean b1 = (Boolean) getCachePin().getValue();
@@ -206,7 +208,8 @@ public class SettingsControl extends AbstractControl
     
     storePin = new CheckboxInput(Settings.getStorePin());
     storePin.setComment("");
-    storePin.addListener(new Listener() {
+    storePin.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Wir loesen nur bei dem Selection-Event aus, nicht bei FocusOut/FocusIn
@@ -257,7 +260,8 @@ public class SettingsControl extends AbstractControl
 
     this.exFeatures = new CheckboxInput(fs.enabled());
     this.exFeatures.setName(i18n.tr("Experimentelle Funktionen aktivieren"));
-    final Listener l = new Listener() {
+    final Listener l = new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/controller/UeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UeberweisungControl.java
@@ -96,7 +96,8 @@ public class UeberweisungControl extends AbstractBaseUeberweisungControl
     this.typ.setName(i18n.tr("Auftragstyp"));
     this.typ.setAttribute("name");
     this.typ.setEnabled(!u.ausgefuehrt());
-    this.typ.addListener(new Listener() {
+    this.typ.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Wir muessen die Entscheidung, ob es eine Termin-Ueberweisung ist,
@@ -129,7 +130,8 @@ public class UeberweisungControl extends AbstractBaseUeberweisungControl
       return this.termin;
     
     this.termin = super.getTermin();
-    this.termin.addListener(new Listener() {
+    this.termin.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         try
@@ -205,7 +207,8 @@ public class UeberweisungControl extends AbstractBaseUeberweisungControl
     // Listener fuer die nachtraegliche Aenderung
     if (textschluessel.isEnabled())
     {
-      textschluessel.addListener(new Listener() {
+      textschluessel.addListener(new Listener()
+      {
         public void handleEvent(Event event)
         {
           TextSchluessel s = (TextSchluessel) textschluessel.getValue();

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -90,7 +90,8 @@ public class UmsatzDetailControl extends AbstractControl
    * ct.
    * @param view
    */
-  public UmsatzDetailControl(AbstractView view) {
+  public UmsatzDetailControl(AbstractView view)
+  {
     super(view);
   }
 
@@ -486,7 +487,8 @@ public class UmsatzDetailControl extends AbstractControl
 	  this.zweckSwitch = new CheckboxInput(b);
 	  this.zweckSwitch.setName(i18n.tr("Alle Daten des Verwendungszwecks anzeigen"));
 	  
-	  Listener l = new Listener() {
+    Listener l = new Listener()
+    {
       @Override
       public void handleEvent(Event event)
       {

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
@@ -54,7 +54,8 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
    * ct.
    * @param view
    */
-  public UmsatzDetailEditControl(AbstractView view) {
+  public UmsatzDetailEditControl(AbstractView view)
+  {
     super(view);
   }
 
@@ -122,8 +123,10 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
     
     this.betrag.setComment(konto == null ? "" : konto.getWaehrung());
     
-    final Listener l = new Listener() {
-      public void handleEvent(Event event) {
+    final Listener l = new Listener()
+    {
+      public void handleEvent(Event event)
+      {
         try
         {
           Double value = (Double) betrag.getValue();
@@ -331,7 +334,8 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
   public boolean handleStore()
   {
     Umsatz u = getUmsatz();
-    try {
+    try
+    {
 
       u.transactionBegin();
 
@@ -506,12 +510,14 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
       if (event == null || event.data == null || !(event.data instanceof Address))
         return;
       Address empfaenger = (Address) event.data;
 
-      try {
+      try
+      {
         getEmpfaengerKonto().setValue(empfaenger.getIban());
 
         String bic = empfaenger.getBic();

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
@@ -82,7 +82,8 @@ public class UmsatzTypTreeControl extends AbstractControl
     // bei Ausloesungen ueber SWT-Events verzoegern wir
     // das Reload, um schnell aufeinanderfolgende Updates
     // zu buendeln.
-    this.listener = new DelayedListener(new Listener() {
+    this.listener = new DelayedListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         handleReload();
@@ -98,7 +99,8 @@ public class UmsatzTypTreeControl extends AbstractControl
    */
   public Listener changedListener(final Input input)
   {
-    return new Listener() {
+    return new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/About.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/About.java
@@ -126,14 +126,16 @@ public class About extends AbstractDialog
 //        }
 //      }
 //    },null,false,"stock_keyring.png");
-    buttons.addButton(i18n.tr("Spenden"),new Action() {
+    buttons.addButton(i18n.tr("Spenden"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         close();
         new DonateView().handleAction(null);
       }
     },null,false,"emblem-special.png");
-    buttons.addButton(i18n.tr("Schlieﬂen"),new Action() {
+    buttons.addButton(i18n.tr("Schlieﬂen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         close();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/AccountContainerDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/AccountContainerDialog.java
@@ -240,7 +240,8 @@ public class AccountContainerDialog extends AbstractDialog
     };
     
     // BUGZILLA 381
-    this.host.addListener(new Listener() {
+    this.host.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         // Triggert den Code zum Entfernen des "https://" und der Leerzeichen

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/AdresseAuswahlDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/AdresseAuswahlDialog.java
@@ -77,7 +77,8 @@ public class AdresseAuswahlDialog extends AbstractDialog
    */
   protected void paint(Composite parent) throws Exception
   {
-    Action a = new Action() {
+    Action a = new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (context == null || !(context instanceof Address))
@@ -107,7 +108,8 @@ public class AdresseAuswahlDialog extends AbstractDialog
       }
     },null,true,"ok.png");
     apply.setEnabled(false);
-    empf.addSelectionListener(new Listener() {
+    empf.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         apply.setEnabled(empf.getSelection() != null);
@@ -132,7 +134,8 @@ public class AdresseAuswahlDialog extends AbstractDialog
     // Unabhaengig von dem, was der User als Groesse eingestellt hat, bleibt das die Minimalgroesse.
     getShell().setMinimumSize(WINDOW_WIDTH,WINDOW_HEIGHT);
     
-    getShell().addDisposeListener(new DisposeListener() {
+    getShell().addDisposeListener(new DisposeListener()
+    {
       
       @Override
       public void widgetDisposed(DisposeEvent e)

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/BaseDauerauftragDeleteDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/BaseDauerauftragDeleteDialog.java
@@ -49,7 +49,8 @@ public class BaseDauerauftragDeleteDialog extends AbstractDialog
   /**
    * @param position
    */
-  public BaseDauerauftragDeleteDialog(int position) {
+  public BaseDauerauftragDeleteDialog(int position)
+  {
     super(position);
     this.setTitle(i18n.tr("Zieldatum"));
   }
@@ -83,8 +84,10 @@ public class BaseDauerauftragDeleteDialog extends AbstractDialog
 
     CalendarDialog cd = new CalendarDialog(CalendarDialog.POSITION_MOUSE);
     cd.setTitle(i18n.tr("Zieldatum"));
-    cd.addCloseListener(new Listener() {
-      public void handleEvent(Event event) {
+    cd.addCloseListener(new Listener()
+    {
+      public void handleEvent(Event event)
+      {
         if (event == null || event.data == null || !(event.data instanceof Date))
           return;
 
@@ -169,7 +172,8 @@ public class BaseDauerauftragDeleteDialog extends AbstractDialog
   /**
    * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
    */
-  protected Object getData() throws Exception {
+  protected Object getData() throws Exception
+  {
     return date;
   }
 

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
@@ -117,7 +117,8 @@ public class CSVImportDialog extends AbstractDialog
         reload();
       }
     },null,false,"view-refresh.png");
-    b.addButton(i18n.tr("Profil speichern..."), new Action() {
+    b.addButton(i18n.tr("Profil speichern..."), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -142,7 +143,8 @@ public class CSVImportDialog extends AbstractDialog
         }
       }
     },null,false,"document-save.png");
-    b.addButton(i18n.tr("Profil löschen..."), new Action() {
+    b.addButton(i18n.tr("Profil löschen..."), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -247,7 +249,10 @@ public class CSVImportDialog extends AbstractDialog
       {
         c = (Column) c.clone();
       }
-      catch (CloneNotSupportedException e) {/*dann halt nicht */}
+      catch (CloneNotSupportedException e)
+      {
+        /* dann halt nicht */
+      }
       
       // Spaltennummer speichern
       c.setColumn(i);
@@ -342,7 +347,11 @@ public class CSVImportDialog extends AbstractDialog
           value = current.get(i);
           if (value.length() > 30)
             value = value.substring(0,30) + "...";
-        } catch (Exception e) {} // Spalte gibts in der Zeile nicht
+        }
+        catch (Exception e)
+        {
+          // Spalte gibts in der Zeile nicht
+        }
         
         final SelectInput s = new SelectInput(all,getColumn(columns,i));
         s.setName((i+1) + ". " + (value != null ? value : "<" + i18n.tr("leer") + ">"));
@@ -510,7 +519,8 @@ public class CSVImportDialog extends AbstractDialog
     this.profiles = new SelectInput(list,p);
     this.profiles.setAttribute("name");
     this.profiles.setName(i18n.tr("Profil"));
-    this.profiles.addListener(new Listener() {
+    this.profiles.addListener(new Listener()
+    {
       @Override
       public void handleEvent(Event event)
       {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CSVProfileStoreDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CSVProfileStoreDialog.java
@@ -159,7 +159,8 @@ public class CSVProfileStoreDialog extends AbstractDialog
     if (this.apply != null)
       return this.apply;
     
-    this.apply = new Button(i18n.tr("Übernehmen"),new Action() {
+    this.apply = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         // Name uebernehmen
@@ -205,7 +206,8 @@ public class CSVProfileStoreDialog extends AbstractDialog
     final Input name = this.getName();
     c.addInput(name);
     
-    name.getControl().addKeyListener(new KeyAdapter() {
+    name.getControl().addKeyListener(new KeyAdapter()
+    {
       /**
        * @see org.eclipse.swt.events.KeyAdapter#keyReleased(org.eclipse.swt.events.KeyEvent)
        */

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CamtSetupDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CamtSetupDialog.java
@@ -87,7 +87,8 @@ public class CamtSetupDialog extends AbstractDialog
     
     ButtonArea buttons = new ButtonArea();
 
-    final Button yes = new Button(i18n.tr("Ja, auf CAMT umstellen"),new Action() {
+    final Button yes = new Button(i18n.tr("Ja, auf CAMT umstellen"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -97,7 +98,8 @@ public class CamtSetupDialog extends AbstractDialog
     },null,true,"ok.png");
     buttons.addButton(yes);
 
-    final Button no = new Button(i18n.tr("Nein, nicht umstellen"),new Action() {
+    final Button no = new Button(i18n.tr("Nein, nicht umstellen"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -107,7 +109,8 @@ public class CamtSetupDialog extends AbstractDialog
     },null,true,"window-close.png");
     buttons.addButton(no);
 
-    final Button later = new Button(i18n.tr("Beim nächsten Mal erinnern"),new Action() {
+    final Button later = new Button(i18n.tr("Beim nächsten Mal erinnern"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CaptchaDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CaptchaDialog.java
@@ -128,7 +128,8 @@ public class CaptchaDialog extends AbstractDialog
     
     ButtonArea buttons = new ButtonArea();
     buttons.addButton(this.getApplyButton());
-    buttons.addButton(i18n.tr("Abbrechen"),new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException("Dialog abgebrochen");
@@ -226,7 +227,8 @@ public class CaptchaDialog extends AbstractDialog
     if (this.applyButton != null)
       return this.applyButton;
     
-    this.applyButton = new Button(i18n.tr("Übernehmen"),new Action() {
+    this.applyButton = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         data = (String) getSolution().getValue();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/DebugDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/DebugDialog.java
@@ -73,7 +73,8 @@ public class DebugDialog extends AbstractDialog
     container.addPart(text);
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Schlieﬂen"),new Action() {
+    buttons.addButton(i18n.tr("Schlieﬂen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         close();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -191,7 +191,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
     final Exporter exporter = exp.exporter;
     final IOFormat format = exp.format;
 
-    BackgroundTask t = new BackgroundTask() {
+    BackgroundTask t = new BackgroundTask()
+    {
       public void run(ProgressMonitor monitor) throws ApplicationException
       {
         try
@@ -206,7 +207,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
           
           if (open)
           {
-            GUI.getDisplay().asyncExec(new Runnable() {
+            GUI.getDisplay().asyncExec(new Runnable()
+            {
               public void run()
               {
                 try
@@ -245,7 +247,10 @@ public class ExportDialog extends AbstractDialog implements Extendable
         }
       }
 
-      public void interrupt() {}
+      public void interrupt()
+      {
+      }
+
       public boolean isInterrupted()
       {
         return false;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/HBCIVersionDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/HBCIVersionDialog.java
@@ -62,14 +62,16 @@ public class HBCIVersionDialog extends AbstractDialog
     group.addInput(input);
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"), new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         version = (String) input.getValue();
         close();
       }
     },null,true,"ok.png");
-    buttons.addButton(i18n.tr("Abbrechen"), new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException("cancelled while choosing hbci version");

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoAuswahlDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoAuswahlDialog.java
@@ -143,7 +143,8 @@ public class KontoAuswahlDialog extends AbstractDialog
 
     this.auswahl = new KontoInput(this.preselected,this.filter);
     this.auswahl.setComment(null);
-    auswahl.addListener(new Listener() {
+    auswahl.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         preselected = (Konto) auswahl.getValue();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoDeleteDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoDeleteDialog.java
@@ -97,7 +97,8 @@ public class KontoDeleteDialog extends AbstractDialog<Boolean>
     
     this.check = new CheckboxInput(false);
     this.check.setName(i18n.tr("Konto und alle zugeordneten Daten löschen"));
-    this.check.addListener(new Listener() {
+    this.check.addListener(new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -117,7 +118,8 @@ public class KontoDeleteDialog extends AbstractDialog<Boolean>
     if (this.apply != null)
       return this.apply;
     
-    this.apply = new Button(i18n.tr("Jetzt löschen"),new Action() {
+    this.apply = new Button(i18n.tr("Jetzt löschen"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -150,13 +152,16 @@ public class KontoDeleteDialog extends AbstractDialog<Boolean>
     // Wir laden die Daten im Hintergrund. Das kann sonst bei vielen Daten laenger dauern
     new Thread()
     {
-      public void run() {
-        GUI.getDisplay().asyncExec(new Runnable() {
+      public void run()
+      {
+        GUI.getDisplay().asyncExec(new Runnable()
+        {
           
           @Override
           public void run()
           {
-            BusyIndicator.showWhile(GUI.getDisplay(), new Runnable() {
+            BusyIndicator.showWhile(GUI.getDisplay(), new Runnable()
+            {
               
               @Override
               public void run()

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugMoveDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugMoveDialog.java
@@ -98,7 +98,8 @@ public class KontoauszugMoveDialog extends AbstractDialog<Kontoauszug>
     this.target = new DirectoryInput(dir.getAbsolutePath());
     this.target.setName(i18n.tr("Zielverzeichnis"));
 
-    final Listener l = new Listener() {
+    final Listener l = new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -204,7 +205,8 @@ public class KontoauszugMoveDialog extends AbstractDialog<Kontoauszug>
     if (this.apply != null)
       return this.apply;
     
-    this.apply = new Button(i18n.tr("Dateien jetzt verschieben"),new Action() {
+    this.apply = new Button(i18n.tr("Dateien jetzt verschieben"), new Action()
+    {
       @Override
       public void handleAction(Object context) throws ApplicationException
       {
@@ -275,7 +277,8 @@ public class KontoauszugMoveDialog extends AbstractDialog<Kontoauszug>
 
     final double factor = 100d / (double) list.length;
 
-    Application.getController().start(new BackgroundTask() {
+    Application.getController().start(new BackgroundTask()
+    {
       
       private boolean stop = false;
 

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugPdfSettingsDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugPdfSettingsDialog.java
@@ -179,7 +179,8 @@ public class KontoauszugPdfSettingsDialog extends AbstractDialog
     // Unabhaengig von dem, was der User als Groesse eingestellt hat, bleibt das die Minimalgroesse.
     getShell().setMinimumSize(WINDOW_WIDTH,WINDOW_HEIGHT);
     
-    getShell().addDisposeListener(new DisposeListener() {
+    getShell().addDisposeListener(new DisposeListener()
+    {
       
       @Override
       public void widgetDisposed(DisposeEvent e)
@@ -360,7 +361,8 @@ public class KontoauszugPdfSettingsDialog extends AbstractDialog
     this.messaging = new CheckboxInput(false);
     this.messaging.setName(MetaKey.KONTOAUSZUG_STORE_MESSAGING.getDescription());
     
-    Listener l = new Listener() {
+    Listener l = new Listener()
+    {
       @Override
       public void handleEvent(Event event)
       {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugSettingsDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugSettingsDialog.java
@@ -58,7 +58,8 @@ public class KontoauszugSettingsDialog extends AbstractDialog
     final Container c = new SimpleContainer(parent);
     c.addInput(this.getDisplayAll());
     
-    final Button apply = new Button(i18n.tr("Übernehmen"),new Action() {
+    final Button apply = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/PainVersionDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/PainVersionDialog.java
@@ -111,7 +111,8 @@ public class PainVersionDialog extends AbstractDialog
     final SelectInput select = new SelectInput(list,SepaVersion.findGreatest(list));
     select.setAttribute("file");
     select.setName(i18n.tr("Schema-Version der SEPA XML-Datei"));
-    select.addListener(new Listener() {
+    select.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         if (ok != null)

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/PassportAuswahlDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/PassportAuswahlDialog.java
@@ -80,7 +80,8 @@ public class PassportAuswahlDialog extends AbstractDialog
     c.addInput(this.getComment());
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"), new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try
@@ -100,7 +101,8 @@ public class PassportAuswahlDialog extends AbstractDialog
         }
       }
     },null,true,"ok.png");
-    buttons.addButton(i18n.tr("Abbrechen"),new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException(i18n.tr("Vorgang abgebrochen"));

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/PassportPropertyDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/PassportPropertyDialog.java
@@ -68,7 +68,8 @@ public class PassportPropertyDialog extends AbstractDialog
     table.paint(parent);
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("BPD löschen"),new Action() {
+    buttons.addButton(i18n.tr("BPD löschen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         String s = i18n.tr("Die BPD (Bank-Parameter-Daten) werden beim nächsten Verbindungsaufbau \n" +
@@ -101,7 +102,8 @@ public class PassportPropertyDialog extends AbstractDialog
         }
       }
     },null,false,"user-trash-full.png");
-    buttons.addButton(i18n.tr("Schließen"),new Action() {
+    buttons.addButton(i18n.tr("Schließen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         close();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ReminderIntervalDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ReminderIntervalDialog.java
@@ -97,7 +97,8 @@ public class ReminderIntervalDialog extends AbstractDialog<ReminderInterval>
                        "Erinnerungstermin) automatisch durch Hibiscus " +
                        "dupliziert"),true);
 
-    final Listener listener = new Listener() {
+    final Listener listener = new Listener()
+    {
       public void handleEvent(Event event)
       {
         updatePreview();
@@ -107,7 +108,8 @@ public class ReminderIntervalDialog extends AbstractDialog<ReminderInterval>
 
     ////////////////////////////////////////////////////////////////////////////
     // Die Buttons
-    final Button apply = new Button(i18n.tr("Übernehmen"), new Action() {
+    final Button apply = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         boolean enabled = ((Boolean)checkbox.getValue()).booleanValue();
@@ -115,7 +117,8 @@ public class ReminderIntervalDialog extends AbstractDialog<ReminderInterval>
         close();
       }
     },null,true,"ok.png");
-    final Button cancel = new Button(i18n.tr("Abbrechen"), new Action() {
+    final Button cancel = new Button(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();
@@ -152,7 +155,8 @@ public class ReminderIntervalDialog extends AbstractDialog<ReminderInterval>
     this.endInput = new DateInput(this.end,HBCI.DATEFORMAT);
     this.endInput.setName(i18n.tr("Letzte Ausführung"));
     
-    final Listener endCheck = new Listener() {
+    final Listener endCheck = new Listener()
+    {
       public void handleEvent(Event event)
       {
         Date myEnd = (Date) endInput.getValue();
@@ -183,7 +187,8 @@ public class ReminderIntervalDialog extends AbstractDialog<ReminderInterval>
     this.preview = new TablePart(null);
     this.preview.addColumn(i18n.tr("Vorschau auf die nächsten Folge-Termine"),null);
     this.preview.setSummary(false);
-    this.preview.setFormatter(new TableFormatter() {
+    this.preview.setFormatter(new TableFormatter()
+    {
       public void format(TableItem item)
       {
         Date d = (Date) item.getData();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaExportDialog.java
@@ -69,7 +69,8 @@ public class SepaExportDialog extends AbstractDialog
     this.type = type;
     this.setSize(WINDOW_WIDTH,SWT.DEFAULT);
     
-    this.addCloseListener(new Listener() {
+    this.addCloseListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         if (file != null)
@@ -160,7 +161,8 @@ public class SepaExportDialog extends AbstractDialog
     final SelectInput select = new SelectInput(list,SepaVersion.findGreatest(list));
     select.setAttribute("file");
     select.setName(i18n.tr("Schema-Version der SEPA-Datei"));
-    select.addListener(new Listener() {
+    select.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         if (ok != null)
@@ -205,7 +207,8 @@ public class SepaExportDialog extends AbstractDialog
     };
     input.setName(i18n.tr("SEPA XML-Datei"));
     input.setMandatory(true);
-    input.addListener(new Listener() {
+    input.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         if (ok != null)

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeOptionsDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeOptionsDialog.java
@@ -169,7 +169,8 @@ public class SynchronizeOptionsDialog extends AbstractDialog
     group.addText(i18n.tr("Bitte wählen Sie aus, welche Geschäftsvorfälle bei der " +
     		                  "Synchronisierung des Kontos ausgeführt werden sollen."),true);
     
-    this.apply = new Button(i18n.tr("Übernehmen"),new Action() {
+    this.apply = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         
@@ -345,7 +346,8 @@ public class SynchronizeOptionsDialog extends AbstractDialog
       
       final CheckboxInput syncUms = this.getSyncUmsatz();
       
-      final Listener l = new Listener() {
+      final Listener l = new Listener()
+      {
         
         @Override
         public void handleEvent(Event event)
@@ -448,7 +450,8 @@ public class SynchronizeOptionsDialog extends AbstractDialog
     
     // Wir haengen hier noch einen Listener dran, der bewirkt, dass die Option nur dann auswaehlbar ist,
     // wenn wenigstens ein HBCI-Geschaeftsvorfall durchgefuehrt wird
-    final Listener l = new Listener() {
+    final Listener l = new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/TransferMergeDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/TransferMergeDialog.java
@@ -70,7 +70,8 @@ public class TransferMergeDialog extends AbstractDialog
    * @param t der zugehoerige Sammel-Auftrag.
    * @param position
    */
-  public TransferMergeDialog(SammelTransfer t, int position) {
+  public TransferMergeDialog(SammelTransfer t, int position)
+  {
     super(position);
 
     this.transfer = t;
@@ -81,7 +82,8 @@ public class TransferMergeDialog extends AbstractDialog
   /**
    * @see de.willuhn.jameica.gui.dialogs.AbstractDialog#getData()
    */
-  protected Object getData() throws Exception {
+  protected Object getData() throws Exception
+  {
     return this.transfer;
   }
 

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/TurnusDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/TurnusDialog.java
@@ -81,7 +81,8 @@ public class TurnusDialog extends AbstractDialog
     {
       public void format(TableItem item)
       {
-        try {
+        try
+        {
           Turnus t = (Turnus) item.getData();
           if (t.isInitial())
           {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/TurnusEditDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/TurnusEditDialog.java
@@ -39,7 +39,8 @@ import de.willuhn.util.I18N;
 /**
  * Turnus neu anlegen/aendern.
  */
-public class TurnusEditDialog extends AbstractDialog {
+public class TurnusEditDialog extends AbstractDialog
+{
 
 	private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
@@ -145,7 +145,8 @@ public class UmsatzTypListDialog extends AbstractDialog
     // Unabhaengig von dem, was der User als Groesse eingestellt hat, bleibt das die Minimalgroesse.
     getShell().setMinimumSize(WINDOW_WIDTH,WINDOW_HEIGHT);
     
-    getShell().addDisposeListener(new DisposeListener() {
+    getShell().addDisposeListener(new DisposeListener()
+    {
       
       @Override
       public void widgetDisposed(DisposeEvent e)
@@ -270,7 +271,8 @@ public class UmsatzTypListDialog extends AbstractDialog
       }
     });
     
-    this.table.addSelectionListener(new Listener() {
+    this.table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         getApplyButton().setEnabled(event.data != null);

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypNewDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypNewDialog.java
@@ -60,7 +60,8 @@ public class UmsatzTypNewDialog extends AbstractDialog
     group.addLabelPair("", getCheck());
     
     ButtonArea buttons = new ButtonArea(parent,2);
-    buttons.addButton(i18n.tr("Übernehmen"),new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try
@@ -85,7 +86,8 @@ public class UmsatzTypNewDialog extends AbstractDialog
         }
       }
     },null,true);
-    buttons.addButton(i18n.tr("Abbrechen"),new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/VerwendungszweckDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/VerwendungszweckDialog.java
@@ -100,7 +100,8 @@ public class VerwendungszweckDialog extends AbstractDialog
     this.ewz.paint(container.getComposite());
 
     ButtonArea buttons = new ButtonArea();
-    Button apply = new Button(i18n.tr("Übernehmen"),new Action() {
+    Button apply = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try
@@ -118,7 +119,8 @@ public class VerwendungszweckDialog extends AbstractDialog
     apply.setEnabled(!this.readOnly);
     
     buttons.addButton(apply);
-    buttons.addButton(i18n.tr("Abbrechen"),new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/WalletDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/WalletDialog.java
@@ -81,7 +81,8 @@ public class WalletDialog extends AbstractDialog
     table.paint(parent);
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Schlieﬂen"),new Action() {
+    buttons.addButton(i18n.tr("Schlieﬂen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         close();

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
@@ -60,7 +60,8 @@ public class ExportAddSumRowExtension implements Extension
     
     final CheckboxInput check = new CheckboxInput(initial);
     check.setName(i18n.tr("Summe-Zeile am Ende der Datei anfügen"));
-    check.addListener(new Listener() {
+    check.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         Boolean value = (Boolean) check.getValue();
@@ -78,7 +79,8 @@ public class ExportAddSumRowExtension implements Extension
     try
     {
       final Input format = e.getExporterList();
-      Listener l = new Listener() {
+      Listener l = new Listener()
+      {
         
         @Override
         public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportSaldoExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportSaldoExtension.java
@@ -60,7 +60,8 @@ public class ExportSaldoExtension implements Extension
     
     final CheckboxInput check = new CheckboxInput(initial);
     check.setName(i18n.tr("Spalte \"Saldo\" in der Datei anzeigen"));
-    check.addListener(new Listener() {
+    check.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         Boolean value = (Boolean) check.getValue();
@@ -78,7 +79,8 @@ public class ExportSaldoExtension implements Extension
     try
     {
       final Input format = e.getExporterList();
-      Listener l = new Listener() {
+      Listener l = new Listener()
+      {
         
         @Override
         public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/filter/KontoFilter.java
+++ b/src/de/willuhn/jameica/hbci/gui/filter/KontoFilter.java
@@ -163,7 +163,8 @@ public abstract class KontoFilter implements Filter<Konto>
    */
   public final static KontoFilter SEARCH(final String text, final Integer ignoreFlags, final Integer accountType)
   {
-    return new KontoFilter() {
+    return new KontoFilter()
+    {
       @Override
       public boolean accept(Konto konto) throws RemoteException
       {
@@ -225,7 +226,8 @@ public abstract class KontoFilter implements Filter<Konto>
    */
   public static KontoFilter createForeign(final Class<? extends SynchronizeJob> type)
   {
-    return new KontoFilter() {
+    return new KontoFilter()
+    {
       
       /**
        * @see de.willuhn.jameica.hbci.gui.filter.KontoFilter#accept(de.willuhn.jameica.hbci.rmi.Konto)

--- a/src/de/willuhn/jameica/hbci/gui/input/AbstractDateInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/AbstractDateInput.java
@@ -58,7 +58,8 @@ public abstract class AbstractDateInput extends DateInput
     this.param = parameter != null ? parameter : "date";
     
     // Listener zur Ueberwachung der Aenderungen
-    this.addListener(new Listener() {
+    this.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         store();

--- a/src/de/willuhn/jameica/hbci/gui/input/InputCompat.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/InputCompat.java
@@ -17,7 +17,8 @@ public final class InputCompat
    * @return true wenn der Wert mindestens eines Inputs sich seit dem letzten Aufruf von hasChanged()
    *              der Inputs geaendert hat.
    */
-  public static boolean valueHasChanged(boolean hasChanged, Input... inputs) {
+  public static boolean valueHasChanged(boolean hasChanged, Input... inputs)
+  {
     // Hier auch: Siehe unten: Keine Optimierung erlaubt. Erst muss "valueHasChanged" fuer alle Inputs durchlaufen werden
     return valueHasChanged(inputs) || hasChanged;
   }

--- a/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
@@ -189,7 +189,8 @@ public class KontoInput extends SelectInput
     this.control = super.getControl();
 
     Application.getMessagingFactory().registerMessageConsumer(this.mc);
-    this.control.addDisposeListener(new DisposeListener() {
+    this.control.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -356,9 +357,11 @@ public class KontoInput extends SelectInput
     /**
      * @see org.eclipse.swt.widgets.Listener#handleEvent(org.eclipse.swt.widgets.Event)
      */
-    public void handleEvent(Event event) {
+    public void handleEvent(Event event)
+    {
 
-      try {
+      try
+      {
         Object o = getValue();
         if (o == null || !(o instanceof Konto))
         {
@@ -408,7 +411,8 @@ public class KontoInput extends SelectInput
 
       final Konto konto = (Konto) o;
 
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           // Checken, ob wir das Konto in der Liste haben. Wenn ja, aktualisieren

--- a/src/de/willuhn/jameica/hbci/gui/input/PurposeCodeInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/PurposeCodeInput.java
@@ -39,7 +39,8 @@ public class PurposeCodeInput extends SelectInput
     this.setEditable(true); // Man kann auch selbst Werte eingeben
     this.setComment("");
     
-    final Listener l = new Listener() {
+    final Listener l = new Listener()
+    {
       @Override
       public void handleEvent(Event event)
       {

--- a/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
@@ -92,7 +92,8 @@ public class RangeInput extends SelectInput
     // ja nicht die Eingaben des Users wieder ueberschreiben
     if (from != null || to != null)
     {
-      final Listener l = new Listener() {
+      final Listener l = new Listener()
+      {
         @Override
         public void handleEvent(Event event)
         {

--- a/src/de/willuhn/jameica/hbci/gui/input/ReminderIntervalInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/ReminderIntervalInput.java
@@ -78,7 +78,8 @@ public class ReminderIntervalInput implements Input
     {
       this.input = new LinkInput(i18n.tr("von dieser <a>Vorlage</a>"));
       this.input.setName(i18n.tr("Wiederholung"));
-      this.input.addListener(new Listener() {
+      this.input.addListener(new Listener()
+      {
         public void handleEvent(Event event)
         {
           try
@@ -131,7 +132,8 @@ public class ReminderIntervalInput implements Input
     ((DialogInput)this.input).disableClientControl(); // Freitext-Eingabe gibts nicht.
 
     this.dialog = new ReminderIntervalDialog(ri,termin,end,ReminderIntervalDialog.POSITION_CENTER);
-    this.dialog.addCloseListener(new Listener() {
+    this.dialog.addCloseListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         if (event.detail == SWT.CANCEL)
@@ -147,7 +149,8 @@ public class ReminderIntervalInput implements Input
     // sofort - ohne Klick auf Speichern
     if (this.order.ausgefuehrt())
     {
-      this.input.addListener(new Listener() {
+      this.input.addListener(new Listener()
+      {
         public void handleEvent(Event event)
         {
           try
@@ -272,7 +275,8 @@ public class ReminderIntervalInput implements Input
     final MessageConsumer mc = new DateChangedConsumer();
     final MessagingQueue queue = Application.getMessagingFactory().getMessagingQueue(TerminInput.QUEUE_TERMIN_CHANGED);
     queue.registerMessageConsumer(mc);
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         queue.unRegisterMessageConsumer(mc);

--- a/src/de/willuhn/jameica/hbci/gui/input/UmsatzDaysInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/UmsatzDaysInput.java
@@ -64,7 +64,8 @@ public class UmsatzDaysInput extends ScaleInput
       return c;
     
     this.c = super.getControl();
-    this.c.addDisposeListener(new DisposeListener() {
+    this.c.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         settings.setAttribute(getToken(),(Integer) getValue());

--- a/src/de/willuhn/jameica/hbci/gui/input/UmsatzTypInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/UmsatzTypInput.java
@@ -99,7 +99,8 @@ public class UmsatzTypInput extends SelectInput
     this.setPleaseChoose(i18n.tr("<Keine Kategorie>"));
     
     // Checken, ob wir ueberhaupt irgendwelche Kategorien mit Kommentaren haben
-    this.haveComments = Settings.getDBService().execute("select count(id) from umsatztyp where kommentar is not null and kommentar != ''", null, new ResultSetExtractor() {
+    this.haveComments = Settings.getDBService().execute("select count(id) from umsatztyp where kommentar is not null and kommentar != ''", null, new ResultSetExtractor()
+    {
       
       @Override
       public Object extract(ResultSet rs) throws RemoteException, SQLException
@@ -111,7 +112,8 @@ public class UmsatzTypInput extends SelectInput
     refreshComment();
     
     // Kommentar aktualisieren
-    this.addListener(new Listener() {
+    this.addListener(new Listener()
+    {
     
       public void handleEvent(Event event)
       {

--- a/src/de/willuhn/jameica/hbci/gui/menus/AuslandsUeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/AuslandsUeberweisungList.java
@@ -56,7 +56,8 @@ public class AuslandsUeberweisungList extends ContextMenu
     addItem(new NotActiveSingleMenuItem(i18n.tr("Jetzt ausführen..."), new AuslandsUeberweisungExecute(),"emblem-important.png"));
     addItem(new NotActiveMultiMenuItem(i18n.tr("Als \"ausgeführt\" markieren..."), new TerminableMarkExecuted(),"emblem-default.png"));
     addItem(ContextMenuItem.SEPARATOR);
-    addItem(new CheckedContextMenuItem(i18n.tr("Drucken..."),new Action() {
+    addItem(new CheckedContextMenuItem(i18n.tr("Drucken..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new Print().handleAction(new PrintSupportAuslandsUeberweisungList(context));

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractFromToList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractFromToList.java
@@ -83,8 +83,10 @@ public abstract class AbstractFromToList extends TablePart implements Part
     
     this.buttons = new ButtonArea();
     
-    this.listener = new Listener() {
-      public void handleEvent(Event event) {
+    this.listener = new Listener()
+    {
+      public void handleEvent(Event event)
+      {
         // Wenn das event "null" ist, kann es nicht
         // von SWT ausgeloest worden sein sondern
         // manuell von uns. In dem Fall machen wir ein

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractSammelTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractSammelTransferList.java
@@ -78,8 +78,10 @@ public abstract class AbstractSammelTransferList extends AbstractFromToList
     BeanService service = Application.getBootLoader().getBootable(BeanService.class);
     final ReminderStorageProvider provider = service.get(ReminderStorageProviderHibiscus.class);
 
-    setFormatter(new TableFormatter() {
-      public void format(TableItem item) {
+    setFormatter(new TableFormatter()
+    {
+      public void format(TableItem item)
+      {
         SammelTransfer l = (SammelTransfer) item.getData();
         if (l == null)
           return;
@@ -203,7 +205,8 @@ public abstract class AbstractSammelTransferList extends AbstractFromToList
    */
   public synchronized void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -260,7 +263,8 @@ public abstract class AbstractSammelTransferList extends AbstractFromToList
 
       if (message instanceof ObjectChangedMessage)
       {
-        GUI.startSync(new Runnable() {
+        GUI.startSync(new Runnable()
+        {
           public void run()
           {
             try

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractSepaSammelTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractSepaSammelTransferList.java
@@ -83,8 +83,10 @@ public abstract class AbstractSepaSammelTransferList extends AbstractFromToList
     
     final CurrencyFormatter f = new CurrencyFormatter(HBCIProperties.CURRENCY_DEFAULT_DE,HBCI.DECIMALFORMAT);
     
-    setFormatter(new TableFormatter() {
-      public void format(TableItem item) {
+    setFormatter(new TableFormatter()
+    {
+      public void format(TableItem item)
+      {
         SepaSammelTransfer l = (SepaSammelTransfer) item.getData();
         if (l == null)
           return;
@@ -243,7 +245,8 @@ public abstract class AbstractSepaSammelTransferList extends AbstractFromToList
    */
   public synchronized void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -270,7 +273,8 @@ public abstract class AbstractSepaSammelTransferList extends AbstractFromToList
       if (listener != null)
         this.insertDelay = new DelayedListener(listener);
       
-      this.updateDelay = new DelayedListener(new Listener() {
+      this.updateDelay = new DelayedListener(new Listener()
+      {
         
         @Override
         public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractTransferList.java
@@ -79,8 +79,10 @@ public abstract class AbstractTransferList extends AbstractFromToList
 
     final boolean bold = Settings.getBoldValues();
     
-    setFormatter(new TableFormatter() {
-      public void format(TableItem item) {
+    setFormatter(new TableFormatter()
+    {
+      public void format(TableItem item)
+      {
         Terminable l = (Terminable) item.getData();
         if (l == null)
           return;
@@ -165,7 +167,8 @@ public abstract class AbstractTransferList extends AbstractFromToList
     this.pending = new CheckboxInput(settings.getBoolean("transferlist.filter.pending",false));
     this.pending.setName(i18n.tr("Nur offene Aufträge anzeigen"));
     this.pending.addListener(this.listener);
-    this.pending.addListener(new Listener() {
+    this.pending.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         settings.setAttribute("transferlist.filter.pending",((Boolean)pending.getValue()).booleanValue());
@@ -276,7 +279,8 @@ public abstract class AbstractTransferList extends AbstractFromToList
       
       if (message instanceof ObjectChangedMessage)
       {
-        GUI.startSync(new Runnable() {
+        GUI.startSync(new Runnable()
+        {
           public void run()
           {
             try

--- a/src/de/willuhn/jameica/hbci/gui/parts/EmpfaengerList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/EmpfaengerList.java
@@ -114,7 +114,8 @@ public class EmpfaengerList extends TablePart implements Part
 
     addColumn(i18n.tr("Name"),"name");
     addColumn(i18n.tr("Kontonummer"),"kontonummer");
-    addColumn(i18n.tr("Bankleitzahl"),"blz", new Formatter() {
+    addColumn(i18n.tr("Bankleitzahl"), "blz", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null)
@@ -219,7 +220,8 @@ public class EmpfaengerList extends TablePart implements Part
         // Es existieren mehrere. Wir zeigen eine Auswahl an
         final SelectInput select = new SelectInput(service.getAddressbooks(),null);
         select.setAttribute("name");
-        select.addListener(new Listener() {
+        select.addListener(new Listener()
+        {
           public void handleEvent(Event event)
           {
             Object value = select.getValue();
@@ -255,7 +257,8 @@ public class EmpfaengerList extends TablePart implements Part
     }
     
     // Damit wir den MessageConsumer beim Schliessen wieder entfernen
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mcImport);

--- a/src/de/willuhn/jameica/hbci/gui/parts/ErweiterteVerwendungszwecke.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/ErweiterteVerwendungszwecke.java
@@ -98,7 +98,8 @@ public class ErweiterteVerwendungszwecke implements Part
 
     ////////////////////////////////////////////////////////////////////////////
     // Button zum Hinzufuegen von weiteren Zeilen
-    this.add = new Button("  +  ",new Action() {
+    this.add = new Button("  +  ", new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         int size = fields.size();

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoList.java
@@ -104,7 +104,8 @@ public class KontoList extends TablePart implements Part, Extendable
     this.addFeature(new FeatureSummary());
 
     addColumn(i18n.tr("Kontonummer"),"kontonummer",null,false,Column.ALIGN_RIGHT);
-    addColumn(i18n.tr("Bankleitzahl"),"blz", new Formatter() {
+    addColumn(i18n.tr("Bankleitzahl"), "blz", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null)
@@ -127,7 +128,8 @@ public class KontoList extends TablePart implements Part, Extendable
     addColumn(i18n.tr("Bezeichnung"),"bezeichnung");
     addColumn(i18n.tr("Gruppe"),"kategorie");
     addColumn(i18n.tr("Notiz"),"kommentar");
-    addColumn(i18n.tr("Verfahren"),"passport_class", new Formatter() {
+    addColumn(i18n.tr("Verfahren"), "passport_class", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null || !(o instanceof String))
@@ -158,7 +160,8 @@ public class KontoList extends TablePart implements Part, Extendable
       {
         Konto k = (Konto) item.getData();
         final int saldocolumn = 6;
-        try {
+        try
+        {
           double saldo = k.getSaldo();
           if ((saldo == 0 && k.getSaldoDatum() == null) || Double.isNaN(saldo))
             item.setText(saldocolumn,"");
@@ -337,7 +340,8 @@ public class KontoList extends TablePart implements Part, Extendable
    */
   private void reload()
   {
-    GUI.startSync(new Runnable() {
+    GUI.startSync(new Runnable()
+    {
       
       @Override
       public void run()
@@ -477,7 +481,8 @@ public class KontoList extends TablePart implements Part, Extendable
       if (o == null || !(o instanceof Konto))
         return;
 
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -135,7 +135,8 @@ public class KontoauszugList extends UmsatzList
     // bei Ausloesungen ueber SWT-Events verzoegern wir
     // das Reload, um schnell aufeinanderfolgende Updates
     // zu buendeln.
-    this.listener = new DelayedListener(700,new Listener() {
+    this.listener = new DelayedListener(700, new Listener()
+    {
       public void handleEvent(Event event)
       {
         handleReload(false);
@@ -203,7 +204,8 @@ public class KontoauszugList extends UmsatzList
     // Wir merken uns das aktive Tab.
     Integer tab = (Integer) cache.get("tab");
     if (tab != null) folder.setSelection(tab);
-    folder.addDisposeListener(new DisposeListener() {
+    folder.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         cache.put("tab",folder.getSelectionIndex());
@@ -252,7 +254,8 @@ public class KontoauszugList extends UmsatzList
     
     buttons.paint(parent);
     
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         disposed = true;
@@ -611,15 +614,35 @@ public class KontoauszugList extends UmsatzList
     if (end != null)   umsaetze.addFilter("datum <= ?", new java.sql.Date(DateUtil.endOfDay(end).getTime()));
     /////////////////////////////////////////////////////////////////
     // Gegenkonto
-    if (gkBLZ    != null && gkBLZ.length() > 0)    {umsaetze.addFilter("LOWER(empfaenger_blz) like ?","%" + gkBLZ.toLowerCase() + "%");this.filterCount++;}
-    if (gkNummer != null && gkNummer.length() > 0) {umsaetze.addFilter("LOWER(empfaenger_konto) like ?","%" + gkNummer.toLowerCase() + "%");this.filterCount++;}
-    if (gkName   != null && gkName.length() > 0)   {umsaetze.addFilter("LOWER(empfaenger_name) like ?","%" + gkName.toLowerCase() + "%");this.filterCount++;}
+    if (gkBLZ != null && gkBLZ.length() > 0)
+    {
+      umsaetze.addFilter("LOWER(empfaenger_blz) like ?", "%" + gkBLZ.toLowerCase() + "%");
+      this.filterCount++;
+    }
+    if (gkNummer != null && gkNummer.length() > 0)
+    {
+      umsaetze.addFilter("LOWER(empfaenger_konto) like ?", "%" + gkNummer.toLowerCase() + "%");
+      this.filterCount++;
+    }
+    if (gkName != null && gkName.length() > 0)
+    {
+      umsaetze.addFilter("LOWER(empfaenger_name) like ?", "%" + gkName.toLowerCase() + "%");
+      this.filterCount++;
+    }
     /////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////
     // Konto oder Kontogruppe
-    if (o != null && (o instanceof Konto))         {umsaetze.addFilter("konto_id = " + ((Konto) o).getID());this.filterCount++;}
-    else if (o != null && (o instanceof String))   {umsaetze.addFilter("konto_id in (select id from konto where kategorie = ?)", (String) o);this.filterCount++;}
+    if (o != null && (o instanceof Konto))
+    {
+      umsaetze.addFilter("konto_id = " + ((Konto) o).getID());
+      this.filterCount++;
+    }
+    else if (o != null && (o instanceof String))
+    {
+      umsaetze.addFilter("konto_id in (select id from konto where kategorie = ?)", (String) o);
+      this.filterCount++;
+    }
     /////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////
@@ -829,7 +852,8 @@ public class KontoauszugList extends UmsatzList
     if (!force && !hasChanged())
       return;
     
-    GUI.getDisplay().asyncExec(new Runnable() {
+    GUI.getDisplay().asyncExec(new Runnable()
+    {
       
       @Override
       public void run()
@@ -1065,7 +1089,8 @@ public class KontoauszugList extends UmsatzList
       String s = (String) cache.get("kontoauszug.list.search");
       this.setValue(s);
       this.hasChanged(); // Einmal initial triggern, damit bereits die erste Text-Eingabe als Aenderung erkannt wird
-      this.text.addKeyListener(new KeyAdapter() {
+      this.text.addKeyListener(new KeyAdapter()
+      {
         /**
          * @see org.eclipse.swt.events.KeyAdapter#keyReleased(org.eclipse.swt.events.KeyEvent)
          */

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugPdfList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugPdfList.java
@@ -96,8 +96,10 @@ public class KontoauszugPdfList extends TablePart
 
     this.addFeature(new FeatureShortcut());
 
-    this.listener = new Listener() {
-      public void handleEvent(Event event) {
+    this.listener = new Listener()
+    {
+      public void handleEvent(Event event)
+      {
         // Wenn das event "null" ist, kann es nicht von SWT ausgeloest worden sein
         // sondern manuell von uns. In dem Fall machen wir ein forciertes Update
         // - ohne zu beruecksichtigen, ob in den Eingabe-Feldern wirklich was
@@ -106,7 +108,8 @@ public class KontoauszugPdfList extends TablePart
       }
     };
 
-    this.setFormatter(new TableFormatter() {
+    this.setFormatter(new TableFormatter()
+    {
       
       @Override
       public void format(TableItem item)
@@ -151,7 +154,8 @@ public class KontoauszugPdfList extends TablePart
 
     setContextMenu(new de.willuhn.jameica.hbci.gui.menus.KontoauszugPdfList());
     
-    this.addChangeListener(new TableChangeListener() {
+    this.addChangeListener(new TableChangeListener()
+    {
       public void itemChanged(Object object, String attribute, String newValue) throws ApplicationException
       {
         try
@@ -218,7 +222,8 @@ public class KontoauszugPdfList extends TablePart
    
     this.handleReload(true);
     
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -448,7 +453,8 @@ public class KontoauszugPdfList extends TablePart
       if (!(o instanceof Kontoauszug))
         return;
 
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/NachrichtList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/NachrichtList.java
@@ -87,7 +87,8 @@ public class NachrichtList extends TablePart implements Part
         return i18n.tr("{0} [BLZ: {1}]", new String[] {HBCIProperties.getNameForBank(blz),blz});
       }
     });
-    addColumn(i18n.tr("Nachricht"),"nachricht", new Formatter() {
+    addColumn(i18n.tr("Nachricht"), "nachricht", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null)

--- a/src/de/willuhn/jameica/hbci/gui/parts/PanelButtonNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PanelButtonNew.java
@@ -27,7 +27,8 @@ public class PanelButtonNew extends PanelButton
    */
   public PanelButtonNew(final Class type)
   {
-    super("list-add.png", new Action() {
+    super("list-add.png", new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new Open().handleAction(type);

--- a/src/de/willuhn/jameica/hbci/gui/parts/PassportTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PassportTree.java
@@ -53,7 +53,8 @@ public class PassportTree extends TreePart
    */
   public PassportTree() throws RemoteException
   {
-    super(init(),new Action() {
+    super(init(), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (context == null || (context instanceof Object[]))
@@ -68,7 +69,8 @@ public class PassportTree extends TreePart
     });
     this.addColumn(i18n.tr("Bezeichnung"),"name");
     
-    this.setFormatter(new TreeFormatter() {
+    this.setFormatter(new TreeFormatter()
+    {
       public void format(TreeItem item)
       {
         Object data = item.getData();
@@ -91,7 +93,8 @@ public class PassportTree extends TreePart
     this.setMulti(false);
     
     ContextMenu menu = new ContextMenu();
-    menu.addItem(new CheckedSingleContextMenuItem(i18n.tr("Öffnen"),new Action() {
+    menu.addItem(new CheckedSingleContextMenuItem(i18n.tr("Öffnen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (context == null || !(context instanceof ConfigObject))
@@ -106,7 +109,8 @@ public class PassportTree extends TreePart
         return (o instanceof ConfigObject) && super.isEnabledFor(o);
       }
     });
-    menu.addItem(new ContextMenuItem(i18n.tr("Neuer Bank-Zugang..."),new Action() {
+    menu.addItem(new ContextMenuItem(i18n.tr("Neuer Bank-Zugang..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         Object o = getSelection();
@@ -116,7 +120,8 @@ public class PassportTree extends TreePart
     },"list-add.png"));
     
     menu.addItem(ContextMenuItem.SEPARATOR);
-    menu.addItem(new CheckedSingleContextMenuItem(i18n.tr("Löschen"),new Action() {
+    menu.addItem(new CheckedSingleContextMenuItem(i18n.tr("Löschen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (context == null || !(context instanceof ConfigObject))

--- a/src/de/willuhn/jameica/hbci/gui/parts/PinPad.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PinPad.java
@@ -86,7 +86,8 @@ public class PinPad implements Part
     b.setLayoutData(gd);
     b.addSelectionListener(new SelectionAdapter()
     {
-      public void widgetSelected(SelectionEvent e) {
+      public void widgetSelected(SelectionEvent e)
+      {
         input.setValue("");
       }
     });
@@ -108,7 +109,8 @@ public class PinPad implements Part
     b.setLayoutData(gd);
     b.addSelectionListener(new SelectionAdapter()
     {
-      public void widgetSelected(SelectionEvent e) {
+      public void widgetSelected(SelectionEvent e)
+      {
         String curr = (String) input.getValue();
         if (curr == null)
           curr = "";

--- a/src/de/willuhn/jameica/hbci/gui/parts/RangeList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/RangeList.java
@@ -50,7 +50,8 @@ public class RangeList extends TablePart
     this.category = category;
 
     final ContextMenu ctx = new ContextMenu();
-    ctx.addItem(new ContextMenuItem(i18n.tr("Zurücksetzen"), new Action() {
+    ctx.addItem(new ContextMenuItem(i18n.tr("Zurücksetzen"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException

--- a/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
@@ -212,7 +212,8 @@ public class SaldoChart implements Part
     this.onlyActive = new CheckboxInput(settings.getBoolean("auswertungen.saldochart.filter.active",false));
     this.onlyActive.setName(i18n.tr("Nur aktive Konten"));
     this.onlyActive.addListener(this.reloadListener);
-    this.onlyActive.addListener(new org.eclipse.swt.widgets.Listener() {
+    this.onlyActive.addListener(new org.eclipse.swt.widgets.Listener()
+    {
 
       @Override
       public void handleEvent(Event event)
@@ -309,7 +310,8 @@ public class SaldoChart implements Part
         long d = start * 24l * 60l * 60l * 1000l;
         date = DateUtil.startOfDay(new Date(System.currentTimeMillis() - d));
       }
-    } else if (getStart().getValue() != null)
+    }
+    else if (getStart().getValue() != null)
     {
       date = (Date) getStart().getValue();
     }
@@ -330,7 +332,8 @@ public class SaldoChart implements Part
     if (tiny)
     {
       return null;
-    } else
+    }
+    else
     {
       return (Date) getEnd().getValue();
     }

--- a/src/de/willuhn/jameica/hbci/gui/parts/SammelTransferBuchungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SammelTransferBuchungList.java
@@ -58,7 +58,8 @@ public class SammelTransferBuchungList extends TablePart
   public SammelTransferBuchungList(final GenericIterator list, Action action)
   {
     super(list,action);
-    addColumn(i18n.tr("Auftrag"),"this", new Formatter() {
+    addColumn(i18n.tr("Auftrag"), "this", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null || !(o instanceof SammelTransferBuchung))
@@ -82,7 +83,8 @@ public class SammelTransferBuchungList extends TablePart
     addColumn(i18n.tr("Kontoinhaber"),"gegenkonto_name");
     addColumn(i18n.tr("Kontonummer"),"gegenkonto_nr");
     addColumn(new BlzColumn("gegenkonto_blz",i18n.tr("Bankleitzahl")));
-    addColumn(i18n.tr("Betrag"),"this",new Formatter() {
+    addColumn(i18n.tr("Betrag"), "this", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null || !(o instanceof SammelTransferBuchung))
@@ -105,16 +107,20 @@ public class SammelTransferBuchungList extends TablePart
     });
     addColumn(i18n.tr("Warnungen"),"warnung");
 
-    setFormatter(new TableFormatter() {
-      public void format(TableItem item) {
-        try {
+    setFormatter(new TableFormatter()
+    {
+      public void format(TableItem item)
+      {
+        try
+        {
           SammelTransferBuchung b = (SammelTransferBuchung) item.getData();
           if (StringUtils.trimToNull(b.getWarnung()) != null)
             item.setForeground(Color.ERROR.getSWTColor());
           else if (b.getSammelTransfer().ausgefuehrt())
             item.setForeground(Color.COMMENT.getSWTColor());
         }
-        catch (RemoteException e) {
+        catch (RemoteException e)
+        {
           Logger.error("unable to read sammeltransfer",e);
         }
       }
@@ -135,7 +141,8 @@ public class SammelTransferBuchungList extends TablePart
     addColumn(i18n.tr("Verwendungszweck"),"zweck");
     addColumn(i18n.tr("Kontoinhaber"),"gegenkonto_name");
     addColumn(i18n.tr("Kontonummer"),"gegenkonto_nr");
-    addColumn(i18n.tr("Bankleitzahl"),"gegenkonto_blz", new Formatter() {
+    addColumn(i18n.tr("Bankleitzahl"), "gegenkonto_blz", new Formatter()
+    {
       /**
        * @see de.willuhn.jameica.gui.formatter.Formatter#format(java.lang.Object)
        */
@@ -156,16 +163,22 @@ public class SammelTransferBuchungList extends TablePart
     addColumn(i18n.tr("Betrag"),"betrag",new CurrencyFormatter(curr,HBCI.DECIMALFORMAT));
     addColumn(i18n.tr("Warnungen"),"warnung");
 
-    setFormatter(new TableFormatter() {
-      public void format(TableItem item) {
-        try {
+    setFormatter(new TableFormatter()
+    {
+      public void format(TableItem item)
+      {
+        try
+        {
           SammelTransferBuchung b = (SammelTransferBuchung) item.getData();
           if (StringUtils.trimToNull(b.getWarnung()) != null)
             item.setForeground(Color.ERROR.getSWTColor());
           else if (a.ausgefuehrt())
             item.setForeground(Color.COMMENT.getSWTColor());
         }
-        catch (RemoteException e) { /*ignore */}
+        catch (RemoteException e)
+        {
+          /* ignore */
+        }
       }
     });
     
@@ -184,7 +197,8 @@ public class SammelTransferBuchungList extends TablePart
    */
   public synchronized void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -226,7 +240,8 @@ public class SammelTransferBuchungList extends TablePart
       if (o == null || !(o instanceof SammelTransferBuchung))
         return;
       
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/SepaDauerauftragList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SepaDauerauftragList.java
@@ -127,7 +127,8 @@ public class SepaDauerauftragList extends TablePart implements Part
    */
   public synchronized void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -169,7 +170,8 @@ public class SepaDauerauftragList extends TablePart implements Part
       if (!(o instanceof SepaDauerauftrag))
         return;
 
-      GUI.startSync(new Runnable() {
+      GUI.startSync(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/SepaSammelTransferBuchungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SepaSammelTransferBuchungList.java
@@ -74,7 +74,8 @@ public class SepaSammelTransferBuchungList extends TablePart
   {
     super(list,action);
     
-    addColumn(i18n.tr("Auftrag"),"this", new Formatter() {
+    addColumn(i18n.tr("Auftrag"), "this", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null || !(o instanceof SepaSammelTransferBuchung))
@@ -102,9 +103,12 @@ public class SepaSammelTransferBuchungList extends TablePart
 
     final boolean bold = Settings.getBoldValues();
     
-    setFormatter(new TableFormatter() {
-      public void format(TableItem item) {
-        try {
+    setFormatter(new TableFormatter()
+    {
+      public void format(TableItem item)
+      {
+        try
+        {
           SepaSammelTransferBuchung b = (SepaSammelTransferBuchung) item.getData();
           if (b.getSammelTransfer().ausgefuehrt())
             item.setForeground(Color.COMMENT.getSWTColor());
@@ -112,7 +116,8 @@ public class SepaSammelTransferBuchungList extends TablePart
           if (bold)
             item.setFont(5,Font.BOLD.getSWTFont());
         }
-        catch (RemoteException e) {
+        catch (RemoteException e)
+        {
           Logger.error("unable to read sepa sammeltransfer",e);
         }
       }
@@ -135,7 +140,8 @@ public class SepaSammelTransferBuchungList extends TablePart
    */
   public synchronized void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -218,7 +224,8 @@ public class SepaSammelTransferBuchungList extends TablePart
       if (o == null || !(o instanceof SepaSammelTransferBuchung))
         return;
       
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -158,7 +158,8 @@ public class SparQuote implements Part
     this.tagAuswahl.setComment(i18n.tr(". Tag des Monats"));
     this.tagAuswahl.setName(i18n.tr("Stichtag"));
     this.tagAuswahl.setValue(settings.getInt("stichtag",1));
-    this.tagAuswahl.addListener(new Listener() {
+    this.tagAuswahl.addListener(new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -185,7 +186,8 @@ public class SparQuote implements Part
     this.monatAuswahl.setComment(i18n.tr("Anzahl der Monate pro Periode"));
     this.monatAuswahl.setName(i18n.tr("Monate"));
     this.monatAuswahl.setValue(settings.getInt("monate",1));
-    this.monatAuswahl.addListener(new Listener() {
+    this.monatAuswahl.addListener(new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -318,7 +320,8 @@ public class SparQuote implements Part
         }
       }
     },null,false,"document-save.png");
-    topButtons.addButton(i18n.tr("Aktualisieren"), new Action() {
+    topButtons.addButton(i18n.tr("Aktualisieren"), new Action()
+    {
 
       public void handleAction(Object context) throws ApplicationException
       {
@@ -337,7 +340,8 @@ public class SparQuote implements Part
     this.table.setRememberColWidths(true);
     
     final boolean bold = de.willuhn.jameica.hbci.Settings.getBoldValues();
-    this.table.setFormatter(new TableFormatter() {
+    this.table.setFormatter(new TableFormatter()
+    {
       public void format(TableItem item)
       {
         if (item == null || item.getData() == null)
@@ -486,7 +490,8 @@ public class SparQuote implements Part
       {
         Logger.debug("no date found for umsatz, skipping record");
         continue;
-      } else if (end != null && date.after(end))
+      }
+      else if (end != null && date.after(end))
       {
         //keine Umsätze nach dem gwünschten Zeitraum verarbeiten
         break;

--- a/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
@@ -82,7 +82,8 @@ public class SynchronizeList extends TablePart
     this.setMulti(true);
 
     // BUGZILLA 583
-    this.setFormatter(new TableFormatter() {
+    this.setFormatter(new TableFormatter()
+    {
       public void format(TableItem item)
       {
         try
@@ -102,7 +103,8 @@ public class SynchronizeList extends TablePart
     });
     
     final ContextMenu menu = new ContextMenu();
-    menu.addItem(new CheckedContextMenuItem(i18n.tr("Aktivieren"),new Action() {
+    menu.addItem(new CheckedContextMenuItem(i18n.tr("Aktivieren"), new Action()
+    {
       
       @Override
       public void handleAction(Object context) throws ApplicationException
@@ -192,7 +194,8 @@ public class SynchronizeList extends TablePart
     
     Application.getMessagingFactory().getMessagingQueue(SynchronizeBackend.QUEUE_STATUS).registerMessageConsumer(this.mcSync);
     Application.getMessagingFactory().getMessagingQueue("jameica.gui.view.unbind").registerMessageConsumer(this.mcCache);
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().getMessagingQueue(SynchronizeBackend.QUEUE_STATUS).unRegisterMessageConsumer(mcSync);

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
@@ -132,7 +132,8 @@ public class UmsatzList extends TablePart implements Extendable
         Umsatz u = (Umsatz) item.getData();
         if (u == null) return;
 
-        try {
+        try
+        {
           item.setFont(NeueUmsaetze.isNew(u) ? Font.BOLD.getSWTFont() : Font.DEFAULT.getSWTFont());
 
           final Date datum = u.getDatum();
@@ -213,7 +214,8 @@ public class UmsatzList extends TablePart implements Extendable
       }
     });
     
-    this.addChangeListener(new TableChangeListener() {
+    this.addChangeListener(new TableChangeListener()
+    {
       public void itemChanged(Object object, String attribute, String newValue) throws ApplicationException
       {
         try
@@ -310,7 +312,8 @@ public class UmsatzList extends TablePart implements Extendable
   {
     setContextMenu(new de.willuhn.jameica.hbci.gui.menus.UmsatzList(this.konto));
 
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         disposed = true;
@@ -337,7 +340,8 @@ public class UmsatzList extends TablePart implements Extendable
     {
       Container c = new SimpleContainer(parent);
       this.days = new UmsatzDaysInput();
-      this.days.addListener(new DelayedListener(300, new Listener() {
+      this.days.addListener(new DelayedListener(300, new Listener()
+      {
         public void handleEvent(Event event)
         {
           kl.process();
@@ -393,8 +397,7 @@ public class UmsatzList extends TablePart implements Extendable
             {
               sleep = false;
               sleep(700l);
-            }
-            while (sleep); // Wir warten ggf. nochmal
+            } while (sleep); // Wir warten ggf. nochmal
 
             // Ne, wir wurden nicht gekillt. Also machen wir uns ans Werk
             process();
@@ -607,7 +610,8 @@ public class UmsatzList extends TablePart implements Extendable
       };
     }
 
-    DelayedListener updateKontoListListener = new DelayedListener(new Listener() {
+    DelayedListener updateKontoListListener = new DelayedListener(new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -630,7 +634,8 @@ public class UmsatzList extends TablePart implements Extendable
       if (o == null || !(o instanceof Umsatz))
         return;
 
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTree.java
@@ -83,7 +83,8 @@ public class UmsatzTree extends TreePart
     
     final boolean bold = Settings.getBoldValues();
     
-    this.setFormatter(new TreeFormatter() {
+    this.setFormatter(new TreeFormatter()
+    {
     
       public void format(TreeItem item)
       {
@@ -157,7 +158,8 @@ public class UmsatzTree extends TreePart
 
     this.setContextMenu(new UmsatzList());
     
-    this.addSelectionListener(new Listener() {
+    this.addSelectionListener(new Listener()
+    {
       @Override
       public void handleEvent(org.eclipse.swt.widgets.Event event)
       {

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypList.java
@@ -65,7 +65,8 @@ public class UmsatzTypList extends TablePart implements Part
     addColumn(i18n.tr("Bezeichnung"),"name");
     addColumn(i18n.tr("Nummer"),"nummer-int"); // BUGZILLA 554
     addColumn(i18n.tr("Suchbegriff"),"pattern"); // BUGZILLA 756
-    addColumn(i18n.tr("Umsatzart"),"umsatztyp",new Formatter() {
+    addColumn(i18n.tr("Umsatzart"), "umsatztyp", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null)
@@ -137,7 +138,8 @@ public class UmsatzTypList extends TablePart implements Part
    */
   public synchronized void paint(Composite parent) throws RemoteException
   {
-    parent.addDisposeListener(new DisposeListener() {
+    parent.addDisposeListener(new DisposeListener()
+    {
       public void widgetDisposed(DisposeEvent e)
       {
         Application.getMessagingFactory().unRegisterMessageConsumer(mc);
@@ -183,7 +185,8 @@ public class UmsatzTypList extends TablePart implements Part
       if (data == null || !(data instanceof UmsatzTyp))
         return;
 
-      GUI.getDisplay().syncExec(new Runnable() {
+      GUI.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypTree.java
@@ -72,7 +72,8 @@ public class UmsatzTypTree extends TreePart
     addColumn(i18n.tr("Bezeichnung"),"name");
     addColumn(i18n.tr("Reihenfolge"),"nummer"); // BUGZILLA 554/988
     addColumn(i18n.tr("Suchbegriff"),"pattern"); // BUGZILLA 756
-    addColumn(i18n.tr("Umsatzart"),"umsatztyp",new Formatter() {
+    addColumn(i18n.tr("Umsatzart"), "umsatztyp", new Formatter()
+    {
       public String format(Object o)
       {
         if (o == null)

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypVerlauf.java
@@ -236,10 +236,12 @@ public class UmsatzTypVerlauf implements Part
     private Date chartStartDate  = null;
     private Date chartStopDate   = null;
     
-    private List<Umsatz> getRecursiveUmsaetze(UmsatzTreeNode group) {
+    private List<Umsatz> getRecursiveUmsaetze(UmsatzTreeNode group)
+    {
       List<Umsatz> result = new ArrayList<Umsatz>();
       result.addAll(group.getUmsaetze());
-      for (UmsatzTreeNode unterkategorie: group.getSubGroups()) {
+      for (UmsatzTreeNode unterkategorie : group.getSubGroups())
+      {
         result.addAll(getRecursiveUmsaetze(unterkategorie));
       }
       return result;

--- a/src/de/willuhn/jameica/hbci/gui/parts/columns/BlzColumn.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/columns/BlzColumn.java
@@ -26,7 +26,8 @@ public class BlzColumn extends Column
    */
   public BlzColumn(String id, String name)
   {
-    super(id,name,new Formatter() {
+    super(id, name, new Formatter()
+    {
       /**
        * @see de.willuhn.jameica.gui.formatter.Formatter#format(java.lang.Object)
        */

--- a/src/de/willuhn/jameica/hbci/gui/parts/columns/KontoColumn.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/columns/KontoColumn.java
@@ -32,7 +32,8 @@ public class KontoColumn extends Column
    */
   public KontoColumn()
   {
-    super("konto_id", i18n.tr("Konto"),new Formatter() {
+    super("konto_id", i18n.tr("Konto"), new Formatter()
+    {
       /**
        * @see de.willuhn.jameica.gui.formatter.Formatter#format(java.lang.Object)
        */

--- a/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
@@ -42,7 +42,8 @@ public abstract class AbstractUmsatzDetail extends AbstractView
   /**
    * @see de.willuhn.jameica.gui.AbstractView#bind()
    */
-  public void bind() throws Exception {
+  public void bind() throws Exception
+  {
 
     final UmsatzDetailControl control = getControl();
     
@@ -105,15 +106,18 @@ public abstract class AbstractUmsatzDetail extends AbstractView
 
   private void forceSaldoUpdateforReverseBooking()
   {
-    if(getCurrentObject() instanceof Umsatz){
+    if (getCurrentObject() instanceof Umsatz)
+    {
       Umsatz umsatz=(Umsatz)getCurrentObject();
       try
       {
-        if(umsatz.isNewObject() && umsatz.getKonto().hasFlag(Konto.FLAG_OFFLINE)){
+        if (umsatz.isNewObject() && umsatz.getKonto().hasFlag(Konto.FLAG_OFFLINE))
+        {
           getControl().getBetrag().getControl().forceFocus();//->Saldenberechnungslistener feuert
           getControl().getUmsatzTyp().focus();
         }
-      } catch (RemoteException e)
+      }
+      catch (RemoteException e)
       {
         //einfach ignoriere, wir wollen ja nur ein Feld vorsorglich aktualisieren
       }

--- a/src/de/willuhn/jameica/hbci/gui/views/AuslandsUeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AuslandsUeberweisungList.java
@@ -40,7 +40,8 @@ public class AuslandsUeberweisungList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.AuslandsUeberweisungList table = control.getAuslandsUeberweisungListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportAuslandsUeberweisungList(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/AuslandsUeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AuslandsUeberweisungNew.java
@@ -95,7 +95,8 @@ public class AuslandsUeberweisungNew extends AbstractView
 
 		ButtonArea buttonArea = new ButtonArea();
 		buttonArea.addButton(i18n.tr("Löschen"),new AuslandsUeberweisungDelete(),transfer,false,"user-trash-full.png");
-    buttonArea.addButton(i18n.tr("Duplizieren..."), new Action() {
+    buttonArea.addButton(i18n.tr("Duplizieren..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (control.handleStore()) // BUGZILLA 1181
@@ -103,16 +104,20 @@ public class AuslandsUeberweisungNew extends AbstractView
       }
     },null,false,"edit-copy.png");
 
-    Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
 				if (control.handleStore())
   				new AuslandsUeberweisungExecute().handleAction(transfer);
       }
     },null,false,"emblem-important.png");
     execute.setEnabled(!transfer.ausgefuehrt());
     
-    Button store = new Button(i18n.tr("&Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("&Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
       	control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/DauerauftragList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/DauerauftragList.java
@@ -45,7 +45,8 @@ public class DauerauftragList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.DauerauftragList table = control.getDauerauftragListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportDauerauftrag(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/DonateView.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/DonateView.java
@@ -86,7 +86,8 @@ public class DonateView extends AbstractView
       final String name = "Olaf Willuhn";
       
       ButtonArea buttons = new ButtonArea();
-      buttons.addButton(i18n.tr("Dauerauftrag erstellen"),new Action() {
+      buttons.addButton(i18n.tr("Dauerauftrag erstellen"), new Action()
+      {
         public void handleAction(Object context) throws ApplicationException
         {
           try
@@ -115,7 +116,8 @@ public class DonateView extends AbstractView
           }
         }
       },null,false,"emblem-special.png");
-      buttons.addButton(i18n.tr("...oder Überweisung"),new Action() {
+      buttons.addButton(i18n.tr("...oder Überweisung"), new Action()
+      {
         public void handleAction(Object context) throws ApplicationException
         {
           try

--- a/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
@@ -87,7 +87,8 @@ public class KontoNew extends AbstractView
 
     final KontoInput quickSelect = new KontoInput(k,KontoFilter.ALL);
     quickSelect.setName(i18n.tr("Konto wechseln"));
-    quickSelect.addListener(new Listener() {
+    quickSelect.addListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         try

--- a/src/de/willuhn/jameica/hbci/gui/views/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoauszugList.java
@@ -50,14 +50,16 @@ public class KontoauszugList extends AbstractView
       list.getKontoAuswahl().setValue(konto);
     
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportUmsatzList(list));
-    list.addSelectionListener(new Listener() {
+    list.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(list.getSelection() != null);
       }
     });
     
-    final PanelButton settings = new PanelButton("document-properties.png",new Action() {
+    final PanelButton settings = new PanelButton("document-properties.png", new Action()
+    {
       @Override
       public void handleAction(Object context) throws ApplicationException
       {

--- a/src/de/willuhn/jameica/hbci/gui/views/KontoauszugPdfList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoauszugPdfList.java
@@ -41,7 +41,8 @@ public class KontoauszugPdfList extends AbstractView
     
     list.paint(getParent());
     
-    PanelButton button = new PanelButton("document-properties.png",new Action() {
+    PanelButton button = new PanelButton("document-properties.png", new Action()
+    {
       @Override
       public void handleAction(Object context) throws ApplicationException
       {

--- a/src/de/willuhn/jameica/hbci/gui/views/LastschriftList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/LastschriftList.java
@@ -37,7 +37,8 @@ public class LastschriftList extends AbstractView
 
     final de.willuhn.jameica.hbci.gui.parts.LastschriftList table = control.getLastschriftListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportLastschriftList(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/LastschriftNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/LastschriftNew.java
@@ -44,7 +44,8 @@ public class LastschriftNew extends AbstractView
   /**
    * @see de.willuhn.jameica.gui.AbstractView#bind()
    */
-  public void bind() throws Exception {
+  public void bind() throws Exception
+  {
 
 		final LastschriftControl control = new LastschriftControl(this);
     this.transfer = (Lastschrift) control.getTransfer();
@@ -86,8 +87,10 @@ public class LastschriftNew extends AbstractView
 
 		ButtonArea buttonArea = new ButtonArea();
 		buttonArea.addButton(i18n.tr("Löschen"), new DBObjectDelete(),transfer,false,"user-trash-full.png");
-		Button store = new Button(i18n.tr("Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
       	control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/NachrichtDetails.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/NachrichtDetails.java
@@ -26,14 +26,16 @@ import de.willuhn.util.I18N;
 /**
  * Zeigt eine System-Nachricht an.
  */
-public class NachrichtDetails extends AbstractView {
+public class NachrichtDetails extends AbstractView
+{
 
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   /**
    * @see de.willuhn.jameica.gui.AbstractView#bind()
    */
-  public void bind() throws Exception {
+  public void bind() throws Exception
+  {
 
     NachrichtControl control = new NachrichtControl(this);
     

--- a/src/de/willuhn/jameica/hbci/gui/views/NachrichtList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/NachrichtList.java
@@ -26,7 +26,8 @@ public class NachrichtList extends AbstractView
   /**
    * @see de.willuhn.jameica.gui.AbstractView#bind()
    */
-  public void bind() throws Exception {
+  public void bind() throws Exception
+  {
 
 		GUI.getView().setTitle(i18n.tr("System-Nachrichten"));
 		

--- a/src/de/willuhn/jameica/hbci/gui/views/PassportList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/PassportList.java
@@ -47,7 +47,8 @@ public class PassportList extends AbstractView
     final PassportTree tree = control.getPassports();
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(new Button(i18n.tr("Neuer Bank-Zugang..."),new Action() {
+    buttons.addButton(new Button(i18n.tr("Neuer Bank-Zugang..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         // new de.willuhn.jameica.hbci.gui.action.AccountNew().handleAction(null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SammelLastBuchungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SammelLastBuchungNew.java
@@ -60,8 +60,10 @@ public class SammelLastBuchungNew extends AbstractView
     delete.setEnabled(!l.ausgefuehrt());
     buttonArea.addButton(delete);
 
-    Button store = new Button(i18n.tr("Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore(false);
       }
     },null,false,"document-save.png");
@@ -69,8 +71,10 @@ public class SammelLastBuchungNew extends AbstractView
     buttonArea.addButton(store);
     
     // BUGZILLA 116 http://www.willuhn.de/bugzilla/show_bug.cgi?id=116
-    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore(true);
       }
     },null,!l.ausgefuehrt(),"go-next.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/SammelLastschriftList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SammelLastschriftList.java
@@ -37,7 +37,8 @@ public class SammelLastschriftList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.SammelLastschriftList table = control.getListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportSammelLastschrift(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SammelLastschriftNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SammelLastschriftNew.java
@@ -67,7 +67,8 @@ public class SammelLastschriftNew extends AbstractView
     group.addLabelPair(i18n.tr("Summe der Buchungen"),control.getSumme());
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Sammelauftrag löschen"),new Action() {
+    buttons.addButton(i18n.tr("Sammelauftrag löschen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new DBObjectDelete().handleAction(context);
@@ -83,8 +84,10 @@ public class SammelLastschriftNew extends AbstractView
         }
       }
     },transfer,false,"user-trash-full.png");
-    Button store = new Button(i18n.tr("Speichern"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/SammelUeberweisungBuchungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SammelUeberweisungBuchungNew.java
@@ -62,8 +62,10 @@ public class SammelUeberweisungBuchungNew extends AbstractView
     delete.setEnabled(!l.ausgefuehrt());
     buttonArea.addButton(delete);
 
-    Button store = new Button(i18n.tr("Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore(false);
       }
     },null,false,"document-save.png");
@@ -71,8 +73,10 @@ public class SammelUeberweisungBuchungNew extends AbstractView
     buttonArea.addButton(store);
     
     // BUGZILLA 116 http://www.willuhn.de/bugzilla/show_bug.cgi?id=116
-    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore(true);
       }
     },null,!l.ausgefuehrt(),"go-next.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/SammelUeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SammelUeberweisungList.java
@@ -36,7 +36,8 @@ public class SammelUeberweisungList extends AbstractView
     SammelUeberweisungControl control = new SammelUeberweisungControl(this);
     final de.willuhn.jameica.hbci.gui.parts.SammelUeberweisungList table = control.getListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportSammelUeberweisung(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SammelUeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SammelUeberweisungNew.java
@@ -66,7 +66,8 @@ public class SammelUeberweisungNew extends AbstractView
     group.addLabelPair(i18n.tr("Summe der Buchungen"),control.getSumme());
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Sammelauftrag löschen"),new Action() {
+    buttons.addButton(i18n.tr("Sammelauftrag löschen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new DBObjectDelete().handleAction(context);
@@ -82,8 +83,10 @@ public class SammelUeberweisungNew extends AbstractView
         }
       }
     },control.getTransfer(),false,"user-trash-full.png");
-    Button store = new Button(i18n.tr("Speichern"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaDauerauftragList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaDauerauftragList.java
@@ -47,7 +47,8 @@ public class SepaDauerauftragList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.SepaDauerauftragList table = control.getDauerauftragListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportSepaDauerauftrag(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaLastschriftList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaLastschriftList.java
@@ -39,7 +39,8 @@ public class SepaLastschriftList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.SepaLastschriftList table = control.getSepaLastschriftListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportSepaLastschriftList(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaLastschriftNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaLastschriftNew.java
@@ -100,7 +100,8 @@ public class SepaLastschriftNew extends AbstractView
 
 		ButtonArea buttonArea = new ButtonArea();
 		buttonArea.addButton(i18n.tr("Löschen"),new DBObjectDelete(),transfer,false,"user-trash-full.png");
-    buttonArea.addButton(i18n.tr("Duplizieren..."), new Action() {
+    buttonArea.addButton(i18n.tr("Duplizieren..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (control.handleStore()) // BUGZILLA 1181
@@ -108,16 +109,20 @@ public class SepaLastschriftNew extends AbstractView
       }
     },null,false,"edit-copy.png");
 
-    Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
 				if (control.handleStore())
   				new SepaLastschriftExecute().handleAction(transfer);
       }
     },null,false,"emblem-important.png");
     execute.setEnabled(!transfer.ausgefuehrt());
     
-    Button store = new Button(i18n.tr("&Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("&Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
       	control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaSammelLastBuchungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaSammelLastBuchungNew.java
@@ -46,7 +46,8 @@ public class SepaSammelLastBuchungNew extends AbstractView
     GUI.getView().setTitle(i18n.tr("SEPA-Sammellastschrift {0}: Buchung bearbeiten",l.getBezeichnung()));
 
     // Zusaetzlicher Back-Button, um zurueck zum Auftrag zu kommen
-    GUI.getView().addPanelButton(new PanelButton("slastschrift.png",new SepaSammelLastschriftNew(){
+    GUI.getView().addPanelButton(new PanelButton("slastschrift.png", new SepaSammelLastschriftNew()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         super.handleAction(l);
@@ -87,8 +88,10 @@ public class SepaSammelLastBuchungNew extends AbstractView
     delete.setEnabled(!l.ausgefuehrt());
     buttonArea.addButton(delete);
 
-    Button store = new Button(i18n.tr("&Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("&Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore();
       }
     },null,false,"document-save.png");
@@ -96,8 +99,10 @@ public class SepaSammelLastBuchungNew extends AbstractView
     buttonArea.addButton(store);
     
     // BUGZILLA 116 http://www.willuhn.de/bugzilla/show_bug.cgi?id=116
-    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (control.handleStore())
         {
           new de.willuhn.jameica.hbci.gui.action.SepaSammelLastBuchungNew().handleAction(l);

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaSammelLastschriftList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaSammelLastschriftList.java
@@ -39,7 +39,8 @@ public class SepaSammelLastschriftList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.SepaSammelLastschriftList table = control.getListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportSepaSammelLastschrift(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaSammelLastschriftNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaSammelLastschriftNew.java
@@ -90,7 +90,8 @@ public class SepaSammelLastschriftNew extends AbstractView
     }
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Sammelauftrag löschen"),new Action() {
+    buttons.addButton(i18n.tr("Sammelauftrag löschen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new DBObjectDelete().handleAction(context);
@@ -106,7 +107,8 @@ public class SepaSammelLastschriftNew extends AbstractView
         }
       }
     },transfer,false,"user-trash-full.png");
-    buttons.addButton(i18n.tr("Duplizieren..."), new Action() {
+    buttons.addButton(i18n.tr("Duplizieren..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (control.handleStore()) // BUGZILLA 1181
@@ -114,24 +116,30 @@ public class SepaSammelLastschriftNew extends AbstractView
       }
     },null,false,"edit-copy.png");
 
-    Button add = new Button(i18n.tr("Neue Buchungen hinzufügen"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button add = new Button(i18n.tr("Neue Buchungen hinzufügen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (control.handleStore())
           new de.willuhn.jameica.hbci.gui.action.SepaSammelLastBuchungNew().handleAction(transfer);
       }
     },null,false,"text-x-generic.png");
     add.setEnabled(!transfer.ausgefuehrt());
     
-		Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action() {
-			public void handleAction(Object context) throws ApplicationException {
+    Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (control.handleStore())
   				new SepaSammelLastschriftExecute().handleAction(transfer);
 			}
 		},null,false,"emblem-important.png");
     execute.setEnabled(!transfer.ausgefuehrt());
     
-    Button store = new Button(i18n.tr("&Speichern"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("&Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaSammelUeberweisungBuchungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaSammelUeberweisungBuchungNew.java
@@ -45,7 +45,9 @@ public class SepaSammelUeberweisungBuchungNew extends AbstractView
     GUI.getView().setTitle(i18n.tr("SEPA-Sammelüberweisung {0}: Buchung bearbeiten",l.getBezeichnung()));
 
     // Zusaetzlicher Back-Button, um zurueck zum Auftrag zu kommen
-    GUI.getView().addPanelButton(new PanelButton("sueberweisung.png",new de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungNew(){
+    GUI.getView().addPanelButton(
+        new PanelButton("sueberweisung.png", new de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungNew()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         super.handleAction(l);
@@ -83,8 +85,10 @@ public class SepaSammelUeberweisungBuchungNew extends AbstractView
     delete.setEnabled(!l.ausgefuehrt());
     buttonArea.addButton(delete);
 
-    Button store = new Button(i18n.tr("&Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("&Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore();
       }
     },null,false,"document-save.png");
@@ -92,8 +96,10 @@ public class SepaSammelUeberweisungBuchungNew extends AbstractView
     buttonArea.addButton(store);
     
     // BUGZILLA 116 http://www.willuhn.de/bugzilla/show_bug.cgi?id=116
-    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store2 = new Button(i18n.tr("Speichern und nächste Buchung"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (control.handleStore())
         {
           new de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungBuchungNew().handleAction(l);

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaSammelUeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaSammelUeberweisungList.java
@@ -39,7 +39,8 @@ public class SepaSammelUeberweisungList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.SepaSammelUeberweisungList table = control.getListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportSepaSammelUeberweisung(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/SepaSammelUeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/SepaSammelUeberweisungNew.java
@@ -88,7 +88,8 @@ public class SepaSammelUeberweisungNew extends AbstractView
     }
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Sammelauftrag löschen"),new Action() {
+    buttons.addButton(i18n.tr("Sammelauftrag löschen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new SepaSammelUeberweisungDelete().handleAction(context);
@@ -104,7 +105,8 @@ public class SepaSammelUeberweisungNew extends AbstractView
         }
       }
     },transfer,false,"user-trash-full.png");
-    buttons.addButton(i18n.tr("Duplizieren..."), new Action() {
+    buttons.addButton(i18n.tr("Duplizieren..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (control.handleStore())
@@ -112,24 +114,30 @@ public class SepaSammelUeberweisungNew extends AbstractView
       }
     },null,false,"edit-copy.png");
 
-    Button add = new Button(i18n.tr("Neue Buchungen hinzufügen"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button add = new Button(i18n.tr("Neue Buchungen hinzufügen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (control.handleStore())
           new de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungBuchungNew().handleAction(transfer);
       }
     },null,false,"text-x-generic.png");
     add.setEnabled(!transfer.ausgefuehrt());
     
-		Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action() {
-			public void handleAction(Object context) throws ApplicationException {
+    Button execute = new Button(i18n.tr("Jetzt ausführen..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (control.handleStore())
   				new SepaSammelUeberweisungExecute().handleAction(transfer);
 			}
 		},null,false,"emblem-important.png");
     execute.setEnabled(!transfer.ausgefuehrt());
     
-    Button store = new Button(i18n.tr("&Speichern"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("&Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/UeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UeberweisungList.java
@@ -37,7 +37,8 @@ public class UeberweisungList extends AbstractView
     
     final de.willuhn.jameica.hbci.gui.parts.UeberweisungList table = control.getUeberweisungListe();
     final PanelButtonPrint print = new PanelButtonPrint(new PrintSupportUeberweisungList(table));
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         print.setEnabled(table.getSelection() != null);

--- a/src/de/willuhn/jameica/hbci/gui/views/UeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UeberweisungNew.java
@@ -44,7 +44,8 @@ public class UeberweisungNew extends AbstractView
   /**
    * @see de.willuhn.jameica.gui.AbstractView#bind()
    */
-  public void bind() throws Exception {
+  public void bind() throws Exception
+  {
 
 		final UeberweisungControl control = new UeberweisungControl(this);
     this.transfer = (Ueberweisung) control.getTransfer();
@@ -86,8 +87,10 @@ public class UeberweisungNew extends AbstractView
 
 		ButtonArea buttonArea = new ButtonArea();
 		buttonArea.addButton(i18n.tr("Löschen"),new DBObjectDelete(),transfer,false,"user-trash-full.png");
-    Button store = new Button(i18n.tr("Speichern"), new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    Button store = new Button(i18n.tr("Speichern"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
       	control.handleStore();
       }
     },null,!transfer.ausgefuehrt(),"document-save.png");

--- a/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypDetail.java
@@ -69,7 +69,8 @@ public class UmsatzTypDetail extends AbstractView
     
     ButtonArea buttons = new ButtonArea();
     buttons.addButton(i18n.tr("Löschen"),   new DBObjectDelete(),control.getCurrentObject(),false,"user-trash-full.png");
-    buttons.addButton(i18n.tr("Duplizieren..."), new Action() {
+    buttons.addButton(i18n.tr("Duplizieren..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (control.handleStore())

--- a/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypTree.java
@@ -72,7 +72,8 @@ public class UmsatzTypTree extends AbstractView
       
       // Duerfen wir erst nach dem Zeichnen
       final Listener l = control.changedListener(t);
-      t.getControl().addKeyListener(new KeyAdapter(){
+      t.getControl().addKeyListener(new KeyAdapter()
+      {
         /**
          * @see org.eclipse.swt.events.KeyAdapter#keyReleased(org.eclipse.swt.events.KeyEvent)
          */
@@ -91,14 +92,16 @@ public class UmsatzTypTree extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
 
-    buttons.addButton(i18n.tr("Alle aufklappen/zuklappen"), new Action() {
+    buttons.addButton(i18n.tr("Alle aufklappen/zuklappen"), new Action()
+    {
     
       public void handleAction(Object context) throws ApplicationException
       {
         control.handleExpand();
       }
     },null,false,"folder.png");
-    buttons.addButton(i18n.tr("Exportieren..."), new Action(){
+    buttons.addButton(i18n.tr("Exportieren..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         // Muss ich in die Action verpacken, weil der Button sonst mit dem
@@ -128,7 +131,8 @@ public class UmsatzTypTree extends AbstractView
     buttons.paint(getParent());
 
     final TabFolder folder = new TabFolder(getParent(), SWT.NONE);
-    folder.addSelectionListener(new SelectionAdapter() {
+    folder.addSelectionListener(new SelectionAdapter()
+    {
       public void widgetSelected(SelectionEvent e)
       {
         if (folder.getSelectionIndex() == 1)

--- a/src/de/willuhn/jameica/hbci/io/AbstractPDFUmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractPDFUmsatzExporter.java
@@ -174,7 +174,8 @@ public abstract class AbstractPDFUmsatzExporter<T extends GenericObject> impleme
           reporter.setNextRecord();
         }
         
-        if (addSumRow) {
+        if (addSumRow)
+        {
           reporter.addColumn(reporter.getDetailCell(null, Element.ALIGN_LEFT));
           reporter.addColumn(reporter.getDetailCell(i18n.tr("Summe"), Element.ALIGN_LEFT,null,null,Font.BOLD));
           reporter.addColumn(reporter.getDetailCell(null, Element.ALIGN_LEFT));
@@ -186,7 +187,8 @@ public abstract class AbstractPDFUmsatzExporter<T extends GenericObject> impleme
         sumOverall += sumRow;
       }
       
-      if (addSumRow) {
+      if (addSumRow)
+      {
         reporter.addColumn(reporter.getDetailCell(null, Element.ALIGN_LEFT));
         reporter.addColumn(reporter.getDetailCell(i18n.tr("Gesamtsumme"), Element.ALIGN_LEFT,null,null,Font.BOLD));
         reporter.addColumn(reporter.getDetailCell(null, Element.ALIGN_LEFT));
@@ -262,7 +264,8 @@ public abstract class AbstractPDFUmsatzExporter<T extends GenericObject> impleme
     if (!Umsatz.class.equals(objectType))
       return null;
     
-    IOFormat format = new IOFormat() {
+    IOFormat format = new IOFormat()
+    {
       public String getName()
       {
         return AbstractPDFUmsatzExporter.this.getName();

--- a/src/de/willuhn/jameica/hbci/io/AbstractUmsatzTreeExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractUmsatzTreeExporter.java
@@ -35,7 +35,8 @@ public abstract class AbstractUmsatzTreeExporter implements Exporter
     if (!UmsatzTree.class.equals(objectType))
       return null;
 
-    IOFormat myFormat = new IOFormat() {
+    IOFormat myFormat = new IOFormat()
+    {
     
       /**
        * @see de.willuhn.jameica.hbci.io.IOFormat#getName()

--- a/src/de/willuhn/jameica/hbci/io/CamtUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/CamtUmsatzImporter.java
@@ -257,7 +257,8 @@ public class CamtUmsatzImporter implements Importer
     if (!Umsatz.class.equals(objectType))
       return null; // Wir bieten uns nur fuer Umsaetze an
     
-    IOFormat fXml = new MyIOFormat() {
+    IOFormat fXml = new MyIOFormat()
+    {
       public String getName()
       {
         return CamtUmsatzImporter.this.getName() + " (XML)";
@@ -280,7 +281,8 @@ public class CamtUmsatzImporter implements Importer
         return new String[] {"*.xml"};
       }
     };
-    IOFormat fZip = new MyIOFormat() {
+    IOFormat fZip = new MyIOFormat()
+    {
       public String getName()
       {
         return CamtUmsatzImporter.this.getName() + " (ZIP)";

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -243,7 +243,8 @@ public class MT940UmsatzExporter implements Exporter
    */
   protected void sort(List<Umsatz> list)
   {
-    Collections.sort(list,new Comparator<Umsatz>() {
+    Collections.sort(list, new Comparator<Umsatz>()
+    {
       /**
        * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
        */
@@ -279,7 +280,8 @@ public class MT940UmsatzExporter implements Exporter
     if (!Umsatz.class.equals(objectType))
       return null;
 
-    return new IOFormat[]{new IOFormat() {
+    return new IOFormat[] { new IOFormat()
+    {
       public String getName()
       {
         return MT940UmsatzExporter.this.getName();

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzImporter.java
@@ -185,7 +185,8 @@ public class MT940UmsatzImporter implements Importer
     if (!Umsatz.class.equals(objectType))
       return null; // Wir bieten uns nur fuer Umsaetze an
     
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return MT940UmsatzImporter.this.getName();

--- a/src/de/willuhn/jameica/hbci/io/MoneyplexUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MoneyplexUmsatzImporter.java
@@ -421,7 +421,8 @@ public class MoneyplexUmsatzImporter implements Importer
     if (!Umsatz.class.equals(objectType))
       return null; // Wir bieten uns nur fuer Umsaetze an
     
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return MoneyplexUmsatzImporter.this.getName();

--- a/src/de/willuhn/jameica/hbci/io/PDFUmsatzByTypeExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/PDFUmsatzByTypeExporter.java
@@ -51,7 +51,8 @@ public class PDFUmsatzByTypeExporter extends AbstractPDFUmsatzExporter<UmsatzTyp
   {
     try
     {
-      Collections.sort(groups,new Comparator<UmsatzTyp>() {
+      Collections.sort(groups, new Comparator<UmsatzTyp>()
+      {
         /**
          * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
          */

--- a/src/de/willuhn/jameica/hbci/io/XMLExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLExporter.java
@@ -84,7 +84,10 @@ public class XMLExporter implements Exporter
         if (writer != null)
           writer.close();
       }
-      catch (Exception e) {/*useless*/}
+      catch (Exception e)
+      {
+        /* useless */
+      }
     }
   }
 
@@ -108,7 +111,8 @@ public class XMLExporter implements Exporter
     if (SepaSammelTransfer.class.isAssignableFrom(objectType))
       return null; // Keine SEPA-Sammel-Auftraege - die muessen gesondert behandelt werden.
     
-    return new IOFormat[]{new IOFormat() {
+    return new IOFormat[] { new IOFormat()
+    {
       public String getName()
       {
         return XMLExporter.this.getName();

--- a/src/de/willuhn/jameica/hbci/io/XMLImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLImporter.java
@@ -62,7 +62,8 @@ public class XMLImporter implements Importer
     Reader reader = null;
     try
     {
-      reader = new XmlReader(is, new ObjectFactory() {
+      reader = new XmlReader(is, new ObjectFactory()
+      {
         public GenericObject create(String type, String id, Map values) throws Exception
         {
           AbstractDBObject object = (AbstractDBObject) Settings.getDBService().createObject((Class<AbstractDBObject>)loader.loadClass(type),null);
@@ -184,7 +185,8 @@ public class XMLImporter implements Importer
     if (Kontoauszug.class.isAssignableFrom(objectType))
       return null;
 
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return XMLImporter.this.getName();

--- a/src/de/willuhn/jameica/hbci/io/XMLKontoauszugImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLKontoauszugImporter.java
@@ -56,7 +56,8 @@ public class XMLKontoauszugImporter extends XMLImporter
     Reader reader = null;
     try
     {
-      reader = new XmlReader(is, new ObjectFactory() {
+      reader = new XmlReader(is, new ObjectFactory()
+      {
         public GenericObject create(String type, String id, Map values) throws Exception
         {
           AbstractDBObject object = (AbstractDBObject) Settings.getDBService().createObject((Class<AbstractDBObject>)loader.loadClass(type),null);
@@ -178,7 +179,8 @@ public class XMLKontoauszugImporter extends XMLImporter
     if (!Kontoauszug.class.isAssignableFrom(objectType))
       return null; // Nur fuer Umsaetze anbieten - fuer alle anderen tut es die Basis-Implementierung
     
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return i18n.tr("Hibiscus-Format");

--- a/src/de/willuhn/jameica/hbci/io/XMLSammelTransferExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLSammelTransferExporter.java
@@ -53,7 +53,8 @@ public class XMLSammelTransferExporter extends XMLExporter
     if (!SammelTransfer.class.isAssignableFrom(objectType))
       return null; // Nur fuer Sammel-Auftraege anbieten - fuer alle anderen tut es die Basis-Implementierung
 
-    return new IOFormat[]{new IOFormat() {
+    return new IOFormat[] { new IOFormat()
+    {
       public String getName()
       {
         return i18n.tr("Hibiscus-Format");

--- a/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferExporter.java
@@ -53,7 +53,8 @@ public class XMLSepaSammelTransferExporter extends XMLExporter
     if (!SepaSammelTransfer.class.isAssignableFrom(objectType))
       return null; // Nur fuer SEPA-Sammel-Auftraege anbieten - fuer alle anderen tut es die Basis-Implementierung
 
-    return new IOFormat[]{new IOFormat() {
+    return new IOFormat[] { new IOFormat()
+    {
       public String getName()
       {
         return i18n.tr("Hibiscus-Format");

--- a/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferImporter.java
@@ -186,7 +186,8 @@ public class XMLSepaSammelTransferImporter extends XMLImporter
     if (!SepaSammelTransfer.class.isAssignableFrom(objectType))
       return null; // Nur fuer Sammel-Auftraege anbieten - fuer alle anderen tut es die Basis-Implementierung
     
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return i18n.tr("Hibiscus-Format");

--- a/src/de/willuhn/jameica/hbci/io/XMLUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLUmsatzImporter.java
@@ -57,7 +57,8 @@ public class XMLUmsatzImporter extends XMLImporter
     Reader reader = null;
     try
     {
-      reader = new XmlReader(is, new ObjectFactory() {
+      reader = new XmlReader(is, new ObjectFactory()
+      {
         public GenericObject create(String type, String id, Map values) throws Exception
         {
           AbstractDBObject object = (AbstractDBObject) Settings.getDBService().createObject((Class<AbstractDBObject>)loader.loadClass(type),null);
@@ -180,7 +181,8 @@ public class XMLUmsatzImporter extends XMLImporter
     if (!Umsatz.class.isAssignableFrom(objectType))
       return null; // Nur fuer Umsaetze anbieten - fuer alle anderen tut es die Basis-Implementierung
     
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return i18n.tr("Hibiscus-Format");

--- a/src/de/willuhn/jameica/hbci/io/XMLUmsatzTypImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLUmsatzTypImporter.java
@@ -60,7 +60,8 @@ public class XMLUmsatzTypImporter implements Importer
     Reader reader = null;
     try
     {
-      reader = new XmlReader(is, new ObjectFactory() {
+      reader = new XmlReader(is, new ObjectFactory()
+      {
         public GenericObject create(String type, String id, Map values) throws Exception
         {
           AbstractDBObjectNode object = (AbstractDBObjectNode) Settings.getDBService().createObject((Class<AbstractDBObject>)loader.loadClass(type),null);
@@ -178,7 +179,8 @@ public class XMLUmsatzTypImporter implements Importer
     if (!UmsatzTyp.class.isAssignableFrom(objectType))
       return null;
     
-    IOFormat f = new IOFormat() {
+    IOFormat f = new IOFormat()
+    {
       public String getName()
       {
         return i18n.tr("Hibiscus-Format");

--- a/src/de/willuhn/jameica/hbci/io/ZUGFeRDImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/ZUGFeRDImporter.java
@@ -64,7 +64,8 @@ public class ZUGFeRDImporter implements Importer
     if (!AuslandsUeberweisung.class.equals(objectType)) 
       return null; // Wir bieten uns nur fuer SEPA-Ueberweisungen an 
 
-    IOFormat f = new IOFormat() { 
+    IOFormat f = new IOFormat()
+    {
       public String getName() 
       { 
         return ZUGFeRDImporter.this.getName(); 

--- a/src/de/willuhn/jameica/hbci/io/csv/AbstractBaseUeberweisungFormat.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/AbstractBaseUeberweisungFormat.java
@@ -91,7 +91,8 @@ public abstract class AbstractBaseUeberweisungFormat<T extends BaseUeberweisung>
   {
     if (this.listener == null)
     {
-      this.listener = new ImportListener(){
+      this.listener = new ImportListener()
+      {
         
         /**
          * @see de.willuhn.jameica.hbci.io.csv.ImportListener#beforeSet(de.willuhn.jameica.hbci.io.csv.ImportEvent)

--- a/src/de/willuhn/jameica/hbci/io/csv/AddressFormat.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/AddressFormat.java
@@ -73,7 +73,8 @@ public class AddressFormat implements Format<HibiscusAddress>
   {
     if (this.listener == null)
     {
-      this.listener = new ImportListener(){
+      this.listener = new ImportListener()
+      {
         
         private AddressbookService addressbook = null;
 

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -254,8 +254,7 @@ public class CsvImporter implements Importer
           monitor.log("  " + i18n.tr("Fehler in Zeile {0}: {1}",new String[]{Integer.toString(csv.getLineNumber()),e.getMessage()}));
           error++;
         }
-      }
-      while ((line = csv.read()) != null);
+      } while ((line = csv.read()) != null);
 
       // Fertig.
       monitor.setStatusText(i18n.tr("{0} importiert, {1} fehlerhaft, {2} übersprungen", new String[]{Integer.toString(created),Integer.toString(error),Integer.toString(skipped)}));

--- a/src/de/willuhn/jameica/hbci/io/csv/ProfileUtil.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/ProfileUtil.java
@@ -126,7 +126,10 @@ public class ProfileUtil
         {
           decoder.close();
         }
-        catch (Exception e) { /* useless */}
+        catch (Exception e)
+        {
+          /* useless */
+        }
       }
     }
     return result;
@@ -197,11 +200,16 @@ public class ProfileUtil
     }
     finally
     {
-      if (encoder != null) {
-        try {
+      if (encoder != null)
+      {
+        try
+        {
           encoder.close();
         }
-        catch (Exception e) { /* useless */}
+        catch (Exception e)
+        {
+          /* useless */
+        }
       }
     }
   }

--- a/src/de/willuhn/jameica/hbci/io/csv/UmsatzFormat.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/UmsatzFormat.java
@@ -97,7 +97,8 @@ public class UmsatzFormat implements Format<Umsatz>
   {
     if (this.listener == null)
     {
-      this.listener = new ImportListener(){
+      this.listener = new ImportListener()
+      {
         
         /**
          * @see de.willuhn.jameica.hbci.io.csv.ImportListener#beforeStore(de.willuhn.jameica.hbci.io.csv.ImportEvent)

--- a/src/de/willuhn/jameica/hbci/messaging/MarkOverdueMessageConsumer.java
+++ b/src/de/willuhn/jameica/hbci/messaging/MarkOverdueMessageConsumer.java
@@ -83,7 +83,8 @@ public class MarkOverdueMessageConsumer implements MessageConsumer
     
     final long currentValue = this.getCounter(type.getValue()).incrementAndGet();
     
-    worker.schedule(new Runnable() {
+    worker.schedule(new Runnable()
+    {
       
       @Override
       public void run()
@@ -190,7 +191,8 @@ public class MarkOverdueMessageConsumer implements MessageConsumer
       }
 
       final int result = sum;
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         @Override
         public void run()
         {

--- a/src/de/willuhn/jameica/hbci/messaging/MessagingAvailableConsumer.java
+++ b/src/de/willuhn/jameica/hbci/messaging/MessagingAvailableConsumer.java
@@ -41,7 +41,8 @@ public class MessagingAvailableConsumer implements MessageConsumer
   @Override
   public void handleMessage(Message message) throws Exception
   {
-    new Thread(new Runnable() {
+    new Thread(new Runnable()
+    {
       
       @Override
       public void run()

--- a/src/de/willuhn/jameica/hbci/messaging/SyncEngineStatusMessageConsumer.java
+++ b/src/de/willuhn/jameica/hbci/messaging/SyncEngineStatusMessageConsumer.java
@@ -56,7 +56,8 @@ public class SyncEngineStatusMessageConsumer implements MessageConsumer
         status == ProgressMonitor.STATUS_DONE || 
         status == ProgressMonitor.STATUS_ERROR)
     {
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         @Override
         public void run()
         {

--- a/src/de/willuhn/jameica/hbci/passport/Passport.java
+++ b/src/de/willuhn/jameica/hbci/passport/Passport.java
@@ -24,7 +24,8 @@ import de.willuhn.jameica.hbci.rmi.Konto;
  * die Unterstuetzung von DDV-Chipkarten vorhandene
  * <i>de.willuhn.jameica.passports.ddv.server.PassportImpl</i> dienen.
  */
-public interface Passport extends Remote {
+public interface Passport extends Remote
+{
 
 
 	/**

--- a/src/de/willuhn/jameica/hbci/passports/ddv/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/Controller.java
@@ -126,29 +126,40 @@ public class Controller extends AbstractControl
 
     ContextMenu ctx = new ContextMenu();
 
-    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Öffnen"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Öffnen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (context == null)
           return;
         try
         {
           GUI.startView(Detail.class,context);
         }
-        catch (Exception e) {
+        catch (Exception e)
+        {
           Logger.error("error while loading config",e);
           GUI.getStatusBar().setErrorText(i18n.tr("Fehler beim Anlegen der Konfiguration"));
         }
       }
     },"document-open.png"));
 
-    ctx.addItem(new ContextMenuItem(i18n.tr("Neue Konfiguration..."),new Action() {
-      public void handleAction(Object context) throws ApplicationException {handleCreate();}
-    },"document-new.png"));
+    ctx.addItem(new ContextMenuItem(i18n.tr("Neue Konfiguration..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        handleCreate();
+      }
+    }, "document-new.png"));
 
     ctx.addItem(ContextMenuItem.SEPARATOR);
-    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."),new Action() {
-      public void handleAction(Object context) throws ApplicationException {handleDelete((DDVConfig)context);}
-    },"user-trash-full.png"));
+    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        handleDelete((DDVConfig) context);
+      }
+    }, "user-trash-full.png"));
 
     this.configList.setContextMenu(ctx);
     this.configList.setMulti(false);
@@ -391,7 +402,8 @@ public class Controller extends AbstractControl
         if (config != null)
         {
           // wenn wir einen gefunden haben, uebernehmen wir die Daten.
-          GUI.getDisplay().asyncExec(new Runnable() {
+          GUI.getDisplay().asyncExec(new Runnable()
+          {
             public void run()
             {
               Reader reader = config.getReaderPreset();
@@ -632,7 +644,8 @@ public class Controller extends AbstractControl
     if (!handleStore())
       return;
 
-    Application.getController().start(new BackgroundTask() {
+    Application.getController().start(new BackgroundTask()
+    {
       public void run(ProgressMonitor monitor) throws ApplicationException
       {
         HBCIPassportChipcard passport = null;
@@ -706,8 +719,14 @@ public class Controller extends AbstractControl
         }
       }
       
-      public boolean isInterrupted(){return false;}
-      public void interrupt(){}
+      public boolean isInterrupted()
+      {
+        return false;
+      }
+
+      public void interrupt()
+      {
+      }
     });
   }
 
@@ -721,7 +740,8 @@ public class Controller extends AbstractControl
      */
     public void handleEvent(Event event)
     {
-      try {
+      try
+      {
         Reader r = (Reader) getReaderPresets().getValue();
         if (r == null)
           return;

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
@@ -108,7 +108,8 @@ public class DDVConfigFactory
     }
 
     // Alphabetisch sortieren
-    Collections.sort(presets,new Comparator<Reader>() {
+    Collections.sort(presets, new Comparator<Reader>()
+    {
       public int compare(Reader r1, Reader r2)
       {
         return r1.getName().compareTo(r2.getName());
@@ -375,7 +376,11 @@ public class DDVConfigFactory
     try
     {
       Thread.sleep(250L);
-    } catch (Exception e) { /* ignore */}
+    }
+    catch (Exception e)
+    {
+      /* ignore */
+    }
     
     return false;
   }

--- a/src/de/willuhn/jameica/hbci/passports/ddv/SelectConfigDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/SelectConfigDialog.java
@@ -51,7 +51,8 @@ public class SelectConfigDialog extends AbstractDialog
     LabelGroup group = new LabelGroup(parent,i18n.tr("Konfiguration"));
     group.addText(text == null ? i18n.tr("Bitte wählen Sie die zu verwendende Kartenleser-Konfiguration aus") : text,true);
     
-    final TablePart table = new TablePart(DDVConfigFactory.getConfigs(), new Action() {
+    final TablePart table = new TablePart(DDVConfigFactory.getConfigs(), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (context == null || !(context instanceof DDVConfig))
@@ -68,7 +69,8 @@ public class SelectConfigDialog extends AbstractDialog
     table.paint(parent);
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"), new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         selected = (DDVConfig) table.getSelection();
@@ -77,7 +79,8 @@ public class SelectConfigDialog extends AbstractDialog
         close();
       }
     },null,true);
-    buttons.addButton(i18n.tr("Abbrechen"), new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();

--- a/src/de/willuhn/jameica/hbci/passports/ddv/rmi/Passport.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/rmi/Passport.java
@@ -13,6 +13,7 @@ package de.willuhn.jameica.hbci.passports.ddv.rmi;
 /**
  * Passport fuer das Sicherheitsmedium "Chipkarte" (DDV).
  */
-public interface Passport extends de.willuhn.jameica.hbci.passport.Passport {
+public interface Passport extends de.willuhn.jameica.hbci.passport.Passport
+{
 
 }

--- a/src/de/willuhn/jameica/hbci/passports/ddv/server/AbstractReader.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/server/AbstractReader.java
@@ -51,7 +51,8 @@ public abstract class AbstractReader implements Reader
       
 
       case Platform.OS_WINDOWS:
-        try {
+        try
+        {
           f = new File("C:/Windows/System32");
           if (f.isDirectory() && f.exists()) return f;
 
@@ -75,7 +76,8 @@ public abstract class AbstractReader implements Reader
         return f;
 
       case Platform.OS_WINDOWS_64:
-        try {
+        try
+        {
 
           f = new File("C:/Windows/SysWOW64");
           if (f.isDirectory() && f.exists()) return f;

--- a/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
@@ -178,21 +178,27 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
   /**
    * @see de.willuhn.jameica.hbci.passport.PassportHandle#isOpen()
    */
-  public boolean isOpen() throws RemoteException {
+  public boolean isOpen() throws RemoteException
+  {
 		return handler != null && hbciPassport != null;
-	}
+  }
 
   /**
    * @see de.willuhn.jameica.hbci.passport.PassportHandle#close()
    */
-  public void close() throws RemoteException {
+  public void close() throws RemoteException
+  {
 		if (hbciPassport == null && handler == null)
 			return;
-		try {
+    try
+    {
 			Logger.info("closing ddv passport");
 			handler.close();
-		}
-		catch (Exception e) {/*useless*/}
+    }
+    catch (Exception e)
+    {
+      /* useless */
+    }
 		hbciPassport = null;
 		handler = null;
 
@@ -210,7 +216,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
   public Konto[] getKonten() throws RemoteException, ApplicationException
   {
   	Logger.info("reading accounts from ddv passport");
-		try {
+    try
+    {
 			open();
 			org.kapott.hbci.structures.Konto[] konten = hbciPassport.getAccounts();
 			if (konten == null || konten.length == 0)
@@ -231,10 +238,14 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 		}
 		finally
 		{
-			try {
+			try
+			{
 				close();
 			}
-			catch (RemoteException e2) {/*useless*/}
+			catch (RemoteException e2)
+			{
+				/*useless*/
+			}
 		}
   }
 
@@ -244,7 +255,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
   public boolean callback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData) throws Exception
   {
     
-    switch (reason) {
+    switch (reason)
+    {
     
       case HBCICallback.NEED_SOFTPIN:
       {

--- a/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportImpl.java
@@ -35,21 +35,24 @@ public class PassportImpl extends UnicastRemoteObject implements Passport
   /**
    * @throws RemoteException
    */
-  public PassportImpl() throws RemoteException {
+  public PassportImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.jameica.hbci.passport.Passport#getHandle()
    */
-  public PassportHandle getHandle() throws RemoteException {
+  public PassportHandle getHandle() throws RemoteException
+  {
     return new PassportHandleImpl(this.konto);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.passport.Passport#getName()
    */
-  public String getName() throws RemoteException {
+  public String getName() throws RemoteException
+  {
     return i18n.tr("Chipkartenleser");
   }
 
@@ -81,7 +84,8 @@ public class PassportImpl extends UnicastRemoteObject implements Passport
   /**
    * @see de.willuhn.jameica.hbci.passport.Passport#getConfigDialog()
    */
-  public Class getConfigDialog() throws RemoteException {
+  public Class getConfigDialog() throws RemoteException
+  {
     return View.class;
   }
 

--- a/src/de/willuhn/jameica/hbci/passports/pintan/ChipTANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/ChipTANDialog.java
@@ -68,7 +68,8 @@ public class ChipTANDialog extends TANDialog
   private ChipTanCardService service = null;
   private CheckboxInput autoContinue = null;
   
-  private final Listener resizeListener = new DelayedListener(new Listener() {
+  private final Listener resizeListener = new DelayedListener(new Listener()
+  {
     @Override
     public void handleEvent(Event event)
     {
@@ -147,7 +148,8 @@ public class ChipTANDialog extends TANDialog
     
     this.autoContinue = new CheckboxInput(SETTINGS.getBoolean(PARAM_AUTOCONTINUE,false));
     this.autoContinue.setName(i18n.tr("Bei Erhalt der TAN automatisch fortsetzen"));
-    this.autoContinue.addListener(new Listener() {
+    this.autoContinue.addListener(new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)
@@ -294,7 +296,8 @@ public class ChipTANDialog extends TANDialog
       };
       usbThread.start();
       
-      getShell().addDisposeListener(new DisposeListener() {
+      getShell().addDisposeListener(new DisposeListener()
+      {
         @Override
         public void widgetDisposed(DisposeEvent e)
         {
@@ -337,7 +340,8 @@ public class ChipTANDialog extends TANDialog
     if (s == null || s.length() == 0)
       return;
     
-    GUI.getDisplay().asyncExec(new Runnable() {
+    GUI.getDisplay().asyncExec(new Runnable()
+    {
       
       @Override
       public void run()
@@ -402,7 +406,8 @@ public class ChipTANDialog extends TANDialog
       
       // Redraw ausloesen
       // Wir sind hier nicht im Event-Dispatcher-Thread von SWT. Daher uebergeben wir das an diesen
-      canvas.getDisplay().syncExec(new Runnable() {
+      canvas.getDisplay().syncExec(new Runnable()
+      {
         public void run()
         {
           // Wir muessen hier nochmal checken, weil das inzwischen disposed sein kann.
@@ -495,7 +500,8 @@ public class ChipTANDialog extends TANDialog
         spinner.setMaximum(FlickerRenderer.FREQUENCY_MAX);
         spinner.setIncrement(1);
         spinner.setTextLimit(2);
-        spinner.addSelectionListener(new SelectionAdapter() {
+        spinner.addSelectionListener(new SelectionAdapter()
+        {
           public void widgetSelected(SelectionEvent e)
           {
             int freq = spinner.getSelection();
@@ -563,7 +569,8 @@ public class ChipTANDialog extends TANDialog
           update(e.gc);
         }
       });
-      this.canvas.addDisposeListener(new DisposeListener() {
+      this.canvas.addDisposeListener(new DisposeListener()
+      {
         public void widgetDisposed(DisposeEvent e)
         {
           // Update-Thread stoppen

--- a/src/de/willuhn/jameica/hbci/passports/pintan/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/Controller.java
@@ -92,7 +92,8 @@ public class Controller extends AbstractControl
    * ct.
    * @param view
    */
-  public Controller(AbstractView view) {
+  public Controller(AbstractView view)
+  {
     super(view);
   }
 
@@ -132,29 +133,40 @@ public class Controller extends AbstractControl
 
     ContextMenu ctx = new ContextMenu();
 
-    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Öffnen"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {
+    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Öffnen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
         if (context == null)
           return;
         try
         {
           GUI.startView(Detail.class,context);
         }
-        catch (Exception e) {
+        catch (Exception e)
+        {
           Logger.error("error while loading config",e);
           GUI.getStatusBar().setErrorText(i18n.tr("Fehler beim Anlegen der Konfiguration"));
         }
       }
     },"document-open.png"));
 
-    ctx.addItem(new ContextMenuItem(i18n.tr("PIN/TAN-Zugang anlegen"),new Action() {
-      public void handleAction(Object context) throws ApplicationException {handleCreate();}
-    },"document-new.png"));
+    ctx.addItem(new ContextMenuItem(i18n.tr("PIN/TAN-Zugang anlegen"), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        handleCreate();
+      }
+    }, "document-new.png"));
 
     ctx.addItem(ContextMenuItem.SEPARATOR);
-    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."),new Action() {
-      public void handleAction(Object context) throws ApplicationException {handleDelete((PinTanConfig)context);}
-    },"user-trash-full.png"));
+    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        handleDelete((PinTanConfig) context);
+      }
+    }, "user-trash-full.png"));
 
     configList.setContextMenu(ctx);
     configList.setMulti(false);
@@ -286,7 +298,8 @@ public class Controller extends AbstractControl
     this.useUsb = new CheckboxInput(b == null || b.booleanValue());
     this.useUsb.setName(i18n.tr("Kartenleser per USB zur TAN-Erzeugung verwenden"));
     
-    final Listener l = new Listener() {
+    final Listener l = new Listener()
+    {
       
       @Override
       public void handleEvent(Event event)

--- a/src/de/willuhn/jameica/hbci/passports/pintan/Detail.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/Detail.java
@@ -88,7 +88,8 @@ public class Detail extends AbstractView
       PtSecMech secMech = control.getConfig().getStoredSecMech();
       ButtonArea buttons = new ButtonArea();
       String tanMedia = control.getConfig().getTanMedia();
-      Button b = new Button(i18n.tr("TAN-Verfahren zurücksetzen"), new Action() {
+      Button b = new Button(i18n.tr("TAN-Verfahren zurücksetzen"), new Action()
+      {
         public void handleAction(Object context) throws ApplicationException
         {
           control.handleDeleteTanSettings();

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PhotoTANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PhotoTANDialog.java
@@ -54,7 +54,8 @@ public class PhotoTANDialog extends TANDialog
   private Button smaller = null;
   private Button larger = null;
   
-  private final Listener resizeListener = new DelayedListener(new Listener() {
+  private final Listener resizeListener = new DelayedListener(new Listener()
+  {
     @Override
     public void handleEvent(Event event)
     {

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
@@ -205,7 +205,8 @@ public class PinTanConfigFactory
 
     HBCIUtils.setParam("client.passport.PinTan.checkcert","1");
 
-    return new PassportLoader() {
+    return new PassportLoader()
+    {
 
       private HBCIPassport p = null;
 

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PtSecMechDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PtSecMechDialog.java
@@ -101,7 +101,8 @@ public class PtSecMechDialog extends AbstractDialog
     group.addCheckbox(getSave(),i18n.tr("Auswahl speichern"));
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"),new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try

--- a/src/de/willuhn/jameica/hbci/passports/pintan/SelectConfigDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/SelectConfigDialog.java
@@ -82,7 +82,8 @@ public class SelectConfigDialog extends AbstractDialog
     group.addPart(table);
 
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"), new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         selected = (PinTanConfig) table.getSelection();

--- a/src/de/willuhn/jameica/hbci/passports/pintan/TANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/TANDialog.java
@@ -117,7 +117,8 @@ public class TANDialog extends AbstractDialog
       
       if (session != null)
       {
-        this.addCloseListener(new Listener() {
+        this.addCloseListener(new Listener()
+        {
           
           @Override
           public void handleEvent(Event event)
@@ -186,7 +187,8 @@ public class TANDialog extends AbstractDialog
     if (this.okButton != null)
       return this.okButton;
     
-    this.okButton = new Button("    " + i18n.tr("OK") + "    ",new Action() {
+    this.okButton = new Button("    " + i18n.tr("OK") + "    ", new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         tan = (String) getTANInput().getValue();
@@ -239,7 +241,8 @@ public class TANDialog extends AbstractDialog
     final PasswordInput tan = this.getTANInput();
     c.addInput(tan);
     
-    tan.getControl().addKeyListener(new KeyAdapter() {
+    tan.getControl().addKeyListener(new KeyAdapter()
+    {
       /**
        * @see org.eclipse.swt.events.KeyAdapter#keyReleased(org.eclipse.swt.events.KeyEvent)
        */
@@ -260,14 +263,28 @@ public class TANDialog extends AbstractDialog
     buttons.addButton(new Cancel());
     bottom.addButtonArea(buttons);
 
-    addShellListener(new ShellListener() {
-      public void shellClosed(ShellEvent e) {
+    addShellListener(new ShellListener()
+    {
+      public void shellClosed(ShellEvent e)
+      {
         throw new OperationCanceledException("dialog cancelled via close button");
       }
-      public void shellActivated(ShellEvent e) {}
-      public void shellDeactivated(ShellEvent e) {}
-      public void shellDeiconified(ShellEvent e) {}
-      public void shellIconified(ShellEvent e) {}
+
+      public void shellActivated(ShellEvent e)
+      {
+      }
+
+      public void shellDeactivated(ShellEvent e)
+      {
+      }
+
+      public void shellDeiconified(ShellEvent e)
+      {
+      }
+
+      public void shellIconified(ShellEvent e)
+      {
+      }
     });
     
     this.getShell().setMinimumSize(getShell().computeSize(WINDOW_WIDTH,WINDOW_HEIGHT));

--- a/src/de/willuhn/jameica/hbci/passports/pintan/TanMediaDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/TanMediaDialog.java
@@ -105,7 +105,8 @@ public class TanMediaDialog extends AbstractDialog
     group.addCheckbox(getSave(),i18n.tr("Auswahl speichern"));
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"),new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try
@@ -144,7 +145,8 @@ public class TanMediaDialog extends AbstractDialog
         }
       }
     },null,true,"ok.png");
-    buttons.addButton(i18n.tr("Abbrechen"),new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
@@ -68,7 +68,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
    * @param passport
    * @throws RemoteException
    */
-  public PassportHandleImpl(PassportImpl passport) throws RemoteException {
+  public PassportHandleImpl(PassportImpl passport) throws RemoteException
+  {
     super();
 		this.passport = passport;
   }
@@ -77,7 +78,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
    * @param config
    * @throws RemoteException
    */
-  public PassportHandleImpl(PinTanConfig config) throws RemoteException {
+  public PassportHandleImpl(PinTanConfig config) throws RemoteException
+  {
     super();
     this.config = config;
   }
@@ -92,7 +94,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			return handler;
 
 		Logger.info("open pin/tan passport");
-		try {
+    try
+    {
 	
       if (config == null && this.passport == null)
         throw new ApplicationException(i18n.tr("Keine Konfiguration oder Konto ausgewählt"));
@@ -207,14 +210,16 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
   /**
    * @see de.willuhn.jameica.hbci.passport.PassportHandle#isOpen()
    */
-  public boolean isOpen() throws RemoteException {
+  public boolean isOpen() throws RemoteException
+  {
 		return handler != null && hbciPassport != null;
 	}
 
   /**
    * @see de.willuhn.jameica.hbci.passport.PassportHandle#close()
    */
-  public void close() throws RemoteException {
+  public void close() throws RemoteException
+  {
 		if (hbciPassport == null && handler == null)
 			return;
 
@@ -225,11 +230,15 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 		}
 		finally
 		{
-	    try {
+	    try
+	    {
 	      Logger.info("closing pin/tan passport");
 	      handler.close();
 	    }
-	    catch (Exception e) {/*useless*/}
+	    catch (Exception e)
+	    {
+	      /*useless*/
+	    }
 	    hbciPassport = null;
 	    handler = null;
 
@@ -299,7 +308,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
   public Konto[] getKonten() throws RemoteException, ApplicationException
   {
   	Logger.info("reading accounts from pin/tan passport");
-		try {
+    try
+    {
 			open();
 			org.kapott.hbci.structures.Konto[] konten = hbciPassport.getAccounts();
 			if (konten == null || konten.length == 0)
@@ -323,7 +333,10 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			try {
 				close();
 			}
-			catch (RemoteException e2) {/*useless*/}
+			catch (RemoteException e2)
+			{
+				/*useless*/
+			}
 		}
   }
 

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportImpl.java
@@ -37,14 +37,16 @@ public class PassportImpl extends UnicastRemoteObject implements Passport
   /**
    * @throws RemoteException
    */
-  public PassportImpl() throws RemoteException {
+  public PassportImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.jameica.hbci.passport.Passport#getName()
    */
-  public String getName() throws RemoteException {
+  public String getName() throws RemoteException
+  {
     return i18n.tr("PIN/TAN");
   }
 
@@ -72,7 +74,8 @@ public class PassportImpl extends UnicastRemoteObject implements Passport
   /**
    * @see de.willuhn.jameica.hbci.passport.Passport#getConfigDialog()
    */
-  public Class getConfigDialog() throws RemoteException {
+  public Class getConfigDialog() throws RemoteException
+  {
     return View.class;
   }
 

--- a/src/de/willuhn/jameica/hbci/passports/rdh/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/Controller.java
@@ -59,7 +59,8 @@ import de.willuhn.util.I18N;
 /**
  * Controller, der die Eingaben zur Konfiguration des Passports handelt.
  */
-public class Controller extends AbstractControl {
+public class Controller extends AbstractControl
+{
 
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
@@ -92,7 +93,8 @@ public class Controller extends AbstractControl {
    * ct.
    * @param view
    */
-  public Controller(AbstractView view) {
+  public Controller(AbstractView view)
+  {
     super(view);
   }
 
@@ -319,9 +321,13 @@ public class Controller extends AbstractControl {
       }
     },"document-open.png"));
 
-    ctx.addItem(new ContextMenuItem(i18n.tr("Neuer Schlüssel..."),new Action() {
-      public void handleAction(Object context) throws ApplicationException {startCreate();}
-    },"document-new.png"));
+    ctx.addItem(new ContextMenuItem(i18n.tr("Neuer Schlüssel..."), new Action()
+    {
+      public void handleAction(Object context) throws ApplicationException
+      {
+        startCreate();
+      }
+    }, "document-new.png"));
     ctx.addItem(new ContextMenuItem(i18n.tr("Schlüssel importieren..."),new Action()
     {
       public void handleAction(Object context) throws ApplicationException
@@ -335,7 +341,8 @@ public class Controller extends AbstractControl {
     ctx.addItem(new ActivateKey(true));
     ctx.addItem(new ActivateKey(false));
     ctx.addItem(ContextMenuItem.SEPARATOR);
-    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."), new Action() {
+    ctx.addItem(new CheckedContextMenuItem(i18n.tr("Löschen..."), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         try

--- a/src/de/willuhn/jameica/hbci/passports/rdh/KeyFormatDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/KeyFormatDialog.java
@@ -68,7 +68,8 @@ public class KeyFormatDialog extends AbstractDialog
     this.warn.setName("");
     this.warn.setColor(Color.ERROR);
     
-    final Action action = new Action() {
+    final Action action = new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         Object o = table.getSelection();
@@ -99,7 +100,8 @@ public class KeyFormatDialog extends AbstractDialog
     
     ButtonArea buttons = new ButtonArea();
     buttons.addButton(i18n.tr("Übernehmen"), action,null,false,"ok.png");
-    buttons.addButton(i18n.tr("Abbrechen"), new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException("cancelled in key format dialog");

--- a/src/de/willuhn/jameica/hbci/passports/rdh/KeyPasswordLoadDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/KeyPasswordLoadDialog.java
@@ -112,7 +112,8 @@ public class KeyPasswordLoadDialog extends PasswordDialog
     if (this.filename == null)
       return;
     
-    Part p = new Part() {
+    Part p = new Part()
+    {
       public void paint(Composite parent) throws RemoteException
       {
         String text = i18n.tr("Schlüsseldatei: {0}",filename);
@@ -123,7 +124,8 @@ public class KeyPasswordLoadDialog extends PasswordDialog
         comment.setLayoutData(new GridData(GridData.FILL_BOTH));
         // Workaround fuer Windows, weil dort mehrzeilige
         // Labels nicht korrekt umgebrochen werden.
-        comment.addControlListener(new ControlAdapter() {
+        comment.addControlListener(new ControlAdapter()
+        {
           public void controlResized(ControlEvent e)
           {
             comment.setSize(comment.computeSize(comment.getSize().x,SWT.DEFAULT));

--- a/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
@@ -203,7 +203,8 @@ public class RDHKeyFactory
       Logger.error(ae.getMessage());
       
       // Meldung wurde sonst nicht in der GUI angezeigt. Siehe http://www.onlinebanking-forum.de/forum/topic.php?p=106085#real106085
-      GUI.getDisplay().asyncExec(new Runnable() {
+      GUI.getDisplay().asyncExec(new Runnable()
+      {
         public void run()
         {
           Application.getMessagingFactory().sendMessage(new StatusBarMessage(ae.getMessage(),StatusBarMessage.TYPE_ERROR));

--- a/src/de/willuhn/jameica/hbci/passports/rdh/SelectKeyDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/SelectKeyDialog.java
@@ -67,7 +67,8 @@ public class SelectKeyDialog extends AbstractDialog
     Container container = new SimpleContainer(parent);
     container.addText(i18n.tr("Bitte wählen Sie den zu verwendenden Schlüssel aus"),true);
 
-    final Button apply = new Button(i18n.tr("Übernehmen"), new Action() {
+    final Button apply = new Button(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new Apply().handleAction(table.getSelection());
@@ -83,13 +84,15 @@ public class SelectKeyDialog extends AbstractDialog
       l.add(new KeyObject(key));
     }
     
-    this.table = new TablePart(l, new Action() {
+    this.table = new TablePart(l, new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         new Apply().handleAction(context);
       }
     });
-    table.setFormatter(new TableFormatter() {
+    table.setFormatter(new TableFormatter()
+    {
       public void format(TableItem item)
       {
         if (item == null || item.getData() == null)
@@ -107,7 +110,8 @@ public class SelectKeyDialog extends AbstractDialog
       }
     });
     
-    table.addSelectionListener(new Listener() {
+    table.addSelectionListener(new Listener()
+    {
       public void handleEvent(Event event)
       {
         apply.setEnabled(table.getSelection() != null);
@@ -122,7 +126,8 @@ public class SelectKeyDialog extends AbstractDialog
     
     ButtonArea buttons = new ButtonArea();
     buttons.addButton(apply);
-    buttons.addButton(i18n.tr("Abbrechen"), new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();

--- a/src/de/willuhn/jameica/hbci/passports/rdh/SelectSizEntryDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/SelectSizEntryDialog.java
@@ -68,7 +68,8 @@ public class SelectSizEntryDialog extends AbstractDialog
       list.add(e);
     }
     
-    final TablePart table = new TablePart(list, new Action() {
+    final TablePart table = new TablePart(list, new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         if (context == null || !(context instanceof Entry))
@@ -85,7 +86,8 @@ public class SelectSizEntryDialog extends AbstractDialog
     table.paint(parent);
     
     ButtonArea buttons = new ButtonArea();
-    buttons.addButton(i18n.tr("Übernehmen"), new Action() {
+    buttons.addButton(i18n.tr("Übernehmen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         Object o = table.getSelection();
@@ -97,7 +99,8 @@ public class SelectSizEntryDialog extends AbstractDialog
         close();
       }
     },null,false,"ok.png");
-    buttons.addButton(i18n.tr("Abbrechen"), new Action() {
+    buttons.addButton(i18n.tr("Abbrechen"), new Action()
+    {
       public void handleAction(Object context) throws ApplicationException
       {
         throw new OperationCanceledException();

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
@@ -93,7 +93,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
     I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
 		Logger.info("open rdh passport");
-		try {
+    try
+    {
 	
       RDHKey activeKey = this.key != null ? this.key : RDHKeyFactory.findByKonto(passport != null ? passport.getKonto() : null);
       
@@ -183,7 +184,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 		}
 		finally
 		{
-	    try {
+	    try
+	    {
 	      Logger.info("closing rdh passport");
 	      handler.close();
 	    }
@@ -233,7 +235,8 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
   public Konto[] getKonten() throws RemoteException, ApplicationException
   {
 		Logger.info("reading accounts from rdh passport");
-		try {
+		try
+		{
 			open();
 			org.kapott.hbci.structures.Konto[] konten = hbciPassport.getAccounts();
 			if (konten == null || konten.length == 0)
@@ -254,10 +257,14 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 		}
 		finally
 		{
-			try {
+			try
+			{
 				close();
 			}
-			catch (RemoteException e2) {/*useless*/}
+			catch (RemoteException e2)
+			{
+				/*useless*/
+			}
 		}
   }
 

--- a/src/de/willuhn/jameica/hbci/reminder/ReminderStorageProviderHibiscus.java
+++ b/src/de/willuhn/jameica/hbci/reminder/ReminderStorageProviderHibiscus.java
@@ -120,7 +120,8 @@ public class ReminderStorageProviderHibiscus extends AbstractReminderStorageProv
    */
   public String[] getUUIDs() throws Exception
   {
-    return (String[]) Settings.getDBService().execute("select uuid from reminder",null,new ResultSetExtractor() {
+    return (String[]) Settings.getDBService().execute("select uuid from reminder", null, new ResultSetExtractor()
+    {
       public Object extract(ResultSet rs) throws RemoteException, SQLException
       {
         List<String> list = new ArrayList<String>();

--- a/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
+++ b/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
@@ -68,7 +68,8 @@ public class AccountBalanceService
       Logger.info("  found " + this.providers.size() + " provider(s)");
       
       // Wir sortieren die Provider so, dass der Standard-Provider immer als letzter an die Reihe kommt.
-      Collections.sort(this.providers,new Comparator<AccountBalanceProvider>() {
+      Collections.sort(this.providers, new Comparator<AccountBalanceProvider>()
+      {
         public int compare(AccountBalanceProvider o1, AccountBalanceProvider o2)
         {
           
@@ -98,9 +99,12 @@ public class AccountBalanceService
    * @param konto Das Konto, fuer welches Salden gesucht sind.
    * @return Einen speziellen Provider fuer beispielsweise Depots oder den DEFAULT-Provider.
    */
-  public AccountBalanceProvider getBalanceProviderForAccount(Konto konto) {
-    for(AccountBalanceProvider provider : getProviders()) {
-      if(provider.supports(konto)) {
+  public AccountBalanceProvider getBalanceProviderForAccount(Konto konto)
+  {
+    for (AccountBalanceProvider provider : getProviders())
+    {
+      if (provider.supports(konto))
+      {
         return provider;
       }
     }

--- a/src/de/willuhn/jameica/hbci/report/balance/BookingAccountBalanceProvider.java
+++ b/src/de/willuhn/jameica/hbci/report/balance/BookingAccountBalanceProvider.java
@@ -38,7 +38,8 @@ public class BookingAccountBalanceProvider implements AccountBalanceProvider
    * @see de.willuhn.jameica.hbci.report.balance.AccountBalanceProvider#supports(de.willuhn.jameica.hbci.rmi.Konto)
    */
   @Override
-  public boolean supports(Konto konto) {
+  public boolean supports(Konto konto)
+  {
     // Dies ist der Standard-Provider fuer Konten in Hibiscus und er unterstuetzt jedes Konto per Definition.
     return true;
   }
@@ -47,7 +48,8 @@ public class BookingAccountBalanceProvider implements AccountBalanceProvider
    * @see de.willuhn.jameica.hbci.report.balance.AccountBalanceProvider#getBalanceChartData(de.willuhn.jameica.hbci.rmi.Konto, java.util.Date, java.util.Date)
    */
   @Override
-  public AbstractChartDataSaldo getBalanceChartData(Konto konto, Date start, Date end) {
+  public AbstractChartDataSaldo getBalanceChartData(Konto konto, Date start, Date end)
+  {
     List<Value> data = getBalanceData(konto, start, end);
     return new ChartDataSaldoVerlauf(konto, data);
   }
@@ -106,7 +108,8 @@ public class BookingAccountBalanceProvider implements AccountBalanceProvider
         cal.add(Calendar.DAY_OF_MONTH,1);
         localStart = cal.getTime();
       }
-    } catch (RemoteException e)
+    }
+    catch (RemoteException e)
     {
       Logger.error("Fehler beim der Ermittlung der Salden", e);
     }

--- a/src/de/willuhn/jameica/hbci/rmi/Protokoll.java
+++ b/src/de/willuhn/jameica/hbci/rmi/Protokoll.java
@@ -18,7 +18,8 @@ import java.util.Date;
  * wann welche Art von HBCI-Aktion (z.Bsp. Umsaetze abrufen oder Ueberweisung)
  * ausgefuehrt wurde.
  */
-public interface Protokoll extends HibiscusDBObject {
+public interface Protokoll extends HibiscusDBObject
+{
 
 	/**
 	 * Protokoll-Typ unbekannt (Default).

--- a/src/de/willuhn/jameica/hbci/server/AbstractBaseUeberweisungImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractBaseUeberweisungImpl.java
@@ -33,14 +33,16 @@ public abstract class AbstractBaseUeberweisungImpl extends AbstractHibiscusTrans
   /**
    * @throws RemoteException
    */
-  public AbstractBaseUeberweisungImpl() throws RemoteException {
+  public AbstractBaseUeberweisungImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.datasource.GenericObject#getPrimaryAttribute()
    */
-  public String getPrimaryAttribute() throws RemoteException {
+  public String getPrimaryAttribute() throws RemoteException
+  {
     return "zweck";
   }
 
@@ -103,7 +105,8 @@ public abstract class AbstractBaseUeberweisungImpl extends AbstractHibiscusTrans
   /**
    * @see de.willuhn.jameica.hbci.rmi.Terminable#getTermin()
    */
-  public Date getTermin() throws RemoteException {
+  public Date getTermin() throws RemoteException
+  {
     return (Date) getAttribute("termin");
   }
 
@@ -118,7 +121,8 @@ public abstract class AbstractBaseUeberweisungImpl extends AbstractHibiscusTrans
   /**
    * @see de.willuhn.jameica.hbci.rmi.Terminable#ausgefuehrt()
    */
-  public boolean ausgefuehrt() throws RemoteException {
+  public boolean ausgefuehrt() throws RemoteException
+  {
 		Integer i = (Integer) getAttribute("ausgefuehrt");
 		if (i == null)
 			return false;
@@ -128,14 +132,16 @@ public abstract class AbstractBaseUeberweisungImpl extends AbstractHibiscusTrans
   /**
    * @see de.willuhn.jameica.hbci.rmi.Terminable#setTermin(java.util.Date)
    */
-  public void setTermin(Date termin) throws RemoteException {
+  public void setTermin(Date termin) throws RemoteException
+  {
 		setAttribute("termin",termin);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Terminable#ueberfaellig()
    */
-  public boolean ueberfaellig() throws RemoteException {
+  public boolean ueberfaellig() throws RemoteException
+  {
     if (ausgefuehrt())
     	return false;
     Date termin = getTermin();

--- a/src/de/willuhn/jameica/hbci/server/AbstractHibiscusTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractHibiscusTransferImpl.java
@@ -38,7 +38,8 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
    * ct.
    * @throws RemoteException
    */
-  public AbstractHibiscusTransferImpl() throws RemoteException {
+  public AbstractHibiscusTransferImpl() throws RemoteException
+  {
     super();
   }
 
@@ -81,8 +82,10 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#insertCheck()
    */
-  protected void insertCheck() throws ApplicationException {
-  	try {
+  protected void insertCheck() throws ApplicationException
+  {
+    try
+    {
 			if (getKonto() == null)
 				throw new ApplicationException(i18n.tr("Bitte wählen Sie ein Konto aus."));
 			if (getKonto().isNewObject())
@@ -139,14 +142,16 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#updateCheck()
    */
-  protected void updateCheck() throws ApplicationException {
+  protected void updateCheck() throws ApplicationException
+  {
 		insertCheck();
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#getKonto()
    */
-  public Konto getKonto() throws RemoteException {
+  public Konto getKonto() throws RemoteException
+  {
     Integer i = (Integer) super.getAttribute("konto_id");
     if (i == null)
       return null; // Kein Konto zugeordnet
@@ -158,7 +163,8 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getBetrag()
    */
-  public double getBetrag() throws RemoteException {
+  public double getBetrag() throws RemoteException
+  {
 		Double d = (Double) getAttribute("betrag");
 		if (d == null)
 			return 0;
@@ -168,84 +174,96 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getZweck()
    */
-  public String getZweck() throws RemoteException {
+  public String getZweck() throws RemoteException
+  {
     return (String) getAttribute("zweck");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getZweck2()
    */
-  public String getZweck2() throws RemoteException {
+  public String getZweck2() throws RemoteException
+  {
 		return (String) getAttribute("zweck2");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setKonto(de.willuhn.jameica.hbci.rmi.Konto)
    */
-  public void setKonto(Konto konto) throws RemoteException {
+  public void setKonto(Konto konto) throws RemoteException
+  {
     setAttribute("konto_id",(konto == null || konto.getID() == null) ? null : new Integer(konto.getID()));
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setBetrag(double)
    */
-  public void setBetrag(double betrag) throws RemoteException {
+  public void setBetrag(double betrag) throws RemoteException
+  {
 		setAttribute("betrag", new Double(betrag));
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setZweck(java.lang.String)
    */
-  public void setZweck(String zweck) throws RemoteException {
+  public void setZweck(String zweck) throws RemoteException
+  {
 		setAttribute("zweck",zweck);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setZweck2(java.lang.String)
    */
-  public void setZweck2(String zweck2) throws RemoteException {
+  public void setZweck2(String zweck2) throws RemoteException
+  {
 		setAttribute("zweck2",zweck2);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getGegenkontoNummer()
    */
-  public String getGegenkontoNummer() throws RemoteException {
+  public String getGegenkontoNummer() throws RemoteException
+  {
     return (String) getAttribute("empfaenger_konto");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getGegenkontoBLZ()
    */
-  public String getGegenkontoBLZ() throws RemoteException {
+  public String getGegenkontoBLZ() throws RemoteException
+  {
 		return (String) getAttribute("empfaenger_blz");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getGegenkontoName()
    */
-  public String getGegenkontoName() throws RemoteException {
+  public String getGegenkontoName() throws RemoteException
+  {
 		return (String) getAttribute("empfaenger_name");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setGegenkontoNummer(java.lang.String)
    */
-  public void setGegenkontoNummer(String konto) throws RemoteException {
+  public void setGegenkontoNummer(String konto) throws RemoteException
+  {
 		setAttribute("empfaenger_konto",konto != null ? konto.toUpperCase() : null);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setGegenkontoBLZ(java.lang.String)
    */
-  public void setGegenkontoBLZ(String blz) throws RemoteException {
+  public void setGegenkontoBLZ(String blz) throws RemoteException
+  {
 		setAttribute("empfaenger_blz",blz);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setGegenkontoName(java.lang.String)
    */
-  public void setGegenkontoName(String name) throws RemoteException {
+  public void setGegenkontoName(String name) throws RemoteException
+  {
 		setAttribute("empfaenger_name",name);
   }
 

--- a/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferBuchungImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferBuchungImpl.java
@@ -52,7 +52,8 @@ public abstract class AbstractSammelTransferBuchungImpl extends AbstractHibiscus
    */
   protected void insertCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       if (getSammelTransfer() == null)
         throw new ApplicationException(i18n.tr("Bitte wählen Sie den zugehörigen Sammel-Auftrag aus."));
 

--- a/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
@@ -57,7 +57,8 @@ public abstract class AbstractSammelTransferImpl extends AbstractHibiscusDBObjec
    */
   protected void insertCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       if (getKonto() == null)
         throw new ApplicationException(i18n.tr("Bitte wählen Sie ein Konto aus."));
       if (getKonto().isNewObject())
@@ -81,7 +82,8 @@ public abstract class AbstractSammelTransferImpl extends AbstractHibiscusDBObjec
    */
   protected void updateCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       if (!whileStore && ausgefuehrt())
         throw new ApplicationException(i18n.tr("Auftrag wurde bereits ausgeführt und kann daher nicht mehr geändert werden."));
     }
@@ -223,7 +225,8 @@ public abstract class AbstractSammelTransferImpl extends AbstractHibiscusDBObjec
   {
     // Wir muessen auch alle Buchungen mitloeschen
     // da Constraints dorthin existieren.
-    try {
+    try
+    {
       this.transactionBegin();
 
       int count = 0;

--- a/src/de/willuhn/jameica/hbci/server/AbstractSepaSammelTransferBuchungImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSepaSammelTransferBuchungImpl.java
@@ -53,7 +53,8 @@ public abstract class AbstractSepaSammelTransferBuchungImpl<T extends SepaSammel
    */
   protected void insertCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       if (getSammelTransfer() == null)
         throw new ApplicationException(i18n.tr("Bitte wählen Sie den zugehörigen Sammel-Auftrag aus."));
 

--- a/src/de/willuhn/jameica/hbci/server/AbstractSepaSammelTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSepaSammelTransferImpl.java
@@ -58,7 +58,8 @@ public abstract class AbstractSepaSammelTransferImpl<T extends SepaSammelTransfe
    */
   protected void insertCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       
       Konto k = getKonto();
 
@@ -104,7 +105,8 @@ public abstract class AbstractSepaSammelTransferImpl<T extends SepaSammelTransfe
    */
   protected void updateCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       if (!this.markingExecuted() && this.ausgefuehrt())
         throw new ApplicationException(i18n.tr("Auftrag wurde bereits ausgeführt und kann daher nicht mehr geändert werden."));
     }
@@ -250,7 +252,8 @@ public abstract class AbstractSepaSammelTransferImpl<T extends SepaSammelTransfe
   {
     // Wir muessen auch alle Buchungen mitloeschen
     // da Constraints dorthin existieren.
-    try {
+    try
+    {
       this.transactionBegin();
 
       int count = 0;

--- a/src/de/willuhn/jameica/hbci/server/AuslandsUeberweisungImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AuslandsUeberweisungImpl.java
@@ -34,21 +34,24 @@ public class AuslandsUeberweisungImpl extends AbstractBaseUeberweisungImpl imple
   /**
    * @throws RemoteException
    */
-  public AuslandsUeberweisungImpl() throws RemoteException {
+  public AuslandsUeberweisungImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#getTableName()
    */
-  protected String getTableName() {
+  protected String getTableName()
+  {
     return "aueberweisung";
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Duplicatable#duplicate()
    */
-  public Duplicatable duplicate() throws RemoteException {
+  public Duplicatable duplicate() throws RemoteException
+  {
     AuslandsUeberweisung u = (AuslandsUeberweisung) getService().createObject(AuslandsUeberweisung.class,null);
     u.setBetrag(getBetrag());
     u.setGegenkontoNummer(getGegenkontoNummer());
@@ -69,20 +72,22 @@ public class AuslandsUeberweisungImpl extends AbstractBaseUeberweisungImpl imple
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#insertCheck()
    */
-  protected void insertCheck() throws ApplicationException {
+  protected void insertCheck() throws ApplicationException
+  {
     
-    try {
+    try
+    {
       Konto k = getKonto();
 
       if (k == null)
         throw new ApplicationException(i18n.tr("Bitte wählen Sie ein Konto aus."));
       if (k.isNewObject())
         throw new ApplicationException(i18n.tr("Bitte speichern Sie zunächst das Konto"));
-      
+
       String kiban = k.getIban();
       if (kiban == null || kiban.length() == 0)
         throw new ApplicationException(i18n.tr("Das ausgewählte Konto besitzt keine IBAN"));
-      
+
       String bic = k.getBic();
       if (bic == null || bic.length() == 0)
         throw new ApplicationException(i18n.tr("Das ausgewählte Konto besitzt keine BIC"));

--- a/src/de/willuhn/jameica/hbci/server/Cache.java
+++ b/src/de/willuhn/jameica/hbci/server/Cache.java
@@ -87,7 +87,8 @@ class Cache
    */
   static Cache get(final Class<? extends DBObject> type, boolean init) throws RemoteException
   {
-    return get(type,new ObjectFactory() {
+    return get(type, new ObjectFactory()
+    {
       public DBIterator load() throws RemoteException
       {
         return Settings.getDBService().createList(type);

--- a/src/de/willuhn/jameica/hbci/server/DBPropertyUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/DBPropertyUtil.java
@@ -353,7 +353,8 @@ public class DBPropertyUtil
     try
     {
       final String localPrefix = createScopeIdentifier(prefix,scope);
-      final Map<String,DBProperty> cache = CACHE.get(localPrefix,new Callable<Map<String,DBProperty>>() {
+      final Map<String, DBProperty> cache = CACHE.get(localPrefix, new Callable<Map<String, DBProperty>>()
+      {
         /**
          * @see java.util.concurrent.Callable#call()
          */

--- a/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabe.java
+++ b/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabe.java
@@ -97,7 +97,8 @@ public class EinnahmeAusgabe implements EinnahmeAusgabeZeitraum
     if (umsatz.getBetrag() > 0.0d)
     {
       this.einnahmen += umsatz.getBetrag();
-    } else
+    }
+    else
     {
       this.ausgaben += -umsatz.getBetrag();
     }

--- a/src/de/willuhn/jameica/hbci/server/HibiscusAddressImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/HibiscusAddressImpl.java
@@ -23,37 +23,42 @@ import de.willuhn.util.I18N;
 /**
  * Implementierung einer Hibiscus-Adresse.
  */
-public class HibiscusAddressImpl extends AbstractHibiscusDBObject implements HibiscusAddress {
+public class HibiscusAddressImpl extends AbstractHibiscusDBObject implements HibiscusAddress
+{
 
   private final static transient I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   /**
    * @throws RemoteException
    */
-  public HibiscusAddressImpl() throws RemoteException {
+  public HibiscusAddressImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#getTableName()
    */
-  protected String getTableName() {
+  protected String getTableName()
+  {
     return "empfaenger";
   }
 
   /**
    * @see de.willuhn.datasource.GenericObject#getPrimaryAttribute()
    */
-  public String getPrimaryAttribute() throws RemoteException {
+  public String getPrimaryAttribute() throws RemoteException
+  {
     return "name";
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#insertCheck()
    */
-  protected void insertCheck() throws ApplicationException {
-		try
-		{
+  protected void insertCheck() throws ApplicationException
+  {
+    try
+    {
       //////////////////////////////////////////////////////////////////////////
       // Kontoinhaber
       String name = this.getName();
@@ -125,14 +130,16 @@ public class HibiscusAddressImpl extends AbstractHibiscusDBObject implements Hib
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#updateCheck()
    */
-  protected void updateCheck() throws ApplicationException {
+  protected void updateCheck() throws ApplicationException
+  {
 		insertCheck();
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Address#getKontonummer()
    */
-  public String getKontonummer() throws RemoteException {
+  public String getKontonummer() throws RemoteException
+  {
     return (String) getAttribute("kontonummer");
   }
 
@@ -147,28 +154,32 @@ public class HibiscusAddressImpl extends AbstractHibiscusDBObject implements Hib
   /**
    * @see de.willuhn.jameica.hbci.rmi.Address#getName()
    */
-  public String getName() throws RemoteException {
+  public String getName() throws RemoteException
+  {
 		return (String) getAttribute("name");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusAddress#setKontonummer(java.lang.String)
    */
-  public void setKontonummer(String kontonummer) throws RemoteException {
+  public void setKontonummer(String kontonummer) throws RemoteException
+  {
   	setAttribute("kontonummer",kontonummer);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusAddress#setBlz(java.lang.String)
    */
-  public void setBlz(String blz) throws RemoteException {
+  public void setBlz(String blz) throws RemoteException
+  {
     setAttribute("blz",blz);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusAddress#setName(java.lang.String)
    */
-  public void setName(String name) throws RemoteException {
+  public void setName(String name) throws RemoteException
+  {
   	setAttribute("name",name);
   }
 

--- a/src/de/willuhn/jameica/hbci/server/ProtokollImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/ProtokollImpl.java
@@ -23,7 +23,8 @@ import de.willuhn.util.I18N;
 /**
  * Implementierung der HBCI-Protokollierung pro Konto.
  */
-public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll {
+public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
+{
 
   private final static transient I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
@@ -31,21 +32,24 @@ public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
    * ct.
    * @throws java.rmi.RemoteException
    */
-  public ProtokollImpl() throws RemoteException {
+  public ProtokollImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#getTableName()
    */
-  protected String getTableName() {
+  protected String getTableName()
+  {
     return "protokoll";
   }
 
   /**
    * @see de.willuhn.datasource.GenericObject#getPrimaryAttribute()
    */
-  public String getPrimaryAttribute() throws RemoteException {
+  public String getPrimaryAttribute() throws RemoteException
+  {
     return "kommentar";
   }
 
@@ -66,7 +70,8 @@ public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
    */
   protected void insertCheck() throws ApplicationException
   {
-		try {
+    try
+    {
 			if (getKonto() == null)
 				throw new ApplicationException(i18n.tr("Konto fehlt."));
 
@@ -92,14 +97,16 @@ public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#updateCheck()
    */
-  protected void updateCheck() throws ApplicationException {
+  protected void updateCheck() throws ApplicationException
+  {
     throw new ApplicationException(i18n.tr("Protokoll-Daten dürfen nicht geändert werden."));
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#getForeignObject(java.lang.String)
    */
-  protected Class getForeignObject(String field) throws RemoteException {
+  protected Class getForeignObject(String field) throws RemoteException
+  {
 		if ("konto_id".equals(field))
 			return Konto.class;
 		return null;
@@ -108,28 +115,32 @@ public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#getKonto()
    */
-  public Konto getKonto() throws RemoteException {
+  public Konto getKonto() throws RemoteException
+  {
   	return (Konto) getAttribute("konto_id");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#getKommentar()
    */
-  public String getKommentar() throws RemoteException {
+  public String getKommentar() throws RemoteException
+  {
     return (String) getAttribute("kommentar");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#getDatum()
    */
-  public Date getDatum() throws RemoteException {
+  public Date getDatum() throws RemoteException
+  {
     return (Date) getAttribute("datum");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#getTyp()
    */
-  public int getTyp() throws RemoteException {
+  public int getTyp() throws RemoteException
+  {
 		Integer i = (Integer) getAttribute("typ");
 		if (i == null)
 			return TYP_UNKNOWN;
@@ -139,7 +150,8 @@ public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#setKonto(de.willuhn.jameica.hbci.rmi.Konto)
    */
-  public void setKonto(Konto konto) throws RemoteException {
+  public void setKonto(Konto konto) throws RemoteException
+  {
     setAttribute("konto_id",konto);
 
   }
@@ -147,14 +159,16 @@ public class ProtokollImpl extends AbstractHibiscusDBObject implements Protokoll
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#setKommentar(java.lang.String)
    */
-  public void setKommentar(String kommentar) throws RemoteException {
+  public void setKommentar(String kommentar) throws RemoteException
+  {
   	setAttribute("kommentar",kommentar);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Protokoll#setTyp(int)
    */
-  public void setTyp(int typ) throws RemoteException {
+  public void setTyp(int typ) throws RemoteException
+  {
 		if (typ != TYP_ERROR && typ != TYP_SUCCESS)
 			typ = TYP_UNKNOWN;
 		setAttribute("typ",new Integer(typ));

--- a/src/de/willuhn/jameica/hbci/server/Range.java
+++ b/src/de/willuhn/jameica/hbci/server/Range.java
@@ -398,7 +398,8 @@ public abstract class Range
   /**
    * Zeitraum ab heute vor einem Jahr
    * */
-  public static class Last356Days extends LastYears{
+  public static class Last356Days extends LastYears
+  {
     protected Last356Days()
     {
        super(1, "Letzte 365 Tage");
@@ -408,7 +409,8 @@ public abstract class Range
   /**
    * Zeitraum ab heute vor drei Jahren
    * */
-  public static class Last3Years extends LastYears{
+  public static class Last3Years extends LastYears
+  {
     protected Last3Years()
     {
        super(3, "Letzte 3 Jahre");
@@ -418,7 +420,8 @@ public abstract class Range
   /**
    * Zeitraum ab heute vor fünf Jahren
    * */
-  public static class Last5Years extends LastYears{
+  public static class Last5Years extends LastYears
+  {
     protected Last5Years()
     {
        super(5, "Letzte 5 Jahre");
@@ -428,7 +431,8 @@ public abstract class Range
   /**
    * Zeitraum ab heute vor zehn Jahren
    * */
-  public static class Last10Years extends LastYears{
+  public static class Last10Years extends LastYears
+  {
     protected Last10Years()
     {
        super(10, "Letzte 10 Jahre");

--- a/src/de/willuhn/jameica/hbci/server/SepaDauerauftragImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/SepaDauerauftragImpl.java
@@ -97,7 +97,8 @@ public class SepaDauerauftragImpl extends AbstractBaseDauerauftragImpl implement
    */
   protected void insertCheck() throws ApplicationException
   {
-    try {
+    try
+    {
       
       Konto k = getKonto();
 

--- a/src/de/willuhn/jameica/hbci/server/SepaLastschriftImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/SepaLastschriftImpl.java
@@ -53,7 +53,8 @@ public class SepaLastschriftImpl extends AbstractBaseUeberweisungImpl implements
   /**
    * @see de.willuhn.jameica.hbci.rmi.Duplicatable#duplicate()
    */
-  public Duplicatable duplicate() throws RemoteException {
+  public Duplicatable duplicate() throws RemoteException
+  {
     SepaLastschriftImpl u = (SepaLastschriftImpl) getService().createObject(SepaLastschrift.class,null);
     u.setBetrag(getBetrag());
     u.setGegenkontoNummer(getGegenkontoNummer());
@@ -93,8 +94,10 @@ public class SepaLastschriftImpl extends AbstractBaseUeberweisungImpl implements
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#insertCheck()
    */
-  protected void insertCheck() throws ApplicationException {
-    try {
+  protected void insertCheck() throws ApplicationException
+  {
+    try
+    {
       Konto k = getKonto();
 
       if (k == null)

--- a/src/de/willuhn/jameica/hbci/server/SepaSammelLastschriftImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/SepaSammelLastschriftImpl.java
@@ -58,7 +58,8 @@ public class SepaSammelLastschriftImpl extends AbstractSepaSammelTransferImpl<Se
   {
     super.insertCheck();
 
-    try {
+    try
+    {
       if (getSequenceType() == null)
         throw new ApplicationException(i18n.tr("Bitte wählen Sie den Sequenz-Typ aus"));
 

--- a/src/de/willuhn/jameica/hbci/server/TurnusImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/TurnusImpl.java
@@ -59,7 +59,8 @@ public class TurnusImpl extends AbstractHibiscusDBObject implements Turnus
    */
   protected void deleteCheck() throws ApplicationException
   {
-		try {
+		try
+		{
 			if (isInitial())
 				throw new ApplicationException(i18n.tr("Turnus ist Bestandteil der System-Daten und kann nicht gelöscht werden."));
 		}
@@ -75,7 +76,8 @@ public class TurnusImpl extends AbstractHibiscusDBObject implements Turnus
    */
   protected void insertCheck() throws ApplicationException
   {
-  	try {
+    try
+    {
 
   		if (getZeiteinheit() != Turnus.ZEITEINHEIT_MONATLICH && getZeiteinheit() != Turnus.ZEITEINHEIT_WOECHENTLICH)
   			throw new ApplicationException(i18n.tr("Bitte wählen Sie eine gültige Zeiteinheit aus"));

--- a/src/de/willuhn/jameica/hbci/server/UeberweisungImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UeberweisungImpl.java
@@ -30,14 +30,16 @@ public class UeberweisungImpl extends AbstractBaseUeberweisungImpl implements Ue
   /**
    * @throws RemoteException
    */
-  public UeberweisungImpl() throws RemoteException {
+  public UeberweisungImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#getTableName()
    */
-  protected String getTableName() {
+  protected String getTableName()
+  {
     return "ueberweisung";
   }
 

--- a/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
@@ -43,28 +43,32 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @throws RemoteException
    */
-  public UmsatzImpl() throws RemoteException {
+  public UmsatzImpl() throws RemoteException
+  {
     super();
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#getTableName()
    */
-  protected String getTableName() {
+  protected String getTableName()
+  {
     return "umsatz";
   }
 
   /**
    * @see de.willuhn.datasource.GenericObject#getPrimaryAttribute()
    */
-  public String getPrimaryAttribute() throws RemoteException {
+  public String getPrimaryAttribute() throws RemoteException
+  {
     return "zweck";
   }
 
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#insertCheck()
    */
-  protected void insertCheck() throws ApplicationException {
+  protected void insertCheck() throws ApplicationException
+  {
 		try
 		{
 			if (Double.isNaN(getBetrag()))
@@ -110,7 +114,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.datasource.db.AbstractDBObject#updateCheck()
    */
-  protected void updateCheck() throws ApplicationException {
+  protected void updateCheck() throws ApplicationException
+  {
 		insertCheck();
   }
 
@@ -143,7 +148,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getGegenkontoName()
    */
-  public String getGegenkontoName() throws RemoteException {
+  public String getGegenkontoName() throws RemoteException
+  {
     return (String) getAttribute("empfaenger_name");
   }
 
@@ -166,7 +172,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getBetrag()
    */
-  public double getBetrag() throws RemoteException {
+  public double getBetrag() throws RemoteException
+  {
 		Double d = (Double) getAttribute("betrag");
 		if (d == null)
 			return 0;
@@ -176,28 +183,32 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#getDatum()
    */
-  public Date getDatum() throws RemoteException {
+  public Date getDatum() throws RemoteException
+  {
 		return (Date) getAttribute("datum");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#getValuta()
    */
-  public Date getValuta() throws RemoteException {
+  public Date getValuta() throws RemoteException
+  {
 		return (Date) getAttribute("valuta");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Transfer#getZweck()
    */
-  public String getZweck() throws RemoteException {
+  public String getZweck() throws RemoteException
+  {
 		return (String) getAttribute("zweck");
   }
 
 	/**
 	 * @see de.willuhn.jameica.hbci.rmi.Transfer#getZweck2()
 	 */
-	public String getZweck2() throws RemoteException {
+	public String getZweck2() throws RemoteException
+	{
 		return (String) getAttribute("zweck2");
 	}
 
@@ -229,63 +240,72 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setGegenkontoName(java.lang.String)
    */
-  public void setGegenkontoName(String name) throws RemoteException {
+  public void setGegenkontoName(String name) throws RemoteException
+  {
 		setAttribute("empfaenger_name",name);
   }
 
 	/**
 	 * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setGegenkontoNummer(java.lang.String)
 	 */
-	public void setGegenkontoNummer(String konto) throws RemoteException {
+	public void setGegenkontoNummer(String konto) throws RemoteException
+	{
     setAttribute("empfaenger_konto",konto);
   }
   
 	/**
 	 * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setGegenkontoBLZ(java.lang.String)
 	 */
-	public void setGegenkontoBLZ(String blz) throws RemoteException {
+	public void setGegenkontoBLZ(String blz) throws RemoteException
+	{
     setAttribute("empfaenger_blz",blz);
   }
   
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setBetrag(double)
    */
-  public void setBetrag(double d) throws RemoteException {
+  public void setBetrag(double d) throws RemoteException
+  {
 		setAttribute("betrag",new Double(d));
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setZweck(java.lang.String)
    */
-  public void setZweck(String zweck) throws RemoteException {
+  public void setZweck(String zweck) throws RemoteException
+  {
 		setAttribute("zweck",zweck);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setZweck2(java.lang.String)
    */
-  public void setZweck2(String zweck2) throws RemoteException {
+  public void setZweck2(String zweck2) throws RemoteException
+  {
 		setAttribute("zweck2",zweck2);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#setDatum(java.util.Date)
    */
-  public void setDatum(Date d) throws RemoteException {
+  public void setDatum(Date d) throws RemoteException
+  {
 		setAttribute("datum",d);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#setValuta(java.util.Date)
    */
-  public void setValuta(Date d) throws RemoteException {
+  public void setValuta(Date d) throws RemoteException
+  {
 		setAttribute("valuta",d);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.HibiscusTransfer#setKonto(de.willuhn.jameica.hbci.rmi.Konto)
    */
-  public void setKonto(Konto k) throws RemoteException {
+  public void setKonto(Konto k) throws RemoteException
+  {
     setAttribute("konto_id",(k == null || k.getID() == null) ? null : new Integer(k.getID()));
   }
 
@@ -297,7 +317,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
    * muessen wir selbst einen fachlichen Vergleich durchfuehren.
    * @see de.willuhn.datasource.GenericObject#equals(de.willuhn.datasource.GenericObject)
    */
-  public boolean equals(GenericObject o) throws RemoteException {
+  public boolean equals(GenericObject o) throws RemoteException
+  {
 		if (o == null || !(o instanceof Umsatz))
 			return false;
 		try
@@ -330,7 +351,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#getSaldo()
    */
-  public double getSaldo() throws RemoteException {
+  public double getSaldo() throws RemoteException
+  {
 		Double d = (Double) getAttribute("saldo");
 		if (d == null)
 			return 0;
@@ -340,56 +362,64 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#getPrimanota()
    */
-  public String getPrimanota() throws RemoteException {
+  public String getPrimanota() throws RemoteException
+  {
 		return (String) getAttribute("primanota");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#getArt()
    */
-  public String getArt() throws RemoteException {
+  public String getArt() throws RemoteException
+  {
 		return (String) getAttribute("art");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#getCustomerRef()
    */
-  public String getCustomerRef() throws RemoteException {
+  public String getCustomerRef() throws RemoteException
+  {
 		return (String) getAttribute("customerref");
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#setSaldo(double)
    */
-  public void setSaldo(double s) throws RemoteException {
+  public void setSaldo(double s) throws RemoteException
+  {
 		setAttribute("saldo",new Double(s));
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#setPrimanota(java.lang.String)
    */
-  public void setPrimanota(String primanota) throws RemoteException {
+  public void setPrimanota(String primanota) throws RemoteException
+  {
 		setAttribute("primanota",primanota);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#setArt(java.lang.String)
    */
-  public void setArt(String art) throws RemoteException {
+  public void setArt(String art) throws RemoteException
+  {
 		setAttribute("art",art);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Umsatz#setCustomerRef(java.lang.String)
    */
-  public void setCustomerRef(String ref) throws RemoteException {
+  public void setCustomerRef(String ref) throws RemoteException
+  {
 		setAttribute("customerref",ref);
   }
 
   /**
    * @see de.willuhn.jameica.hbci.rmi.Checksum#getChecksum()
    */
-  public long getChecksum() throws RemoteException {
+  public long getChecksum() throws RemoteException
+  {
 
     Number n = (Number) this.getAttribute("checksum");
     if (n != null && n.longValue() != 0)
@@ -404,19 +434,23 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
     
     if (datum != null)
     {
-      try {
+      try
+      {
         sd = HBCI.DATEFORMAT.format(datum);
       }
-      catch (Exception e) {
+      catch (Exception e)
+      {
         sd = datum.toString();
       }
     }
     if (valuta != null)
     {
-      try {
+      try
+      {
         sv = HBCI.DATEFORMAT.format(valuta);
       }
-      catch (Exception e) {
+      catch (Exception e)
+      {
         sv = valuta.toString();
       }
     }
@@ -639,7 +673,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
     // ID von fest verdrahteten Kategorien
     Integer i = (Integer) super.getAttribute("umsatztyp_id");
 
-    Cache cache = Cache.get(UmsatzTyp.class, new Cache.ObjectFactory() {
+    Cache cache = Cache.get(UmsatzTyp.class, new Cache.ObjectFactory()
+    {
       public DBIterator load() throws RemoteException
       {
         return UmsatzTypUtil.getAll();

--- a/src/de/willuhn/jameica/hbci/server/UmsatzUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzUtil.java
@@ -82,7 +82,8 @@ public class UmsatzUtil
       params = new String[]{(String) kontoOrGroup};
     }
     
-    return (Date) Settings.getDBService().execute(query,params,new ResultSetExtractor() {
+    return (Date) Settings.getDBService().execute(query, params, new ResultSetExtractor()
+    {
       public Object extract(ResultSet rs) throws RemoteException, SQLException
       {
         if (!rs.next())

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragDeleteJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragDeleteJob.java
@@ -142,7 +142,8 @@ public class HBCISepaDauerauftragDeleteJob extends AbstractHBCIJob
   /**
    * @see de.willuhn.jameica.hbci.server.hbci.AbstractHBCIJob#getIdentifier()
    */
-  public String getIdentifier() {
+  public String getIdentifier()
+  {
     return "DauerSEPADel";
   }
 

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
@@ -165,7 +165,8 @@ public class HBCISepaDauerauftragStoreJob extends AbstractHBCIJob
   /**
    * @see de.willuhn.jameica.hbci.server.hbci.AbstractHBCIJob#getIdentifier()
    */
-  public String getIdentifier() {
+  public String getIdentifier()
+  {
 		if (active)
 			return "DauerSEPAEdit";
   	return "DauerSEPANew";

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
@@ -238,7 +238,8 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
         for (int j = 0; j<existing.size(); j++)
         {
           GenericObject dbObject = existing.next();
-          if (dbObject.equals(umsatz)) {
+          if (dbObject.equals(umsatz))
+          {
             counter++;
             fromDB = (Umsatz) dbObject; //wir merken uns immer den letzten Umsatz
           }
@@ -251,7 +252,8 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
           // neu. Dazu zaehlen wir mit, wie oft wir gerade einen "gleichen" 
           // Umsatz empfangen haben. 
           Integer countInCurrentJobResult = duplicates.get(fromDB);
-          if (countInCurrentJobResult == null) {
+          if (countInCurrentJobResult == null)
+          {
             duplicates.put(fromDB, 1);
             skipped++;
             continue;

--- a/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
@@ -80,7 +80,8 @@ public class SynchronizeEngine
       }
       
       // Wir sortieren die Backends so, dass das Primaer-Backend immer Vorrang hat
-      Collections.sort(this.backends,new Comparator<SynchronizeBackend>() {
+      Collections.sort(this.backends, new Comparator<SynchronizeBackend>()
+      {
         public int compare(SynchronizeBackend o1, SynchronizeBackend o2)
         {
           

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeBackend.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeBackend.java
@@ -626,13 +626,17 @@ public class HBCISynchronizeBackend extends AbstractSynchronizeBackend<HBCISynch
       @Override
       public void run()
       {
-        try {
+        try
+        {
           this.result = this.internalExecute();
         }
-        catch (Exception e) { // wir fangen nur Exceptions, keine Errors
+        catch (Exception e)
+        {
+          // wir fangen nur Exceptions, keine Errors
           this.exception = e;
         }
-        catch (Throwable t) {
+        catch (Throwable t)
+        {
           if (t instanceof Error)
             throw (Error) t;
           throw new Error(t);


### PR DESCRIPTION
Um einen konsistent einheitlichen Codestil in den Dateien zu erreichen, werden hier die geschweiften Klammern, die mit dem restlichen Code in der gleichen Zeile stehen, auf eine jeweils eigene Zeile verschoben.

Die restlichen Formatierungsauffälligkeiten (z.B. TAB statt Leerzeichen) werden hier explizit _nicht_ adressiert, um das Code-Review auf einen Fakt zu fokussieren.