### PR TITLE
Korrektur aller Stellen mit Javadoc-Fehler

### DIFF
--- a/src/de/willuhn/jameica/hbci/HBCIProperties.java
+++ b/src/de/willuhn/jameica/hbci/HBCIProperties.java
@@ -246,7 +246,7 @@ public class HBCIProperties
 
   /**
    * Text-Replacements fuer SEPA.
-   * Die in SEPA nicht zulaessigen Zeichen "&*%$üצהÜײִß" werden ersetzt.
+   * Die in SEPA nicht zulaessigen Zeichen "{@code &*%$üצהÜײִß}" werden ersetzt.
    */
   public final static String[][] TEXT_REPLACEMENTS_SEPA = new String[][] {new String[]{"&","*","%","$","ü", "צ", "ה", "Ü", "ײ", "ִ", "ß"},
                                                                           new String[]{"+",".",".",".","ue","oe","ae","Ue","Oe","Ae","ss"}};

--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
@@ -121,10 +121,8 @@ public class ChartFeatureTooltip implements ChartFeature
    * aktuellen Punkt mehrere Serien gefunden werden) und der Angabe des X- und Y-Wertes. Letztere koennen in 
    * Kindklassen typabhängig formatiert werden. Die Default-Implementierung geht davon aus, dass es sich um ein Line-Chart
    * mit Zeitraum auf der X-Achse und Geldbetraegen auf der Y-Achse handelt.
-   * @param data
+   * @param foundData
    * @return der Tooltip-Text.
-   * @see this.getFormattedX()
-   * @see this.getFormattedY()
    */
   protected String getTooltipText(Collection<SeriesData> foundData)
   {

--- a/src/de/willuhn/jameica/hbci/io/AbstractSepaExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractSepaExporter.java
@@ -175,7 +175,7 @@ public abstract class AbstractSepaExporter extends AbstractExporter
    * Schreibt die Eigenschaften des Auftrages in die Properties. 
    * @param o das zu exportierende Objekt.
    * @param idx der Index in der Liste der Objekte.
-   * @param props die Properties.
+   * @param ctx der Auftragskontext.
    * @throws Exception
    */
   protected abstract void exportObject(Object o, int idx, JobContext ctx) throws Exception;

--- a/src/de/willuhn/jameica/hbci/io/IOFormat.java
+++ b/src/de/willuhn/jameica/hbci/io/IOFormat.java
@@ -23,7 +23,7 @@ public interface IOFormat
 {
   /**
    * Liefert einen sprechenden Namen fuer das Datei-Format.
-   * Zum Beispiel &quotCSV-Datei&quot;
+   * Zum Beispiel &quot;CSV-Datei&quot;
    * @return Sprechender Name des Datei-Formats.
    */
   public String getName();

--- a/src/de/willuhn/jameica/hbci/io/csv/ImportListener.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/ImportListener.java
@@ -37,7 +37,7 @@ public class ImportListener
    * Das wird z.Bsp. gebraucht, wenn ein Property in der Bean aus mehreren CSV-Spalten
    * zusammengesetzt ist.
    * @param event das Import-Event.
-   * Das Property "data" ist eine Map<String,Object> mit den Property-Namen als
+   * Das Property "data" ist eine {@code Map<String,Object>} mit den Property-Namen als
    * Keys und den deserialisierten Property-Werten als Values.
    * @throws OperationCanceledException wenn das Objekt uebersprungen werden soll.
    */

--- a/src/de/willuhn/jameica/hbci/messaging/MarkerKontoauszugMessageConsumer.java
+++ b/src/de/willuhn/jameica/hbci/messaging/MarkerKontoauszugMessageConsumer.java
@@ -25,7 +25,7 @@ import de.willuhn.logging.Level;
 import de.willuhn.logging.Logger;
 
 /**
- * Markiert das Navigations-Element "Auswertungen->Kontoauszuege", wenn neue Umsaetze vorhanden sind.
+ * Markiert das Navigations-Element "Auswertungen-&gt;Kontoauszuege", wenn neue Umsaetze vorhanden sind.
  */
 public class MarkerKontoauszugMessageConsumer implements MessageConsumer
 {

--- a/src/de/willuhn/jameica/hbci/messaging/MarkerUmsatzMessageConsumer.java
+++ b/src/de/willuhn/jameica/hbci/messaging/MarkerUmsatzMessageConsumer.java
@@ -25,7 +25,7 @@ import de.willuhn.logging.Level;
 import de.willuhn.logging.Logger;
 
 /**
- * Markiert das Navigations-Element "Auswertungen->Umsaetze", wenn neue Umsaetze vorhanden sind.
+ * Markiert das Navigations-Element "Auswertungen-&gt;Umsaetze", wenn neue Umsaetze vorhanden sind.
  */
 public class MarkerUmsatzMessageConsumer implements MessageConsumer
 {

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PtSecMech.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PtSecMech.java
@@ -92,7 +92,7 @@ public class PtSecMech
   
   /**
    * Erzeugt ein PTSechMech-Objekt aus dem Text.
-   * Der Text ist fuer gewoehnlich so zusammengesetzt: "<id>:<name>".
+   * Der Text ist fuer gewoehnlich so zusammengesetzt: "{@code <id>:<name>}".
    * @param text der zu parsende Text.
    * @return das PTSechMech-Objekt oder NULL, wenn es kein interpretierbares TAN-Verfahren war.
    */

--- a/src/de/willuhn/jameica/hbci/passports/rdh/RDHNewDump.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/RDHNewDump.java
@@ -38,11 +38,11 @@ import org.xml.sax.SAXException;
  * drin steht.
  * Der Code ist aus "HBCIPassportRDHNew" (HBCI4Java) zusammenkopiert.
  * Aufruf:
- * 
+ * {@code
  * java -cp hbci4java-....jar \
  *   de.willuhn.jameica.hbci.passports.rdh.RDHNewDump \
  *   <Schluesseldatei> <Passwort>
- * 
+ * }
  */
 public class RDHNewDump
 {

--- a/src/de/willuhn/jameica/hbci/rmi/HibiscusAddress.java
+++ b/src/de/willuhn/jameica/hbci/rmi/HibiscusAddress.java
@@ -49,7 +49,7 @@ public interface HibiscusAddress extends Address, HibiscusDBObject
   /**
    * Liefert den Namen der Bank.
    * Ist nur fuer auslaendische Banken sinnvoll, da HBCI4Java fuer
-   * deutsche Banken eine Mapping-Tabelle BLZ->Bankname mitbringt.
+   * deutsche Banken eine Mapping-Tabelle BLZ-&gt;Bankname mitbringt.
    * @return Name der Bank.
    * @throws RemoteException
    */
@@ -58,7 +58,7 @@ public interface HibiscusAddress extends Address, HibiscusDBObject
   /**
    * Speichert den Namen der Bank.
    * Ist nur fuer auslaendische Banken sinnvoll, da HBCI4Java fuer
-   * deutsche Banken eine Mapping-Tabelle BLZ->Bankname mitbringt.
+   * deutsche Banken eine Mapping-Tabelle BLZ-&gt;Bankname mitbringt.
    * @param name Name der Bank.
    * @throws RemoteException
    */


### PR DESCRIPTION
Javadoc erwartet bei `>` und `&` stets einen HTML-Tag und bricht ab, wenn dem nicht so ist.

Weiterhin gab es bei der Erstellung der Dokumentation ein paar Warnungen bzgl. fehlender Semikolons oder falscher Parameternamen, die ich hiermit ebenfalls korrigiert habe.