### PR TITLE
Korrektur des Startdatums beim Umsatzabruf

### DIFF
--- a/build/ChangeLog
+++ b/build/ChangeLog
@@ -1,5 +1,6 @@
 HEAD 2.11 (nightly)
 
+  * BUG: 0956 Korrektur des Startdatums beim Umsatzabruf, falls es in der Zukunft liegt, erst nachdem ggf. ein Offset hinzugezählt wurde
   * NEW: 0955 Neue obantoo-Version mit aktualisierter BLZ-Datei gültig ab 06.09.2021
   * BUG: 0954 BIC nicht mehr basierend auf IBAN vorbefüllen, wenn bereits eine eingetragen wurde
   * BUG: 0953 Das Vergrößern des Flicker-Codes führte ab einer gewissen Größe zu Darstellungsfehlern

--- a/build/ChangeLog
+++ b/build/ChangeLog
@@ -1,5 +1,6 @@
 HEAD 2.11 (nightly)
 
+  * NEW: 0957 Korrektur des Startdatums beim Umsatzabruf, falls es außerhalb einer von der Bank in den BPD festgelegten Zeitspanne liegt
   * BUG: 0956 Korrektur des Startdatums beim Umsatzabruf, falls es in der Zukunft liegt, erst nachdem ggf. ein Offset hinzugezählt wurde
   * NEW: 0955 Neue obantoo-Version mit aktualisierter BLZ-Datei gültig ab 06.09.2021
   * BUG: 0954 BIC nicht mehr basierend auf IBAN vorbefüllen, wenn bereits eine eingetragen wurde

--- a/src/de/willuhn/jameica/hbci/server/BPDUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/BPDUtil.java
@@ -68,6 +68,11 @@ public class BPDUtil
     KontoauszugPdf("KontoauszugPdf","HKEKP"),
     
     /**
+     * Query fuer die Suche nach den BPD-Parametern fuer den Abruf der Umsaetze.
+     */
+    Umsatz("KUmsZeit","HKKAZ")
+
+    /**
      * Query fuer Abruf der Umsaetze im CAMT-Format.
      */
     UmsatzCamt("KUmsZeitCamt","HKCAZ")

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
@@ -90,23 +90,23 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
       this.saldoDatum = konto.getSaldoDatum();
       if (this.saldoDatum != null)
       {
+        // Mal schauen, ob wir ein konfiguriertes Offset haben
+        int offset = res.getSettings().getInt("umsatz.startdate.offset", 0);
+        if (offset != 0)
+        {
+          Logger.info("using custom offset for startdate: " + offset);
+          Calendar cal = Calendar.getInstance();
+          cal.setTime(this.saldoDatum);
+          cal.add(Calendar.DATE, offset);
+          this.saldoDatum = cal.getTime();
+        }
+
         // BUGZILLA 917 - checken, ob das Datum vielleicht in der Zukunft liegt. Das ist nicht zulaessig
         Date now = new Date();
         if (saldoDatum.after(now))
         {
           Logger.warn("future start date " + saldoDatum + " given. this is not allowed, changing to current date " + now);
           this.saldoDatum = now;
-        }
-        
-        // Mal schauen, ob wir ein konfiguriertes Offset haben
-        int offset = res.getSettings().getInt("umsatz.startdate.offset",0);
-        if (offset != 0)
-        {
-          Logger.info("using custom offset for startdate: " + offset);
-          Calendar cal = Calendar.getInstance();
-          cal.setTime(this.saldoDatum);
-          cal.add(Calendar.DATE,offset);
-          this.saldoDatum = cal.getTime();
         }
         
         this.saldoDatum = DateUtil.startOfDay(this.saldoDatum);

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
@@ -108,6 +108,23 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
           Logger.warn("future start date " + saldoDatum + " given. this is not allowed, changing to current date " + now);
           this.saldoDatum = now;
         }
+        else
+        {
+          // andernfalls pruefen, ob das Datum innerhalb der von der Bank erlaubten Zeitspanne liegt
+          int timeRange = KontoUtil.getUmsaetzeTimeRange(konto, true);
+          if (timeRange > 0)
+          {
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(now);
+            cal.add(Calendar.DATE, -timeRange);
+            Date earliestDate = cal.getTime();
+            if (saldoDatum.before(earliestDate))
+            {
+              Logger.warn("start date " + saldoDatum + " is more than " + timeRange + " days ago. this is not allowed, changing to earliest date " + earliestDate);
+              this.saldoDatum = earliestDate;
+            }
+          }
+        }
         
         this.saldoDatum = DateUtil.startOfDay(this.saldoDatum);
         Logger.info("startdate: " + HBCI.LONGDATEFORMAT.format(this.saldoDatum));


### PR DESCRIPTION
Das Startdatum beim Umsatzabruf sollte in einem von der Bank festgelegten Zeitintervall liegen (z.B. die letzten 90 Tage). Manche Banken wie die Deutsche Bank oder die Norisbank melden ansonsten einen Fehler, also falls das Startdatum z.B. zu weit zurück in der Vergangenheit liegt. Um diese Fehlermeldung zu vermeiden, wird das Startdatum entsprechend korrigiert, wenn es außerhalb dieses Zeitintervalls liegen sollte. Diese Überprüfungen und Korrekturen werden erst nach dem Hinzufügen eines ggf. konfigurierten Offsets durchgeführt, um sicherzustellen, daß das Startdatum auch wirklich im erlaubten Zeitintervall liegt, also nicht zu weit in der Vergangenheit, aber eben auch nicht in der Zukunft.