### PR TITLE
optimiere `try/catch/finally`

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/AuslandsUeberweisungNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/AuslandsUeberweisungNew.java
@@ -145,13 +145,9 @@ public class AuslandsUeberweisungNew implements Action
         u = i.getUeberweisung();
       }
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoFetchFromPassport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoFetchFromPassport.java
@@ -67,13 +67,9 @@ public class KontoFetchFromPassport implements Action
         passport = (Passport) d.open();
       }
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoKontoauszugReceipt.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoKontoauszugReceipt.java
@@ -60,10 +60,6 @@ public class KontoKontoauszugReceipt implements Action
 	    
 	    backend.execute(Arrays.asList(job));
 		}
-		catch (ApplicationException ae)
-		{
-		  throw ae;
-		}
 		catch (RemoteException re)
 		{
 		  Logger.error("unable to send receipt",re);

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoauszugExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoauszugExport.java
@@ -47,13 +47,9 @@ public class KontoauszugExport extends Export
       if (!Application.getCallback().askUser(note,true))
         return;
     }
-    catch (OperationCanceledException oce)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw oce;
-    }
-    catch (ApplicationException ae)
-    {
-      throw ae;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoauszugSave.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoauszugSave.java
@@ -80,10 +80,6 @@ public class KontoauszugSave implements Action
       KontoauszugPdfUtil.store(k,file);
       Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Kontoauszug gespeichert"),StatusBarMessage.TYPE_SUCCESS));
     }
-    catch (ApplicationException ae)
-    {
-      throw ae;
-    }
     catch (RemoteException re)
     {
       Logger.error("unable to save file",re);

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoauszugSettings.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoauszugSettings.java
@@ -36,13 +36,9 @@ public class KontoauszugSettings implements Action
       KontoauszugSettingsDialog d = new KontoauszugSettingsDialog();
       d.open();
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaConvertAddress.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaConvertAddress.java
@@ -62,13 +62,9 @@ public class SepaConvertAddress implements Action
       if (!Application.getCallback().askUser(q))
         return;
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/action/Synchronize.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/Synchronize.java
@@ -112,13 +112,9 @@ public class Synchronize implements Action
       SynchronizeExecuteDialog d = new SynchronizeExecuteDialog(jobs,SynchronizeExecuteDialog.POSITION_CENTER);
       d.open();
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
@@ -152,13 +152,9 @@ public class CSVImportDialog extends AbstractDialog
           if (!Application.getCallback().askUser(i18n.tr("Soll das Profil wirklich gelöscht werden?"),false))
             return;
         }
-        catch (ApplicationException ae)
+        catch (ApplicationException | OperationCanceledException e)
         {
-          throw ae;
-        }
-        catch (OperationCanceledException oce)
-        {
-          throw oce;
+          throw e;
         }
         catch (Exception e)
         {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/HBCITraceDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/HBCITraceDialog.java
@@ -219,6 +219,7 @@ public class HBCITraceDialog extends AbstractDialog
     }
     catch (OperationCanceledException oce)
     {
+      // Export abbrechen ohne GUI-Nachricht
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/gui/parts/ProtokollList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/ProtokollList.java
@@ -69,6 +69,7 @@ public class ProtokollList extends AbstractFromToList
         }
         catch (RemoteException e)
         {
+          // ignorieren, falls Aufruf von getTyp() scheitert
         }
       }
     });

--- a/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
@@ -294,6 +294,7 @@ public class SynchronizeList extends TablePart
       }
       catch (ApplicationException ae)
       {
+        // hier notwendig, da nächster Catch alles fängt
         throw ae;
       }
       catch (Exception e)

--- a/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SynchronizeList.java
@@ -351,10 +351,6 @@ public class SynchronizeList extends TablePart
       {
         // ignore
       }
-      catch (ApplicationException ae)
-      {
-        throw ae;
-      }
       catch (RemoteException re)
       {
         Logger.error("error while synchronizing",re);

--- a/src/de/willuhn/jameica/hbci/io/AbstractExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractExporter.java
@@ -54,13 +54,9 @@ public abstract class AbstractExporter implements Exporter
       this.commit(objects,format,os,monitor);
       Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Daten exportiert"),StatusBarMessage.TYPE_SUCCESS));
     }
-    catch (OperationCanceledException oce)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw oce;
-    }
-    catch (ApplicationException ae)
-    {
-      throw ae;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
@@ -74,13 +74,9 @@ public abstract class AbstractImporter implements Importer
       this.commit(objects,format,is,monitor);
       monitor.log(i18n.tr("{0} importiert, {1} fehlerhaft",Integer.toString(success),Integer.toString(failed)));
     }
-    catch (OperationCanceledException oce)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw oce;
-    }
-    catch (ApplicationException ae)
-    {
-      throw ae;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -260,13 +260,9 @@ public class CsvImporter implements Importer
       // Fertig.
       monitor.setStatusText(i18n.tr("{0} importiert, {1} fehlerhaft, {2} übersprungen", new String[]{Integer.toString(created),Integer.toString(error),Integer.toString(skipped)}));
     }
-    catch (OperationCanceledException oce)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw oce;
-    }
-    catch (ApplicationException ae)
-    {
-      throw ae;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -349,10 +349,8 @@ public class CsvImporter implements Importer
    */
   private static byte[] copy(InputStream is) throws IOException
   {
-    BufferedInputStream bis = null;
-    try
+    try (BufferedInputStream bis = new BufferedInputStream(is))
     {
-      bis = new BufferedInputStream(is);
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       
       byte[] buf = new byte[4096];
@@ -363,10 +361,6 @@ public class CsvImporter implements Importer
           bos.write(buf,0,read);
       }
       return bos.toByteArray();
-    }
-    finally
-    {
-      bis.close();
     }
   }
   

--- a/src/de/willuhn/jameica/hbci/io/csv/ProfileUtil.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/ProfileUtil.java
@@ -68,10 +68,8 @@ public class ProfileUtil
       return result;
     
     Logger.info("reading csv profile " + file);
-    XMLDecoder decoder = null;
-    try
+    try (XMLDecoder decoder = new XMLDecoder(new BufferedInputStream(new FileInputStream(file))))
     {
-      decoder = new XMLDecoder(new BufferedInputStream(new FileInputStream(file)));
       decoder.setExceptionListener(new ExceptionListener()
       {
         public void exceptionThrown(Exception e)
@@ -118,17 +116,6 @@ public class ProfileUtil
       Logger.error("unable to read profile " + file,e);
       Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Laden der Profile fehlgeschlagen: {0}",e.getMessage()),StatusBarMessage.TYPE_ERROR));
     }
-    finally
-    {
-      if (decoder != null)
-      {
-        try
-        {
-          decoder.close();
-        }
-        catch (Exception e) { /* useless */}
-      }
-    }
     return result;
   }
   
@@ -166,10 +153,8 @@ public class ProfileUtil
     File file = new File(dir,format.getClass().getName() + ".xml");
     
     Logger.info("writing csv profile " + file);
-    XMLEncoder encoder = null;
-    try
+    try (XMLEncoder encoder = new XMLEncoder(new BufferedOutputStream(new FileOutputStream(file))))
     {
-      encoder = new XMLEncoder(new BufferedOutputStream(new FileOutputStream(file)));
       encoder.setExceptionListener(new ExceptionListener()
       {
         public void exceptionThrown(Exception e)
@@ -193,16 +178,7 @@ public class ProfileUtil
     }
     catch (Exception e)
     {
-      Logger.error("unable to store profile " + file,e);
-    }
-    finally
-    {
-      if (encoder != null) {
-        try {
-          encoder.close();
-        }
-        catch (Exception e) { /* useless */}
-      }
+      Logger.error("unable to store profile " + file, e);
     }
   }
   

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfig.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfig.java
@@ -281,10 +281,6 @@ public class DDVConfig implements Configuration
       {
         Logger.warn("account " + ids[i] + " does not exist, removing from list");
       }
-      catch (RemoteException re)
-      {
-        throw re;
-      }
     }
     if (fixedIds.size() != ids.length)
     {

--- a/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
@@ -153,20 +153,10 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
       
 			return handler;
 		}
-    catch (RemoteException re)
+    catch (ApplicationException | OperationCanceledException | RemoteException e)
     {
       close();
-      throw re;
-    }
-    catch (OperationCanceledException oce)
-    {
-      close();
-      throw oce;
-    }
-    catch (ApplicationException ae)
-    {
-      close();
-      throw ae;
+      throw e;
     }
 		catch (Exception e)
 		{

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
@@ -178,13 +178,9 @@ public class PinTanConfigFactory
         // Das kann passieren, wenn der Passport unvollstaendig ist
       }
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
@@ -181,20 +181,10 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			handler=new HBCIHandler(hbciVersion,hbciPassport);
 			return handler;
 		}
-    catch (RemoteException re)
+    catch (ApplicationException | OperationCanceledException | RemoteException e)
     {
       close();
-      throw re;
-    }
-    catch (ApplicationException ae)
-    {
-      close();
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      close();
-      throw oce;
+      throw e;
     }
 		catch (Exception e)
 		{

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PinTanConfigImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PinTanConfigImpl.java
@@ -357,10 +357,6 @@ public class PinTanConfigImpl implements PinTanConfig
       {
         Logger.warn("account " + ids[i] + " does not exist, removing from list");
       }
-      catch (RemoteException re)
-      {
-        throw re;
-      }
     }
     if (fixedIds.size() != ids.length)
     {

--- a/src/de/willuhn/jameica/hbci/passports/rdh/RDHNewDump.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/RDHNewDump.java
@@ -79,10 +79,8 @@ public class RDHNewDump
     DocumentBuilder db=dbf.newDocumentBuilder();
 
     Element root = null;
-    CipherInputStream ci = null;
-    try
+    try (CipherInputStream ci = new CipherInputStream(new FileInputStream(args[0]), cipher))
     {
-      ci = new CipherInputStream(new FileInputStream(args[0]),cipher);
       root=db.parse(ci).getDocumentElement();
     }
     catch (CharConversionException e1)
@@ -93,11 +91,6 @@ public class RDHNewDump
     {
       System.out.println("Passwort falsch (bis JDK 1.4)");
       return;
-    }
-    finally
-    {
-      if (ci != null)
-        ci.close();
     }
 
     TransformerFactory tfac=TransformerFactory.newInstance();

--- a/src/de/willuhn/jameica/hbci/passports/rdh/keyformat/HBCI4JavaFormat.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/keyformat/HBCI4JavaFormat.java
@@ -134,13 +134,9 @@ public class HBCI4JavaFormat extends AbstractKeyFormat
       Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Schlüssel erfolgreich erstellt"), StatusBarMessage.TYPE_SUCCESS));
       return key;
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/passports/rdh/keyformat/SizRdhFormat.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/keyformat/SizRdhFormat.java
@@ -135,13 +135,9 @@ public class SizRdhFormat extends AbstractSizRdhFormat
       key.setFormat(new HBCI4JavaFormat()); // wir tragen nicht uns selbst ein - da wir den ja ins HBCI4Java-Format konvertiert haben
       return key;
     }
-    catch (ApplicationException ae)
+    catch (ApplicationException | OperationCanceledException e)
     {
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      throw oce;
+      throw e;
     }
     catch (Exception e)
     {

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
@@ -146,21 +146,11 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			handler = new HBCIHandler(hbciVersion,hbciPassport);
 			return handler;
 		}
-		catch (RemoteException re)
+		catch (ApplicationException | OperationCanceledException | RemoteException e)
 		{
 			close();
-			throw re;
+			throw e;
 		}
-    catch (ApplicationException ae)
-    {
-      close();
-      throw ae;
-    }
-    catch (OperationCanceledException oce)
-    {
-      close();
-      throw oce;
-    }
 		catch (Exception e)
 		{
 			close();

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/RDHKeyImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/RDHKeyImpl.java
@@ -222,10 +222,6 @@ public class RDHKeyImpl implements RDHKey
       {
         Logger.warn("konto " + ids[i] + " does not exist, skipping");
       }
-      catch (RemoteException re)
-      {
-        throw re;
-      }
     }
     return (Konto[])konten.toArray(new Konto[konten.size()]);
   }

--- a/src/de/willuhn/jameica/hbci/server/AbstractHibiscusDBObject.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractHibiscusDBObject.java
@@ -83,15 +83,10 @@ public abstract class AbstractHibiscusDBObject extends AbstractDBObject implemen
       super.delete();
       this.transactionCommit();
     }
-    catch (RemoteException e)
+    catch (ApplicationException | RemoteException e)
     {
       this.transactionRollback();
       throw e;
-    }
-    catch (ApplicationException e2)
-    {
-      this.transactionRollback();
-      throw e2;
     }
   }
   

--- a/src/de/willuhn/jameica/hbci/server/AbstractHibiscusTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractHibiscusTransferImpl.java
@@ -267,15 +267,10 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
       
       this.transactionCommit();
     }
-    catch (RemoteException re)
+    catch (ApplicationException | RemoteException e)
     {
       this.transactionRollback();
-      throw re;
-    }
-    catch (ApplicationException ae)
-    {
-      this.transactionRollback();
-      throw ae;
+      throw e;
     }
   }
 
@@ -346,7 +341,7 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
       
       this.transactionCommit();
     }
-    catch (RemoteException re)
+    catch (ApplicationException | RemoteException e)
     {
       try
       {
@@ -356,19 +351,7 @@ public abstract class AbstractHibiscusTransferImpl extends AbstractHibiscusDBObj
       {
         Logger.error("unable to rollback transaction",e2);
       }
-      throw re;
-    }
-    catch (ApplicationException ae)
-    {
-      try
-      {
-        this.transactionRollback();
-      }
-      catch (Exception e2)
-      {
-        Logger.error("unable to rollback transaction",e2);
-      }
-      throw ae;
+      throw e;
     }
   }
 }

--- a/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
@@ -247,15 +247,10 @@ public abstract class AbstractSammelTransferImpl extends AbstractHibiscusDBObjec
 
       this.transactionCommit();
     }
-    catch (RemoteException e)
+    catch (ApplicationException | RemoteException e)
     {
       this.transactionRollback();
       throw e;
-    }
-    catch (ApplicationException e2)
-    {
-      this.transactionRollback();
-      throw e2;
     }
   }
 

--- a/src/de/willuhn/jameica/hbci/server/AbstractSepaSammelTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSepaSammelTransferImpl.java
@@ -271,15 +271,10 @@ public abstract class AbstractSepaSammelTransferImpl<T extends SepaSammelTransfe
 
       this.transactionCommit();
     }
-    catch (RemoteException e)
+    catch (ApplicationException | RemoteException e)
     {
       this.transactionRollback();
       throw e;
-    }
-    catch (ApplicationException e2)
-    {
-      this.transactionRollback();
-      throw e2;
     }
   }
 

--- a/src/de/willuhn/jameica/hbci/server/DBReminderImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/DBReminderImpl.java
@@ -95,20 +95,13 @@ public class DBReminderImpl extends AbstractHibiscusDBObject implements DBRemind
     if (serialized == null || serialized.length() == 0)
       return null;
 
-    XMLDecoder decoder = null;
-    try
+    try (XMLDecoder decoder = new XMLDecoder(new ByteArrayInputStream(serialized.getBytes("UTF-8"))))
     {
-      decoder = new XMLDecoder(new ByteArrayInputStream(serialized.getBytes("UTF-8")));
       return (Reminder) decoder.readObject();
     }
     catch (Exception e)
     {
       throw new RemoteException("unable to unserialize reminder",e);
-    }
-    finally
-    {
-      if (decoder != null)
-        decoder.close();
     }
   }
 

--- a/src/de/willuhn/jameica/hbci/server/KontoImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/KontoImpl.java
@@ -393,15 +393,10 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       super.delete();
       this.transactionCommit();
     }
-    catch (RemoteException e)
+    catch (ApplicationException | RemoteException e)
     {
       this.transactionRollback();
       throw e;
-    }
-    catch (ApplicationException e2)
-    {
-      this.transactionRollback();
-      throw e2;
     }
   }
 

--- a/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
@@ -589,7 +589,7 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
       
       this.transactionCommit();
     }
-    catch (RemoteException re)
+    catch (ApplicationException | RemoteException e)
     {
       try
       {
@@ -599,19 +599,7 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
       {
         Logger.error("unable to rollback transaction",e2);
       }
-      throw re;
-    }
-    catch (ApplicationException ae)
-    {
-      try
-      {
-        this.transactionRollback();
-      }
-      catch (Exception e2)
-      {
-        Logger.error("unable to rollback transaction",e2);
-      }
-      throw ae;
+      throw e;
     }
   }
 

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypImpl.java
@@ -569,15 +569,10 @@ public class UmsatzTypImpl extends AbstractDBObjectNode implements UmsatzTyp, Du
       super.delete();
       transactionCommit();
     }
-    catch (RemoteException e)
+    catch (ApplicationException | RemoteException e)
     {
       this.transactionRollback();
       throw e;
-    }
-    catch (ApplicationException e2)
-    {
-      this.transactionRollback();
-      throw e2;
     }
   }
 

--- a/src/de/willuhn/jameica/hbci/server/hbci/AbstractHBCISepaSammelTransferJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/AbstractHBCISepaSammelTransferJob.java
@@ -121,13 +121,9 @@ public abstract class AbstractHBCISepaSammelTransferJob<T extends SepaSammelTran
         
       }
 		}
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIAuslandsUeberweisungJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIAuslandsUeberweisungJob.java
@@ -103,13 +103,9 @@ public class HBCIAuslandsUeberweisungJob extends AbstractHBCIJob
         setJobParam("purposecode",purp);
 
 		}
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIKontoauszugJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIKontoauszugJob.java
@@ -89,13 +89,9 @@ public class HBCIKontoauszugJob extends AbstractHBCIJob
 			      
 			}
     }
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIQuittungJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIQuittungJob.java
@@ -71,13 +71,9 @@ public class HBCIQuittungJob extends AbstractHBCIJob
 			
       setJobParam("receipt",s);
     }
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISaldoJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISaldoJob.java
@@ -57,13 +57,9 @@ public class HBCISaldoJob extends AbstractHBCIJob {
 			
 			setJobParam("my",Converter.HibiscusKonto2HBCIKonto(konto));
     }
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragDeleteJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragDeleteJob.java
@@ -98,13 +98,9 @@ public class HBCISepaDauerauftragDeleteJob extends AbstractHBCIJob
       setJobParam("turnus",turnus.getIntervall());
       setJobParam("execday",turnus.getTag());
 		}
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragListJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragListJob.java
@@ -61,13 +61,9 @@ public class HBCISepaDauerauftragListJob extends AbstractHBCIJob
       own.name = HBCIProperties.replace(own.name,HBCIProperties.TEXT_REPLACEMENTS_SEPA);
       setJobParam("src",own);
 		}
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
@@ -122,13 +122,9 @@ public class HBCISepaDauerauftragStoreJob extends AbstractHBCIJob
 			setJobParam("turnus",turnus.getIntervall());
 			setJobParam("execday",turnus.getTag());
 		}
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaLastschriftJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaLastschriftJob.java
@@ -115,13 +115,9 @@ public class HBCISepaLastschriftJob extends AbstractHBCIJob
       if (targetDate != null)
         setJobParam("targetdate",targetDate);
 		}
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
@@ -131,13 +131,9 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
         setJobParam("startdate", this.saldoDatum);
       }
     }
-		catch (RemoteException e)
+		catch (ApplicationException | RemoteException e)
 		{
 			throw e;
-		}
-		catch (ApplicationException e2)
-		{
-			throw e2;
 		}
 		catch (Throwable t)
 		{


### PR DESCRIPTION
Durch syntaktische Ergänzungen in Java 7 ist es möglich, bei _Try/Catch_ mehrere Codezeilen einzusparen -- bei identischer Funktionalität. Damit sinkt die Fehleranfälligkeit, da die Logik durch das JDK übernommen wird und nicht selbst implementiert werden muss.

Details in den Beschreibungen der einzelnen Commits.