### PR TITLE
Nutze `Math.min()` statt eigener Logik

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -433,10 +433,7 @@ public class SparQuote implements Part
       cal.add(Calendar.MONTH,monate);
 
       // Der Tag, ab dem die naechste Periode beginnt
-      if (stichtag > cal.getActualMaximum(Calendar.DAY_OF_MONTH))
-        cal.set(Calendar.DATE,cal.getActualMaximum(Calendar.DAY_OF_MONTH));
-      else
-        cal.set(Calendar.DATE, stichtag);
+      cal.set(Calendar.DATE, Math.min(stichtag, cal.getActualMaximum(Calendar.DAY_OF_MONTH)));
 
       // Merken wir uns fuer den naechsten Durchlauf
       from = DateUtil.startOfDay(cal.getTime());

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PhotoTANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PhotoTANDialog.java
@@ -178,7 +178,7 @@ public class PhotoTANDialog extends TANDialog
       int width = resize + 100;
       final int displayHeight = GUI.getDisplay().getBounds().height;
       Point p = this.getShell().computeSize(width,SWT.DEFAULT);
-      int height = p.y >= displayHeight ? displayHeight : p.y;
+      int height = Math.min(p.y, displayHeight);
       this.setSize(width,height);
     }
     


### PR DESCRIPTION
Statt die Logik jedes Mal beim Lesen im Kopf ausrechnen zu müssen, erleichtert die Verwendung von `min` intuitiv das Verständnis, dass hier das Minimum der beiden Werte verwendet werden soll.