### PR TITLE
remove redundant initialization

### DIFF
--- a/src/de/willuhn/jameica/hbci/HBCIProperties.java
+++ b/src/de/willuhn/jameica/hbci/HBCIProperties.java
@@ -404,7 +404,7 @@ public class HBCIProperties
     if (bic == null)
       return null;
     
-    Bank bank = null;
+    Bank bank;
     
     // Wenn sie 8 Zeichen lang ist, gehen wir davon aus, dass es eine BLZ ist.
     // Sonst versuchen wir es als BIC zu interpretieren.

--- a/src/de/willuhn/jameica/hbci/MetaKey.java
+++ b/src/de/willuhn/jameica/hbci/MetaKey.java
@@ -109,9 +109,9 @@ public enum MetaKey
 
   ;
 
-  private String name         = null;
-  private String description  = null;
-  private String defaultValue = null;
+  private final String name;
+  private final String description;
+  private final String defaultValue;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/SynchronizeOptions.java
+++ b/src/de/willuhn/jameica/hbci/SynchronizeOptions.java
@@ -26,9 +26,9 @@ import de.willuhn.logging.Logger;
  */
 public class SynchronizeOptions implements Serializable
 {
-  private String id = null;
-  private boolean offline  = false;
-  private boolean disabled = false;
+  private String id;
+  private boolean offline;
+  private boolean disabled;
   private final static Settings settings = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getSettings();
 
   /**

--- a/src/de/willuhn/jameica/hbci/TextSchluessel.java
+++ b/src/de/willuhn/jameica/hbci/TextSchluessel.java
@@ -108,8 +108,8 @@ public class TextSchluessel
     list.add(new TextSchluessel(TS_SPENDE,   i18n.tr("Spende")));
   }
 
-  private String code = null;
-  private String name = null;
+  private String code;
+  private String name;
   
   /**
    * Liefert eine Liste der Textschluessel-Objekte mit den genannten Codes.

--- a/src/de/willuhn/jameica/hbci/calendar/AbstractAppointmentProvider.java
+++ b/src/de/willuhn/jameica/hbci/calendar/AbstractAppointmentProvider.java
@@ -101,7 +101,7 @@ public abstract class AbstractAppointmentProvider<T extends HibiscusDBObject> im
    */
   abstract class AbstractHibiscusAppointment extends AbstractAppointment
   {
-    protected Schedule<T> schedule = null;
+    protected final Schedule<T> schedule;
     
     /**
      * @see de.willuhn.jameica.gui.calendar.AbstractAppointment#execute()

--- a/src/de/willuhn/jameica/hbci/experiments/AbstractHBCI4JavaFeature.java
+++ b/src/de/willuhn/jameica/hbci/experiments/AbstractHBCI4JavaFeature.java
@@ -21,7 +21,7 @@ public abstract class AbstractHBCI4JavaFeature implements Feature
 {
   protected final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private org.kapott.hbci.manager.Feature feature = null;
+  private final org.kapott.hbci.manager.Feature feature;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/DialogFactory.java
+++ b/src/de/willuhn/jameica/hbci/gui/DialogFactory.java
@@ -141,7 +141,7 @@ public class DialogFactory
     if (key == null)
       return null;
 
-    PINEntry entry = null;
+    PINEntry entry;
     
     // Cache checken - ob der fuer die ganze Sitzung stehen bleibt oder nur fuer die
     // Dauer der Synchronisierung, das entscheiden wir nicht hier sondern am Ende der

--- a/src/de/willuhn/jameica/hbci/gui/action/AbstractSammelTransferExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/AbstractSammelTransferExport.java
@@ -39,7 +39,7 @@ public abstract class AbstractSammelTransferExport implements Action
 
 		try
     {
-		  SammelTransfer[] list = null;
+		  SammelTransfer[] list;
 		  if (context instanceof SammelTransfer)
 		    list = new SammelTransfer[]{(SammelTransfer) context};
 		  else

--- a/src/de/willuhn/jameica/hbci/gui/action/AbstractSepaSammelTransferExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/AbstractSepaSammelTransferExport.java
@@ -39,7 +39,7 @@ public abstract class AbstractSepaSammelTransferExport<T extends SepaSammelTrans
 
 		try
     {
-		  SepaSammelTransfer[] list = null;
+		  SepaSammelTransfer[] list;
 		  if (context instanceof SepaSammelTransfer)
 		    list = new SepaSammelTransfer[]{(SepaSammelTransfer) context};
 		  else

--- a/src/de/willuhn/jameica/hbci/gui/action/AuslandsUeberweisungDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/AuslandsUeberweisungDelete.java
@@ -47,7 +47,7 @@ public class AuslandsUeberweisungDelete extends DBObjectDelete
     {
       boolean array = (context instanceof AuslandsUeberweisung[]);
       
-      AuslandsUeberweisung[] list = null;
+      AuslandsUeberweisung[] list;
       if (array)
         list = (AuslandsUeberweisung[]) context;
       else
@@ -62,7 +62,7 @@ public class AuslandsUeberweisungDelete extends DBObjectDelete
       
       if (count > 0)
       {
-        String msg = null;
+        String msg;
         
         if (array)
         {

--- a/src/de/willuhn/jameica/hbci/gui/action/BackupRestore.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/BackupRestore.java
@@ -126,7 +126,7 @@ public class BackupRestore implements Action
           });
           
           long count = 1;
-          GenericObject o = null;
+          GenericObject o;
           while ((o = reader.read()) != null)
           {
             try

--- a/src/de/willuhn/jameica/hbci/gui/action/DBObjectDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/DBObjectDelete.java
@@ -31,7 +31,7 @@ import de.willuhn.util.ProgressMonitor;
  */
 public class DBObjectDelete implements Action
 {
-  private I18N i18n = null;
+  private final I18N i18n;
   
   /**
    * ct.
@@ -107,7 +107,7 @@ public class DBObjectDelete implements Action
   private class Worker implements BackgroundTask
   {
     private boolean cancel = false;
-    private DBObject[] list = null;
+    private final DBObject[] list;
 
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/action/DBObjectDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/DBObjectDelete.java
@@ -86,7 +86,7 @@ public class DBObjectDelete implements Action
       return;
     }
 
-    DBObject[] list = null;
+    DBObject[] list;
     if (array)
       list = (DBObject[]) context;
     else

--- a/src/de/willuhn/jameica/hbci/gui/action/Export.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/Export.java
@@ -58,7 +58,7 @@ public class Export implements Action
     if (export == null)
       throw new ApplicationException(i18n.tr("Bitte wählen Sie die zu exportierenden Daten aus"));
 
-    Object[] objects = null;
+    Object[] objects;
     
     if (export instanceof Object[])
       objects = (Object[]) export;

--- a/src/de/willuhn/jameica/hbci/gui/action/Export.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/Export.java
@@ -25,7 +25,7 @@ public class Export implements Action
 {
   protected final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private Class type = null;
+  private final Class type;
   private Object data = null;
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/action/FlaggableChange.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/FlaggableChange.java
@@ -26,8 +26,8 @@ public class FlaggableChange implements Action
 {
   protected final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private int flags   = 0;
-  private boolean add = true;
+  private final int flags;
+  private final boolean add;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/action/FlaggableChange.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/FlaggableChange.java
@@ -52,7 +52,7 @@ public class FlaggableChange implements Action
     if (!(context instanceof Flaggable) && !(context instanceof Flaggable[]))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Datensätze aus"));
 
-    Flaggable[] objects = null;
+    Flaggable[] objects;
     
     if (context instanceof Flaggable)
       objects = new Flaggable[]{(Flaggable) context};

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoFetchFromPassport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoFetchFromPassport.java
@@ -36,7 +36,7 @@ public class KontoFetchFromPassport implements Action
    */
   public void handleAction(Object context) throws ApplicationException
   {
-    Passport passport = null;
+    Passport passport;
     
     try
     {

--- a/src/de/willuhn/jameica/hbci/gui/action/KontoauszugDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/KontoauszugDelete.java
@@ -60,7 +60,7 @@ public class KontoauszugDelete implements Action
 	    {
 	      protected void extend(Container container) throws Exception
 	      {
-	        String text = null;
+	        String text;
 	        
 	        if (file != null)
 	        {

--- a/src/de/willuhn/jameica/hbci/gui/action/NachrichtMarkRead.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/NachrichtMarkRead.java
@@ -42,7 +42,7 @@ public class NachrichtMarkRead implements Action
 
     boolean array = (context instanceof Nachricht[]);
 
-    Nachricht[] list = null;
+    Nachricht[] list;
     if (array)
       list = (Nachricht[]) context;
     else

--- a/src/de/willuhn/jameica/hbci/gui/action/PassportDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/PassportDetail.java
@@ -44,7 +44,7 @@ public class PassportDetail implements Action
         return;
       }
       
-      Passport p = null;
+      Passport p;
       if (context instanceof Passport)
       {
         p = (Passport) context;

--- a/src/de/willuhn/jameica/hbci/gui/action/PassportSync.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/PassportSync.java
@@ -72,7 +72,7 @@ public class PassportSync implements Action
           };
           Logger.addTarget(target);
 
-          PassportHandle handle = null;
+          PassportHandle handle;
           if (context instanceof Passport)
             handle = ((Passport)context).getHandle();
           else

--- a/src/de/willuhn/jameica/hbci/gui/action/PassportTest.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/PassportTest.java
@@ -76,7 +76,7 @@ public class PassportTest implements Action
           };
           Logger.addTarget(target);
 
-          PassportHandle handle = null;
+          PassportHandle handle;
           if (context instanceof Passport)
             handle = ((Passport)context).getHandle();
           else

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaLastschriftMerge.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaLastschriftMerge.java
@@ -37,7 +37,7 @@ public class SepaLastschriftMerge implements Action
     if (!(context instanceof SepaLastschrift) && !(context instanceof SepaLastschrift[]))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Aufträge aus"));
 
-    SepaLastschrift[] source = null;
+    SepaLastschrift[] source;
     
     if (context instanceof SepaLastschrift)
       source = new SepaLastschrift[]{(SepaLastschrift) context};

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelLastschriftSplit.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelLastschriftSplit.java
@@ -44,7 +44,7 @@ public class SepaSammelLastschriftSplit implements Action
     if (!(context instanceof SepaSammelLastschrift) && !(context instanceof SepaSammelLastschrift[]))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Sammelaufträge aus"));
 
-    SepaSammelLastschrift[] source = null;
+    SepaSammelLastschrift[] source;
     
     if (context instanceof SepaSammelLastschrift)
       source = new SepaSammelLastschrift[]{(SepaSammelLastschrift) context};

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungDelete.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungDelete.java
@@ -47,7 +47,7 @@ public class SepaSammelUeberweisungDelete extends DBObjectDelete
     {
       boolean array = (context instanceof SepaSammelUeberweisung[]);
       
-      SepaSammelUeberweisung[] list = null;
+      SepaSammelUeberweisung[] list;
       if (array)
         list = (SepaSammelUeberweisung[]) context;
       else
@@ -62,7 +62,7 @@ public class SepaSammelUeberweisungDelete extends DBObjectDelete
       
       if (count > 0)
       {
-        String msg = null;
+        String msg;
         
         if (array)
         {

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungSplit.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaSammelUeberweisungSplit.java
@@ -44,7 +44,7 @@ public class SepaSammelUeberweisungSplit implements Action
     if (!(context instanceof SepaSammelUeberweisung) && !(context instanceof SepaSammelUeberweisung[]))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Sammelaufträge aus"));
 
-    SepaSammelUeberweisung[] source = null;
+    SepaSammelUeberweisung[] source;
     
     if (context instanceof SepaSammelUeberweisung)
       source = new SepaSammelUeberweisung[]{(SepaSammelUeberweisung) context};

--- a/src/de/willuhn/jameica/hbci/gui/action/SepaUeberweisungMerge.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SepaUeberweisungMerge.java
@@ -48,7 +48,7 @@ public class SepaUeberweisungMerge implements Action
     if (!(context instanceof AuslandsUeberweisung) && !(context instanceof AuslandsUeberweisung[]))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Aufträge aus"));
 
-    AuslandsUeberweisung[] source = null;
+    AuslandsUeberweisung[] source;
     
     if (context instanceof AuslandsUeberweisung)
       source = new AuslandsUeberweisung[]{(AuslandsUeberweisung) context};

--- a/src/de/willuhn/jameica/hbci/gui/action/TerminableMarkExecuted.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/TerminableMarkExecuted.java
@@ -40,7 +40,7 @@ public class TerminableMarkExecuted implements Action
     if (context == null)
       return;
 
-    Terminable t[] = null;
+    Terminable[] t;
     if (context instanceof Terminable)
       t = new Terminable[]{(Terminable) context};
     else

--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzAssign.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzAssign.java
@@ -42,7 +42,7 @@ public class UmsatzAssign implements Action
     if (!(context instanceof Umsatz) && !(context instanceof Umsatz[]))
       throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Umsätze aus"));
 
-    Umsatz[] umsaetze = null;
+    Umsatz[] umsaetze;
     
     if (context instanceof Umsatz)
       umsaetze = new Umsatz[]{(Umsatz) context};

--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzTypExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzTypExport.java
@@ -42,7 +42,7 @@ public class UmsatzTypExport implements Action
         !(UmsatzTyp[].class.isAssignableFrom(context.getClass())))
 			throw new ApplicationException(i18n.tr("Bitte wählen Sie einen oder mehrere Umsatz-Kategorien aus"));
 
-    Object[] u = null;
+    Object[] u;
 		try {
 
 			if (context instanceof UmsatzTyp)

--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartDataSaldoForecast.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartDataSaldoForecast.java
@@ -23,8 +23,8 @@ import de.willuhn.jameica.hbci.server.Value;
  */
 public class ChartDataSaldoForecast extends AbstractChartDataSaldo
 {
-  private Konto konto      = null;
-  private Date end         = null;
+  private final Konto konto;
+  private final Date end;
   private List<Value> data = null;
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartDataSaldoVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartDataSaldoVerlauf.java
@@ -21,8 +21,8 @@ import de.willuhn.jameica.hbci.server.Value;
  */
 public class ChartDataSaldoVerlauf extends AbstractChartDataSaldo
 {
-  private Konto konto      = null;
-  private List<Value> data = null;
+  private final Konto konto;
+  private final List<Value> data;
   
   /**
    * ct. 

--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartDataUmsatzTyp.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartDataUmsatzTyp.java
@@ -27,8 +27,8 @@ import de.willuhn.util.I18N;
 public class ChartDataUmsatzTyp implements ChartData
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  private int type = UmsatzTyp.TYP_EGAL;
-  private int days = -1;
+  private final int type;
+  private final int days;
   
   /**
    * @param typ Art der Umsaetze.
@@ -102,7 +102,7 @@ public class ChartDataUmsatzTyp implements ChartData
    */
   public class Entry
   {
-    private UmsatzTyp ut = null;
+    private final UmsatzTyp ut;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/ChartFeatureTooltip.java
@@ -232,10 +232,10 @@ public class ChartFeatureTooltip implements ChartFeature
    */
   protected class SeriesData
   {
-    double closestX = 0;
-    double closestY = 0;
-    int seriesIndex = 0;
-    ISeries closestSerie = null;
+    final double closestX;
+    final double closestY;
+    final int seriesIndex;
+    final ISeries closestSerie;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/AbstractSammelTransferBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AbstractSammelTransferBuchungControl.java
@@ -59,7 +59,7 @@ public abstract class AbstractSammelTransferBuchungControl extends AbstractContr
 
 	private CheckboxInput storeAddress = null;
 
-	private I18N i18n                  = null;
+	private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/AuslandsUeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/AuslandsUeberweisungControl.java
@@ -687,8 +687,8 @@ public class AuslandsUeberweisungControl extends AbstractControl
    */
   public class Typ
   {
-    private boolean termin = false;
-    private boolean umb    = false;
+    private final boolean termin;
+    private final boolean umb;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
@@ -97,15 +97,15 @@ public class EinnahmeAusgabeControl extends AbstractControl
     
     ;
 
-    private String name;
+    private final String name;
     /**
      * Typ des Tages zur Adressierung innerhalb des Intervalls
      */
-    private int type;
+    private final int type;
     /**
      * Intervalldauer
      */
-    private int size;
+    private final int size;
 
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/EmpfaengerControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EmpfaengerControl.java
@@ -84,7 +84,7 @@ public class EmpfaengerControl extends AbstractControl
   private Part sammelList2        = null;
   private Part umsatzList         = null;
   
-  private IbanListener ibanListener = new IbanListener();
+  private final IbanListener ibanListener = new IbanListener();
   
   /**
    * @param view

--- a/src/de/willuhn/jameica/hbci/gui/controller/LicenseControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/LicenseControl.java
@@ -31,7 +31,7 @@ import de.willuhn.util.I18N;
 public class LicenseControl extends AbstractControl {
 
   private Part libList = null;
-  private I18N i18n = null;
+  private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/SammelLastBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SammelLastBuchungControl.java
@@ -40,7 +40,7 @@ public class SammelLastBuchungControl extends AbstractSammelTransferBuchungContr
 	private SammelTransferBuchung buchung	  = null;
   private SelectInput textschluessel      = null;
 	
-	private I18N i18n                       = null;
+	private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/SammelUeberweisungBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SammelUeberweisungBuchungControl.java
@@ -40,7 +40,7 @@ public class SammelUeberweisungBuchungControl extends AbstractSammelTransferBuch
 	private SammelTransferBuchung buchung	  = null;
   private SelectInput textschluessel      = null;
 	
-	private I18N i18n                       = null;
+	private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelLastBuchungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelLastBuchungControl.java
@@ -188,7 +188,7 @@ public class SepaSammelLastBuchungControl extends AbstractSepaSammelTransferBuch
    */
   public synchronized boolean handleStore()
   {
-    SepaSammelLastBuchung s = null;
+    SepaSammelLastBuchung s;
     SepaSammelLastschrift t = null;
     
     try

--- a/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelUeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/SepaSammelUeberweisungControl.java
@@ -316,7 +316,7 @@ public class SepaSammelUeberweisungControl extends AbstractSepaSammelTransferCon
    */
   public class Typ
   {
-    private boolean termin = false;
+    private final boolean termin;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/UeberweisungControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UeberweisungControl.java
@@ -282,8 +282,8 @@ public class UeberweisungControl extends AbstractBaseUeberweisungControl
    */
   public class Typ
   {
-    private boolean termin = false;
-    private boolean umb    = false;
+    private final boolean termin;
+    private final boolean umb;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -260,7 +260,7 @@ public class UmsatzDetailControl extends AbstractControl
       return this.empfaengerBlz;
     
     String value = getUmsatz().getGegenkontoBLZ();
-    boolean isBic = value == null || value.trim().length() == 0; // Per Default ist es eine BIC
+    boolean isBic;
     try
     {
       HBCIProperties.checkChars(value,HBCIProperties.HBCI_BLZ_VALIDCHARS); // Wenn das keine Exception wirft, muss es eine BLZ sein

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
@@ -406,7 +406,7 @@ public class UmsatzTypControl extends AbstractControl
    */
   public static class UmsatzTypObject implements GenericObject
   {
-    private int typ = UmsatzTyp.TYP_EGAL;
+    private final int typ;
     
     /**
      * ct

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypTreeControl.java
@@ -68,7 +68,7 @@ public class UmsatzTypTreeControl extends AbstractControl
   private UmsatzTypVerlauf chart   = null;
   private boolean expanded         = false;
   
-  private Listener listener        = null;
+  private final Listener listener;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/AccountContainerDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/AccountContainerDialog.java
@@ -48,7 +48,7 @@ public class AccountContainerDialog extends AbstractDialog
 
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-	private HBCIPassport passport = null;
+	private final HBCIPassport passport;
 	private AccountContainer container = null;
 
 	private Input blz 				  = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/AdresseAuswahlDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/AdresseAuswahlDialog.java
@@ -47,7 +47,7 @@ public class AdresseAuswahlDialog extends AbstractDialog
   private final static int WINDOW_WIDTH = 640;
   private final static int WINDOW_HEIGHT = 460;
 	private Address choosen        = null;
-	private AddressFilter filter   = null;
+	private final AddressFilter filter;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/AuslandsUeberweisungDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/AuslandsUeberweisungDialog.java
@@ -27,7 +27,7 @@ import de.willuhn.jameica.hbci.server.VerwendungszweckUtil;
  */
 public class AuslandsUeberweisungDialog extends AbstractExecuteDialog
 {
-	private AuslandsUeberweisung ueb;
+	private final AuslandsUeberweisung ueb;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
@@ -66,8 +66,8 @@ public class CSVImportDialog extends AbstractDialog
 
   private SelectInput profiles      = null;
   private Profile result            = null;
-  private Format format             = null;
-  private byte[] data               = null;
+  private final Format format;
+  private final byte[] data;
 
   private TextInput sepChar         = null;
   private TextInput quoteChar       = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CSVImportDialog.java
@@ -290,7 +290,7 @@ public class CSVImportDialog extends AbstractDialog
         getError().setValue(i18n.tr("Encoding {0} ignoriert, wird nicht unterstützt",enc));
       }
       csv = new CsvListReader(new InputStreamReader(new ByteArrayInputStream(this.data),charset != null ? charset : Charset.defaultCharset()),prefs);
-      List<String> line = null;
+      List<String> line;
       while ((line = csv.read()) != null)
       {
         // Der CSV-Reader verwendet das List-Objekt leider immer

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CSVProfileStoreDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CSVProfileStoreDialog.java
@@ -45,8 +45,8 @@ public class CSVProfileStoreDialog extends AbstractDialog
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static int WINDOW_WIDTH = 500;
   
-  private Format format          = null;
-  private Profile profile        = null;
+  private final Format format;
+  private final Profile profile;
   private Button apply           = null;
   private TextInput name         = null;
   private LabelInput hint        = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CamtSetupDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CamtSetupDialog.java
@@ -45,7 +45,7 @@ public class CamtSetupDialog extends AbstractDialog
 
   private final static int WINDOW_WIDTH = 780;
   
-  private Konto konto = null;
+  private final Konto konto;
   private CheckboxInput switchAll = null;
   private Boolean value = null;
   

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/CaptchaDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/CaptchaDialog.java
@@ -55,7 +55,7 @@ public class CaptchaDialog extends AbstractDialog
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private InputStream image = null;
+  private final InputStream image;
   private String data       = null;
   
   private TextInput solution = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -141,7 +141,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
    */
   private void export() throws ApplicationException
   {
-    ExpotFormat exp = null;
+    ExpotFormat exp;
 
     try
     {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -72,8 +72,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
 
   private Input exporterListe     = null;
   private CheckboxInput openFile  = null;
-  private Object[] objects        = null;	
-  private Class type              = null;
+  private final Object[] objects;
+  private final Class type;
 
   private boolean exportEnabled   = true;
   private Container group         = null;
@@ -362,8 +362,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
    */
   public class ExpotFormat implements GenericObject, Comparable
 	{
-		private Exporter exporter   = null;
-    private IOFormat format = null;
+		private final Exporter exporter;
+		private final IOFormat format;
 		
 		private ExpotFormat(Exporter exporter, IOFormat format)
 		{

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ImportDialog.java
@@ -57,10 +57,10 @@ public class ImportDialog extends AbstractDialog
 	private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   private Input importerListe     = null;
-  private GenericObject context   = null;	
-  private Class type              = null;
+  private final GenericObject context;
+  private final Class type;
   
-  private Settings  settings      = null;
+  private final Settings  settings;
   private BackgroundTask task     = null;
 
   /**
@@ -290,8 +290,8 @@ public class ImportDialog extends AbstractDialog
    */
   private class Imp implements GenericObject, Comparable
 	{
-		private Importer importer = null;
-    private IOFormat format   = null;
+    private final Importer importer;
+    private final IOFormat format;
 		
 		private Imp(Importer importer, IOFormat format)
 		{

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ImportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ImportDialog.java
@@ -120,7 +120,7 @@ public class ImportDialog extends AbstractDialog
    */
   private void doImport() throws ApplicationException
   {
-    Imp imp = null;
+    Imp imp;
 
     try
     {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoAuswahlDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoAuswahlDialog.java
@@ -48,8 +48,8 @@ public class KontoAuswahlDialog extends AbstractDialog
   
   private String text        = null;
   private Konto choosen      = null;
-  private Konto preselected  = null;
-	private KontoFilter filter = null;
+  private Konto preselected;
+  private final KontoFilter filter;
 	
 	private Button apply        = null;
 	private KontoInput auswahl  = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoDeleteDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoDeleteDialog.java
@@ -47,7 +47,7 @@ public class KontoDeleteDialog extends AbstractDialog<Boolean>
   private final static int WINDOW_WIDTH = 800;
   private final static int WINDOW_HEIGHT= 400;
   
-  private Konto konto         = null;
+  private final Konto konto;
   private TablePart deps      = null;
   private CheckboxInput check = null;
   private Button apply        = null;
@@ -224,9 +224,9 @@ public class KontoDeleteDialog extends AbstractDialog<Boolean>
    */
   public class Dep
   {
-    private String name = null;
-    private int size = 0;
-    private String comment = null;
+    private String name;
+    private int size;
+    private String comment;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugMoveDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugMoveDialog.java
@@ -55,7 +55,7 @@ public class KontoauszugMoveDialog extends AbstractDialog<Kontoauszug>
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static int WINDOW_WIDTH = 580;
   
-  private Kontoauszug[] list = null;
+  private Kontoauszug[] list;
   private DirectoryInput target = null;
   private CheckboxInput overwrite = null;
   private CheckboxInput delete = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugPdfSettingsDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/KontoauszugPdfSettingsDialog.java
@@ -68,7 +68,7 @@ public class KontoauszugPdfSettingsDialog extends AbstractDialog
   private final static int WINDOW_WIDTH = 700;
   private final static int WINDOW_HEIGHT = 500;
 
-  private Konto konto = null;
+  private Konto konto;
   
   private KontoInput kontoAuswahl = null;
   private LabelInput hinweise = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/NewInstKeysDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/NewInstKeysDialog.java
@@ -35,7 +35,7 @@ public class NewInstKeysDialog extends AbstractDialog
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static int WINDOW_WIDTH = 540;
 
-	private HBCIPassport passport = null;
+	private final HBCIPassport passport;
 	private Boolean choosen       = null;
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/PainVersionDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/PainVersionDialog.java
@@ -43,7 +43,7 @@ public class PainVersionDialog extends AbstractDialog
 
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private Type type               = null;
+  private final Type type;
   private SepaVersion painVersion = null;
   private Button ok               = null;
 

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/PassportAuswahlDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/PassportAuswahlDialog.java
@@ -41,7 +41,7 @@ public class PassportAuswahlDialog extends AbstractDialog
 
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private Konto konto         = null;
+  private final Konto konto;
   private PassportInput input = null;
   private Passport passport   = null;
   private LabelInput comment  = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/PassportPropertyDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/PassportPropertyDialog.java
@@ -34,7 +34,7 @@ import de.willuhn.util.I18N;
 public class PassportPropertyDialog extends AbstractDialog
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  private HBCIPassport passport = null;
+  private final HBCIPassport passport;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ReminderIntervalDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ReminderIntervalDialog.java
@@ -49,9 +49,9 @@ public class ReminderIntervalDialog extends AbstractDialog<ReminderInterval>
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private ReminderInterval interval = null;
+  private ReminderInterval interval;
   private Date start                = null;
-  private Date end                  = null;
+  private Date end;
   
   private ReminderIntervalInput input = null;
   private DateInput endInput          = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaDauerauftragDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaDauerauftragDialog.java
@@ -30,7 +30,7 @@ import de.willuhn.jameica.hbci.server.VerwendungszweckUtil;
  */
 public class SepaDauerauftragDialog extends AbstractExecuteDialog
 {
-	private SepaDauerauftrag auftrag;
+	private final SepaDauerauftrag auftrag;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaExportDialog.java
@@ -53,7 +53,7 @@ public class SepaExportDialog extends AbstractDialog
   private final static DateFormat DATEFORMAT = new SimpleDateFormat("yyyyMMdd");
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private Type type               = null;
+  private final Type type;
   private SepaVersion painVersion = null;
   private File file               = null;
   private Button ok               = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaLastschriftDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaLastschriftDialog.java
@@ -27,7 +27,7 @@ import de.willuhn.jameica.hbci.server.VerwendungszweckUtil;
  */
 public class SepaLastschriftDialog extends AbstractExecuteDialog
 {
-	private SepaLastschrift last;
+	private final SepaLastschrift last;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaSammelTransferDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaSammelTransferDialog.java
@@ -27,7 +27,7 @@ import de.willuhn.jameica.hbci.rmi.SepaSammelUeberweisung;
  */
 public class SepaSammelTransferDialog extends AbstractExecuteDialog
 {
-	private SepaSammelTransfer st;
+	private final SepaSammelTransfer st;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaSammelTransferSplitDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaSammelTransferSplitDialog.java
@@ -30,8 +30,8 @@ public class SepaSammelTransferSplitDialog extends AbstractDialog
 {
 	private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 	
-  private int count           = 1;
-  private boolean canDelete   = false;
+  private final int count;
+  private final boolean canDelete;
   private Boolean delete      = null;
 
   private CheckboxInput check = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SepaTransferMergeDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SepaTransferMergeDialog.java
@@ -31,8 +31,8 @@ public class SepaTransferMergeDialog extends AbstractDialog
 {
 	private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 	
-  private int count           = 1;
-  private boolean canDelete   = false;
+  private final int count;
+  private final boolean canDelete;
   private Boolean delete      = null;
 
   private CheckboxInput check = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeExecuteDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeExecuteDialog.java
@@ -35,7 +35,7 @@ public class SynchronizeExecuteDialog extends AbstractDialog
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private List<SynchronizeJob> jobs = null;
+  private final List<SynchronizeJob> jobs;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeOptionsDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeOptionsDialog.java
@@ -66,10 +66,10 @@ public class SynchronizeOptionsDialog extends AbstractDialog
   
   private final static int WINDOW_WIDTH = 500;
   
-  private Konto konto                   = null;
-  private boolean offline               = false;
-  private boolean syncAvail             = false;
-  private SynchronizeOptions options    = null;
+  private final Konto konto;
+  private boolean offline;
+  private boolean syncAvail;
+  private SynchronizeOptions options;
   private CheckboxInput syncOffline     = null;
   private CheckboxInput syncSaldo       = null;
   private CheckboxInput syncUmsatz      = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeOptionsDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/SynchronizeOptionsDialog.java
@@ -135,7 +135,7 @@ public class SynchronizeOptionsDialog extends AbstractDialog
    */
   private Input createCustomProperty(String name) throws RemoteException
   {
-    Input t = null;
+    Input t;
     if (name.endsWith("(true/false)"))
     {
       String newName = name.replace("(true/false)","").trim();

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/TransferMergeDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/TransferMergeDialog.java
@@ -56,7 +56,7 @@ public class TransferMergeDialog extends AbstractDialog
 {
 
 	private final static I18N i18n    = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-	private SammelTransfer transfer   = null;
+	private SammelTransfer transfer;
   private Boolean delete            = Boolean.FALSE;
 
   private CheckboxInput useExisting = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/TurnusEditDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/TurnusEditDialog.java
@@ -44,7 +44,7 @@ public class TurnusEditDialog extends AbstractDialog {
 	private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   // Das Fachobjekt
-  private Turnus turnus = null;
+  private Turnus turnus;
 
   private SelectInput intervall       = null;
   private SelectInput zeiteinheit     = null;
@@ -314,7 +314,7 @@ public class TurnusEditDialog extends AbstractDialog {
   private class Zeiteinheit implements GenericObject
   {
 
-    private int id = -1;
+    private final int id;
     private String name = pleaseChoose;
 
     private Zeiteinheit(int id)
@@ -372,7 +372,7 @@ public class TurnusEditDialog extends AbstractDialog {
   private class Tag implements GenericObject
   {
 
-    private int id = -1;
+    private final int id;
     private String name = pleaseChoose;
 
     private Tag(int id)

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
@@ -64,9 +64,9 @@ public class UmsatzTypListDialog extends AbstractDialog
   private final static int WINDOW_WIDTH = 370;
   private final static int WINDOW_HEIGHT = 500;
 
-  private List<UmsatzTypBean> list = null;
-  private UmsatzTyp choosen        = null;
-  private int typ                  = UmsatzTyp.TYP_EGAL;
+  private List<UmsatzTypBean> list;
+  private UmsatzTyp choosen;
+  private final int typ;
   
   private TextInput search         = null;
   private TablePart table          = null;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypListDialog.java
@@ -235,7 +235,7 @@ public class UmsatzTypListDialog extends AbstractDialog
               item.setText(0,b.getPathName());
           }
           
-          Color c = null;
+          Color c;
           
           if (ut.isCustomColor())
           {

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypNewDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/UmsatzTypNewDialog.java
@@ -34,9 +34,9 @@ import de.willuhn.util.I18N;
  */
 public class UmsatzTypNewDialog extends AbstractDialog
 {
-  private I18N i18n        = null;
+  private final I18N i18n;
   private LabelInput check = null;
-  private UmsatzTypControl control = null;
+  private final UmsatzTypControl control;
   
   /**
    * @param position

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/WalletDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/WalletDialog.java
@@ -96,8 +96,8 @@ public class WalletDialog extends AbstractDialog
    */
   public class Entry 
   {
-    private String name  = null;
-    private String value = null;
+    private final String name;
+    private final String value;
     
     private Entry(String name, Serializable s)
     {

--- a/src/de/willuhn/jameica/hbci/gui/input/AbstractDateInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/AbstractDateInput.java
@@ -34,7 +34,7 @@ public abstract class AbstractDateInput extends DateInput
   
   final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private String param = null;
+  private final String param;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/input/BICInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/BICInput.java
@@ -30,7 +30,7 @@ public class BICInput extends AccountInput
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private Listener listener = null;
+  private final Listener listener;
 
   // erlauben wir zwar erstmal, ersetzen wir aber noch
   private final static String LOWERCASE_CHARS = "abcdefghijklmnopqrstuvwxyz"; 

--- a/src/de/willuhn/jameica/hbci/gui/input/BLZInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/BLZInput.java
@@ -33,8 +33,8 @@ import de.willuhn.util.I18N;
 public class BLZInput extends AccountInput
 {
   private List<Listener> blzListener = new ArrayList<Listener>();
-  private Listener listener = null;
-  private I18N i18n         = null;
+  private final Listener listener;
+  private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/input/HBCIVersionInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/HBCIVersionInput.java
@@ -190,8 +190,8 @@ public class HBCIVersionInput extends SelectInput
    */
   private static class HBCIVersion
   {
-    private org.kapott.hbci.manager.HBCIVersion version = null;
-    private boolean active = true;
+    private final org.kapott.hbci.manager.HBCIVersion version;
+    private final boolean active;
 
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/input/IBANInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/IBANInput.java
@@ -29,7 +29,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class IBANInput extends TextInput
 {
-  private Input bicInput = null;
+  private final Input bicInput;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
@@ -48,10 +48,10 @@ public class KontoInput extends SelectInput
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static de.willuhn.jameica.system.Settings settings = new de.willuhn.jameica.system.Settings(KontoInput.class);
 
-  private Konto konto = null;
+  private Konto konto;
   private static List<String> groups = null;
 
-  private KontoListener listener = null;
+  private KontoListener listener;
   private String token = null;
   private boolean store = true;
   private Control control = null;

--- a/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/KontoInput.java
@@ -413,7 +413,7 @@ public class KontoInput extends SelectInput
         {
           // Checken, ob wir das Konto in der Liste haben. Wenn ja, aktualisieren
           // wir dessen Saldo
-          List list = null;
+          List list;
 
           try
           {

--- a/src/de/willuhn/jameica/hbci/gui/input/KontoartInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/KontoartInput.java
@@ -22,7 +22,7 @@ import de.willuhn.util.I18N;
 public class KontoartInput extends SelectInput
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  private Integer current = null;
+  private final Integer current;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/RangeInput.java
@@ -35,9 +35,9 @@ public class RangeInput extends SelectInput
   private final static Settings settings = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getSettings();
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private String param = null;
-  private Input from = null;
-  private Input to = null;
+  private final String param;
+  private final Input from;
+  private final Input to;
   private boolean inUpdate = false;
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/input/ReminderIntervalInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/ReminderIntervalInput.java
@@ -53,8 +53,8 @@ public class ReminderIntervalInput implements Input
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private Terminable order              = null;
-  private Input input                   = null;
+  private final Terminable order;
+  private Input input;
   private ReminderIntervalDialog dialog = null;
   private boolean containsInterval      = false;
   private Date end                      = null;

--- a/src/de/willuhn/jameica/hbci/gui/input/TerminInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/TerminInput.java
@@ -36,8 +36,8 @@ public class TerminInput extends DateInput
   
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private Terminable auftrag = null;
-  private Listener listener  = null;
+  private Terminable auftrag;
+  private Listener listener;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/input/UmsatzTypInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/UmsatzTypInput.java
@@ -38,7 +38,7 @@ public class UmsatzTypInput extends SelectInput
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private boolean haveComments      = false;
+  private boolean haveComments;
   private boolean haveCustomComment = false;
   private boolean haveAutoComment   = false;
 

--- a/src/de/willuhn/jameica/hbci/gui/menus/DauerauftragList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/DauerauftragList.java
@@ -30,7 +30,7 @@ import de.willuhn.util.I18N;
  */
 public class DauerauftragList extends ContextMenu
 {
-	private I18N i18n	= null;
+	private final I18N i18n;
 
   /**
 	 * Erzeugt ein Kontext-Menu fuer eine Liste von Dauerauftraegen.

--- a/src/de/willuhn/jameica/hbci/gui/menus/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/KontoList.java
@@ -123,7 +123,7 @@ public class KontoList extends ContextMenu implements Extendable
    */
   private class AccountItem extends CheckedSingleContextMenuItem
   {
-    private boolean offline = false;
+    private final boolean offline;
 
     /**
      * ct.
@@ -228,7 +228,7 @@ public class KontoList extends ContextMenu implements Extendable
    */
   private class ChangeFlagsMenuItem extends CheckedSingleContextMenuItem
   {
-    boolean f1 = false;
+    final boolean f1;
 
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/menus/LastschriftList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/LastschriftList.java
@@ -31,7 +31,7 @@ import de.willuhn.util.I18N;
  */
 public class LastschriftList extends ContextMenu
 {
-	private I18N i18n	= null;
+	private final I18N i18n;
 
 	/**
 	 * Erzeugt ein Kontext-Menu fuer eine Liste von Lastschriften.

--- a/src/de/willuhn/jameica/hbci/gui/menus/NachrichtList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/NachrichtList.java
@@ -29,7 +29,7 @@ import de.willuhn.util.I18N;
 public class NachrichtList extends ContextMenu
 {
 
-	private I18N i18n;
+	private final I18N i18n;
 
 	/**
 	 * Erzeugt das Kontext-Menu fuer eine Liste von Nachrichten.

--- a/src/de/willuhn/jameica/hbci/gui/menus/UmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/gui/menus/UmsatzList.java
@@ -349,7 +349,7 @@ public class UmsatzList extends ContextMenu implements Extendable
     {
       if ((o instanceof Umsatz) || (o instanceof Umsatz[]))
       {
-        Umsatz[] umsaetze = null;
+        Umsatz[] umsaetze;
         
         if (o instanceof Umsatz)
           umsaetze = new Umsatz[]{(Umsatz) o};

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractFromToList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractFromToList.java
@@ -69,9 +69,9 @@ public abstract class AbstractFromToList extends TablePart implements Part
   private Input text             = null;
   private Container left         = null;
 
-  protected Listener listener    = null;
+  protected final Listener listener;
   
-  private ButtonArea buttons     = null;
+  private final ButtonArea buttons;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractSammelTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractSammelTransferList.java
@@ -63,7 +63,7 @@ import de.willuhn.logging.Logger;
  */
 public abstract class AbstractSammelTransferList extends AbstractFromToList
 {
-  private MessageConsumer mc = null;
+  private final MessageConsumer mc;
   private CheckboxInput pending = null;
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractSepaSammelTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractSepaSammelTransferList.java
@@ -64,7 +64,7 @@ import de.willuhn.logging.Logger;
  */
 public abstract class AbstractSepaSammelTransferList extends AbstractFromToList
 {
-  private MessageConsumer mc = null;
+  private final MessageConsumer mc;
   private CheckboxInput pending = null;
 
   /**
@@ -260,7 +260,7 @@ public abstract class AbstractSepaSammelTransferList extends AbstractFromToList
   public class TransferMessageConsumer implements MessageConsumer
   {
     private DelayedListener insertDelay = null;
-    private DelayedListener updateDelay = null;
+    private final DelayedListener updateDelay;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractTransferList.java
@@ -63,7 +63,7 @@ import de.willuhn.logging.Logger;
  */
 public abstract class AbstractTransferList extends AbstractFromToList
 {
-  private MessageConsumer mc = null;
+  private final MessageConsumer mc;
   private CheckboxInput pending = null;
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/DauerauftragList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/DauerauftragList.java
@@ -40,7 +40,7 @@ import de.willuhn.util.I18N;
  */
 public class DauerauftragList extends TablePart implements Part
 {
-  private I18N i18n = null;
+  private I18N i18n;
 
   /**
    * @param action

--- a/src/de/willuhn/jameica/hbci/gui/parts/EinnahmenAusgabenVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/EinnahmenAusgabenVerlauf.java
@@ -22,7 +22,7 @@ public class EinnahmenAusgabenVerlauf implements Part
   
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private VergleichBarChart chart   = null;
-  private List<EinnahmeAusgabeZeitraum> data = null;
+  private List<EinnahmeAusgabeZeitraum> data;
 
   /**
    * Konstruktor mit anzuzeigenden Werten

--- a/src/de/willuhn/jameica/hbci/gui/parts/EmpfaengerList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/EmpfaengerList.java
@@ -67,12 +67,12 @@ public class EmpfaengerList extends TablePart implements Part
   
   private Addressbook book       = null;
   private TextInput search       = null;
-  private KeyAdapter listener    = null;
-  private AddressFilter filter   = null;
-  private boolean createButton   = true;
+  private final KeyAdapter listener;
+  private final AddressFilter filter;
+  private final boolean createButton;
 
-  private MessageConsumer mcImport = null;
-  private MessageConsumer mcChanged = null;
+  private final MessageConsumer mcImport;
+  private final MessageConsumer mcChanged;
   
   private static Settings mySettings = new Settings(EmpfaengerList.class);
 

--- a/src/de/willuhn/jameica/hbci/gui/parts/ErweiterteVerwendungszwecke.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/ErweiterteVerwendungszwecke.java
@@ -44,12 +44,12 @@ public class ErweiterteVerwendungszwecke implements Part
 {
   private final static I18N i18n    = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private String[] orig             = null;
+  private String[] orig;
   private List<TextInput> fields    = new ArrayList<TextInput>();
   private Button add                = null;
   
-  private boolean readonly          = false;
-  private Konto konto               = null;
+  private boolean readonly;
+  private Konto konto;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoList.java
@@ -408,7 +408,7 @@ public class KontoList extends TablePart implements Part, Extendable
   {
     try
     {
-      List<Konto> items = null;
+      List<Konto> items;
       Object o = this.getSelection();
 
       // Nur wenn mehr als ein Konto markiert ist, nehmen

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoList.java
@@ -87,7 +87,7 @@ public class KontoList extends TablePart implements Part, Extendable
   private CheckboxInput onlyActive = null;
   private SelectInput accountType = null;
   
-  private MessageConsumer mc = null;
+  private final MessageConsumer mc;
   private boolean showFilter = true;
   
   private Listener listener = new MyListener();

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -94,7 +94,7 @@ public class KontoauszugList extends UmsatzList
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static Settings syssettings = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getSettings();
   
-  private UmsatzTyp searchTyp          = null;
+  private UmsatzTyp searchTyp;
   private SearchInput search           = null;
   private CheckboxInput regex          = null;
 
@@ -115,7 +115,7 @@ public class KontoauszugList extends UmsatzList
   private DecimalInput betragFrom      = null;
   private DecimalInput betragTo        = null;
 
-  private Listener listener            = null;
+  private Listener listener;
   
   private boolean disposed             = false; // BUGZILLA 462
   private boolean changed              = false;

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -971,7 +971,7 @@ public class KontoauszugList extends UmsatzList
                 // Mal schauen, obs den Typ schon gibt
                 DBIterator existing = de.willuhn.jameica.hbci.Settings.getDBService().createList(UmsatzTyp.class);
                 existing.addFilter("pattern = ?", new Object[]{text});
-                UmsatzTyp typ = null; 
+                UmsatzTyp typ;
                 if (existing.size() > 0)
                 {
                   if (!Application.getCallback().askUser(i18n.tr("Eine Umsatz-Kategorie mit diesem Suchbegriff existiert bereits. Überschreiben?")))

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugPdfList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugPdfList.java
@@ -76,7 +76,7 @@ public class KontoauszugPdfList extends TablePart
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   
-  private MessageConsumer mc            = null;
+  private final MessageConsumer mc;
 
   private KontoInput kontoAuswahl       = null;
   private Input from                    = null;
@@ -85,7 +85,7 @@ public class KontoauszugPdfList extends TablePart
   private CheckboxInput unread          = null;
   private CheckboxInput inclusiveFilter = null;
 
-  private Listener listener             = null;
+  private final Listener listener;
 
   /**
    * ct.
@@ -497,7 +497,7 @@ public class KontoauszugPdfList extends TablePart
    */
   private class KontoAction implements Action
   {
-    private Action redirect = null;
+    private final Action redirect;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/NachrichtList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/NachrichtList.java
@@ -37,7 +37,7 @@ import de.willuhn.util.I18N;
  */
 public class NachrichtList extends TablePart implements Part
 {
-  private I18N i18n = null;
+  private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/PassportPropertyList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PassportPropertyList.java
@@ -47,7 +47,7 @@ public class PassportPropertyList implements Part
   private final static String PREFIX_BPD = "BPD";
   private final static String PREFIX_UPD = "UPD";
   
-  private HBCIPassport passport = null;
+  private final HBCIPassport passport;
   private List<Value> list      = new ArrayList<Value>();
   private PropertyTable table   = null;
   private TextInput search      = null;
@@ -213,9 +213,9 @@ public class PassportPropertyList implements Part
    */
   private static class Value implements GenericObject
   {
-    private String prefix = null;
-    private String name   = null;
-    private String value  = null;
+    private final String prefix;
+    private final String name;
+    private final String value;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/PassportTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PassportTree.java
@@ -210,7 +210,7 @@ public class PassportTree extends TreePart
    */
   private static class PassportObject implements GenericObjectNode
   {
-    private Passport passport        = null;
+    private final Passport passport;
     private GenericIterator children = null;
     
     /**
@@ -321,8 +321,8 @@ public class PassportTree extends TreePart
    */
   private static class ConfigObject implements GenericObject
   {
-    private Passport passport    = null;
-    private Configuration config = null;
+    private final Passport passport;
+    private final Configuration config;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/PinPad.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PinPad.java
@@ -38,7 +38,7 @@ public class PinPad implements Part
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   private Composite comp      = null;
-  private PasswordInput input = null;
+  private final PasswordInput input;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/ProtokollList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/ProtokollList.java
@@ -33,7 +33,7 @@ import de.willuhn.jameica.util.DateUtil;
 public class ProtokollList extends AbstractFromToList
 {
   private KontoInput kontoAuswahl = null;
-  private Konto konto = null;
+  private final Konto konto;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/RangeList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/RangeList.java
@@ -32,7 +32,7 @@ import de.willuhn.util.I18N;
 public class RangeList extends TablePart
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  private String category = null;
+  private final String category;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SaldoChart.java
@@ -76,7 +76,7 @@ public class SaldoChart implements Part
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static de.willuhn.jameica.system.Settings settings = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getSettings();
 
-  private Konto konto             = null;
+  private final Konto konto;
   private boolean tiny            = false;
   
   private KontoInput kontoauswahl = null;

--- a/src/de/willuhn/jameica/hbci/gui/parts/SepaDauerauftragList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SepaDauerauftragList.java
@@ -49,7 +49,7 @@ import de.willuhn.util.I18N;
  */
 public class SepaDauerauftragList extends TablePart implements Part
 {
-  private MessageConsumer mc = null;
+  private MessageConsumer mc;
 
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 

--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -90,7 +90,7 @@ public class SparQuote implements Part
   private List<UmsatzEntry> data       = new ArrayList<UmsatzEntry>();
   private List<UmsatzEntry> trend      = new ArrayList<UmsatzEntry>();
 
-  private Listener listener            = null; // BUGZILLA 575
+  private final Listener listener; // BUGZILLA 575
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
@@ -80,8 +80,8 @@ public class UmsatzList extends TablePart implements Extendable
   static Map cache = new HashMap();
   
 
-  private MessageConsumer mcChanged = null;
-  private MessageConsumer mcNew     = null;
+  private MessageConsumer mcChanged;
+  private MessageConsumer mcNew;
 
   private UmsatzDaysInput days      = null;
 
@@ -362,7 +362,7 @@ public class UmsatzList extends TablePart implements Extendable
   {
     private boolean sleep = true;
     private Thread timeout = null;
-    private Calendar cal = null;
+    private final Calendar cal;
    
     private KL() throws RemoteException
     {

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzList.java
@@ -453,7 +453,7 @@ public class UmsatzList extends TablePart implements Extendable
             else if (umsaetze != null)
             {
               removeAll();
-              Date date = null;
+              Date date;
               Date limit = null;
               if (t > 0)
               {

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypChart.java
@@ -41,7 +41,7 @@ import de.willuhn.util.I18N;
 public class UmsatzTypChart implements Part
 {
   
-  private I18N i18n   = null;
+  private final I18N i18n;
   private int start   = UmsatzDaysInput.getDefaultDays();
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypList.java
@@ -48,8 +48,8 @@ import de.willuhn.util.I18N;
 public class UmsatzTypList extends TablePart implements Part
 {
 
-  private I18N i18n = null;
-  private MessageConsumer mc = null;
+  private I18N i18n;
+  private MessageConsumer mc;
   
   private static Hashtable<String,Color> colorCache = new Hashtable<String,Color>();
 

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypVerlauf.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTypVerlauf.java
@@ -65,9 +65,9 @@ public class UmsatzTypVerlauf implements Part
     
     ;
     
-    private int type;
-    private int size;
-    private String name;
+    private final int type;
+    private final int size;
+    private final String name;
     
     /**
      * ct.
@@ -230,7 +230,7 @@ public class UmsatzTypVerlauf implements Part
    */
   private class ChartDataUmsatz implements LineChartData
   {
-    private UmsatzTreeNode group = null;
+    private final UmsatzTreeNode group;
     private List<Entry> entries  = new ArrayList<Entry>();
     private boolean hasData      = false;
     private Date chartStartDate  = null;

--- a/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
@@ -184,7 +184,7 @@ public class KontoNew extends AbstractView
 
     ButtonArea buttons = new ButtonArea();
 
-    Button fetch = null;
+    Button fetch;
 
     Konto konto = control.getKonto();
     if (konto.hasFlag(Konto.FLAG_OFFLINE))

--- a/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/KontoNew.java
@@ -54,7 +54,7 @@ public class KontoNew extends AbstractView
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private KontoControl control = null;
+  private final KontoControl control;
   
   @Resource
   private SynchronizeEngine synchronizeEngine = null;

--- a/src/de/willuhn/jameica/hbci/gui/views/UmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UmsatzDetail.java
@@ -57,7 +57,7 @@ public class UmsatzDetail extends AbstractUmsatzDetail
     checked.setEnabled(!u.hasFlag(Umsatz.FLAG_NOTBOOKED) && !u.hasFlag(Umsatz.FLAG_CHECKED));
     buttons.addButton(checked);
     
-    Button ab = null;
+    Button ab;
     final Address found = getControl().getAddressbookEntry();
     if (found != null)
     {

--- a/src/de/willuhn/jameica/hbci/io/AbstractDTAUSIO.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractDTAUSIO.java
@@ -111,7 +111,7 @@ public abstract class AbstractDTAUSIO implements IO
    */
   class MyIOFormat implements IOFormat
   {
-    Class type = null;
+    final Class type;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/io/AbstractDTAUSImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractDTAUSImporter.java
@@ -107,7 +107,7 @@ public abstract class AbstractDTAUSImporter extends AbstractDTAUSIO implements I
         
         DBService service = de.willuhn.jameica.hbci.Settings.getDBService();
 
-        CSatz c = null;
+        CSatz c;
         while ((c = parser.next()) != null)
         {
           try

--- a/src/de/willuhn/jameica/hbci/io/AbstractExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractExporter.java
@@ -159,7 +159,7 @@ public abstract class AbstractExporter implements Exporter
    */
   class MyIOFormat implements IOFormat
   {
-    Class type = null;
+    final Class type;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractImporter.java
@@ -168,7 +168,7 @@ public abstract class AbstractImporter implements Importer
    */
   class MyIOFormat implements IOFormat
   {
-    Class type = null;
+    final Class type;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/io/AbstractSepaExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractSepaExporter.java
@@ -86,7 +86,7 @@ public abstract class AbstractSepaExporter extends AbstractExporter
     
     // Wir haben unterschiedliche Konten. Die Auftraege koennen aber nur einem Konto zugeordnet sein.
     // Wir fragen daher den User.
-    Konto konto = null;
+    Konto konto;
     if (ids.size() > 1)
     {
       KontoAuswahlDialog d = new KontoAuswahlDialog(null,KontoFilter.FOREIGN,KontoAuswahlDialog.POSITION_CENTER);

--- a/src/de/willuhn/jameica/hbci/io/CamtUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/CamtUmsatzImporter.java
@@ -89,7 +89,7 @@ public class CamtUmsatzImporter implements Importer
         // Wir kriegen aus dem ZIP-Inputstream nicht raus, wieviele Dateien enthalten sind sondern koennen nur drueber iterieren.
         // Daher rechnen wir fuer den Fortschrittsbalken mal pauschal mit 22 Dateien (pro Buchungstag aka Wochentag eines Monats eine Datei)
         ZipInputStream zis = new ZipInputStream(is);
-        ZipEntry ze = null;
+        ZipEntry ze;
         double fc = 22d;
         int no = 1;
         while ((ze = zis.getNextEntry()) != null)

--- a/src/de/willuhn/jameica/hbci/io/IORegistry.java
+++ b/src/de/willuhn/jameica/hbci/io/IORegistry.java
@@ -26,10 +26,10 @@ public class IORegistry
 {
 
   // Liste der Export-Filter
-  private static List<Exporter> exporters = null;
+  private static final List<Exporter> exporters;
 
   // Liste der Importer
-  private static List<Importer> importers = null;
+  private static final List<Importer> importers;
 
   static
   {

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -161,7 +161,7 @@ public class MT940UmsatzExporter implements Exporter
     		
     		//Verwendungszweck
     		String[] lines = VerwendungszweckUtil.rewrap(65,VerwendungszweckUtil.toArray(u));
-    		int m = 0;
+    		int m;
     		for (m=0;m<lines.length;++m)
     		{
       		// in MT940 sind nur max. 10 Zeilen zugelassen. Die restlichen muessen wir

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -319,7 +319,7 @@ public class MT940UmsatzExporter implements Exporter
   {
     private String[] search  = new String[]{"Ü", "Ö", "Ä", "ü", "ö", "ä", "ß"};
     private String[] replace = new String[]{"UE","OE","AE","ue","oe","ae","ss"};
-    private boolean doReplace = true;
+    private boolean doReplace;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporterMerged.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporterMerged.java
@@ -129,7 +129,7 @@ public class MT940UmsatzExporterMerged extends MT940UmsatzExporter
     		
     		//Verwendungszweck
     		String[] lines = VerwendungszweckUtil.rewrap(65,VerwendungszweckUtil.toArray(u));
-    		int m=0;
+    		int m;
     		for (m=0;m<lines.length;++m)
     		{
       		// in MT940 sind nur max. 10 Zeilen zugelassen. Die restlichen muessen wir

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzImporter.java
@@ -80,7 +80,7 @@ public class MT940UmsatzImporter implements Importer
 
       InputStreamReader encodedIs = new InputStreamReader(is,MT940UmsatzExporter.CHARSET);
       StringBuffer sb = new StringBuffer();
-      int read = 0;
+      int read;
       char[] buf = new char[8192];
 
       while ((read = encodedIs.read(buf)) != -1)

--- a/src/de/willuhn/jameica/hbci/io/Reporter.java
+++ b/src/de/willuhn/jameica/hbci/io/Reporter.java
@@ -52,14 +52,14 @@ public class Reporter
   private List<PdfPCell> headers = new ArrayList<PdfPCell>();
   private List<Integer> widths = new ArrayList<Integer>();
 
-  private OutputStream out = null;
-  private Document rpt = null;
+  private final OutputStream out;
+  private final Document rpt;
   private PdfPTable table = null;
 
-  private int maxRecords = 0;
+  private final int maxRecords;
   private int currRecord = 0;
 
-  private ProgressMonitor monitor = null;
+  private final ProgressMonitor monitor;
   
   /**
    * Farbvorgabe fuer normalen Text.

--- a/src/de/willuhn/jameica/hbci/io/VelocityExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/VelocityExporter.java
@@ -199,10 +199,10 @@ public class VelocityExporter implements Exporter
    */
   public class VelocityFormat implements IOFormat
   {
-    private String extension = null;
-    private String variant   = null;
+    private final String extension;
+    private final String variant;
     
-    private File template = null;
+    private final File template;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/io/XMLImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLImporter.java
@@ -84,7 +84,7 @@ public class XMLImporter implements Importer
       int created = 0;
       int error   = 0;
 
-      DBObject object = null;
+      DBObject object;
       while ((object = (DBObject) reader.read()) != null)
       {
         if (monitor != null)

--- a/src/de/willuhn/jameica/hbci/io/XMLKontoauszugImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLKontoauszugImporter.java
@@ -75,7 +75,7 @@ public class XMLKontoauszugImporter extends XMLImporter
         monitor.setStatusText(i18n.tr("Lese Datei ein"));
 
 
-      Konto konto = null;
+      Konto konto;
       if (context instanceof Konto)
       {
         konto = (Konto) context;
@@ -97,7 +97,7 @@ public class XMLKontoauszugImporter extends XMLImporter
       int created = 0;
       int error   = 0;
 
-      Kontoauszug ka = null;
+      Kontoauszug ka;
       while ((ka = (Kontoauszug) reader.read()) != null)
       {
         if (monitor != null)

--- a/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLSepaSammelTransferImporter.java
@@ -76,7 +76,7 @@ public class XMLSepaSammelTransferImporter extends XMLImporter
         monitor.setStatusText(i18n.tr("Lese Datei ein"));
 
 
-      Konto konto = null;
+      Konto konto;
       try
       {
         // Wir fragen das Konto grundsaetzlich manuell ab. Siehe BUGZILLA 700
@@ -97,7 +97,7 @@ public class XMLSepaSammelTransferImporter extends XMLImporter
 
       SepaSammelTransfer currentTransfer = null;
       
-      DBObject object = null;
+      DBObject object;
       while ((object = (DBObject) reader.read()) != null)
       {
         if (monitor != null)

--- a/src/de/willuhn/jameica/hbci/io/XMLUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLUmsatzImporter.java
@@ -76,7 +76,7 @@ public class XMLUmsatzImporter extends XMLImporter
         monitor.setStatusText(i18n.tr("Lese Datei ein"));
 
 
-      Konto konto = null;
+      Konto konto;
       if (context instanceof Konto)
       {
         konto = (Konto) context;
@@ -99,7 +99,7 @@ public class XMLUmsatzImporter extends XMLImporter
       int created = 0;
       int error   = 0;
 
-      Umsatz umsatz = null;
+      Umsatz umsatz;
       while ((umsatz = (Umsatz) reader.read()) != null)
       {
         if (monitor != null)

--- a/src/de/willuhn/jameica/hbci/io/XMLUmsatzTypImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/XMLUmsatzTypImporter.java
@@ -84,7 +84,7 @@ public class XMLUmsatzTypImporter implements Importer
 
       Map<String,String> idMap = new HashMap<String,String>();
       
-      AbstractDBObjectNode object = null;
+      AbstractDBObjectNode object;
       while ((object = (AbstractDBObjectNode) reader.read()) != null)
       {
         

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -376,7 +376,7 @@ public class CsvImporter implements Importer
    */
   private class MyIOFormat implements IOFormat
   {
-    private Format format = null;
+    private final Format format;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -123,7 +123,7 @@ public class CsvImporter implements Importer
       int created       = 0;
       int error         = 0;
       int skipped       = 0;
-      DBObject object   = null;
+      DBObject object;
       String value      = null;
       List<Column> cols = p.getColumns();
       ImportListener l  = f.getImportListener();
@@ -356,7 +356,7 @@ public class CsvImporter implements Importer
       ByteArrayOutputStream bos = new ByteArrayOutputStream();
       
       byte[] buf = new byte[4096];
-      int read   = 0;
+      int read;
       while ((read = is.read(buf)) != -1)
       {
         if (read > 0) // Nur schreiben, wenn wirklich was gelesen wurde

--- a/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportBaseUeberweisung.java
+++ b/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportBaseUeberweisung.java
@@ -34,7 +34,7 @@ import net.sf.paperclips.TextPrint;
  */
 public abstract class AbstractPrintSupportBaseUeberweisung extends AbstractPrintSupport
 {
-  private BaseUeberweisung auftrag = null;
+  private final BaseUeberweisung auftrag;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportBaseUeberweisungList.java
+++ b/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportBaseUeberweisungList.java
@@ -37,7 +37,7 @@ import de.willuhn.util.ApplicationException;
  */
 public abstract class AbstractPrintSupportBaseUeberweisungList extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSammelTransfer.java
+++ b/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSammelTransfer.java
@@ -37,7 +37,7 @@ import net.sf.paperclips.TextPrint;
  */
 public abstract class AbstractPrintSupportSammelTransfer extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSepaSammelTransfer.java
+++ b/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSepaSammelTransfer.java
@@ -40,7 +40,7 @@ import net.sf.paperclips.TextPrint;
  */
 public abstract class AbstractPrintSupportSepaSammelTransfer<T extends SepaSammelTransfer> extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSepaTransfer.java
+++ b/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSepaTransfer.java
@@ -34,7 +34,7 @@ import net.sf.paperclips.TextPrint;
  */
 public abstract class AbstractPrintSupportSepaTransfer<T extends BaseUeberweisung> extends AbstractPrintSupport
 {
-  private T auftrag = null;
+  private final T auftrag;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSepaTransferList.java
+++ b/src/de/willuhn/jameica/hbci/io/print/AbstractPrintSupportSepaTransferList.java
@@ -37,7 +37,7 @@ import net.sf.paperclips.TextStyle;
  */
 public abstract class AbstractPrintSupportSepaTransferList extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/PrintSupportDauerauftrag.java
+++ b/src/de/willuhn/jameica/hbci/io/print/PrintSupportDauerauftrag.java
@@ -35,7 +35,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class PrintSupportDauerauftrag extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/PrintSupportSepaDauerauftrag.java
+++ b/src/de/willuhn/jameica/hbci/io/print/PrintSupportSepaDauerauftrag.java
@@ -34,7 +34,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class PrintSupportSepaDauerauftrag extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/PrintSupportUeberweisung.java
+++ b/src/de/willuhn/jameica/hbci/io/print/PrintSupportUeberweisung.java
@@ -22,7 +22,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class PrintSupportUeberweisung extends AbstractPrintSupportBaseUeberweisung
 {
-  private Ueberweisung u = null;
+  private final Ueberweisung u;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/io/print/PrintSupportUmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/io/print/PrintSupportUmsatzList.java
@@ -44,7 +44,7 @@ import net.sf.paperclips.TextStyle;
  */
 public class PrintSupportUmsatzList extends AbstractPrintSupport
 {
-  private Object ctx = null;
+  private final Object ctx;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/messaging/CheckOfflineUmsatzMessageConsumer.java
+++ b/src/de/willuhn/jameica/hbci/messaging/CheckOfflineUmsatzMessageConsumer.java
@@ -87,7 +87,7 @@ public class CheckOfflineUmsatzMessageConsumer implements MessageConsumer
     }
 
     // Checken, ob wir ein lokal passendes Offline-Konto haben
-    Konto gegenkonto = null;
+    Konto gegenkonto;
     String s = StringUtils.trimToNull(u.getGegenkontoNummer());
     if (s == null)
     {

--- a/src/de/willuhn/jameica/hbci/messaging/ObjectMessage.java
+++ b/src/de/willuhn/jameica/hbci/messaging/ObjectMessage.java
@@ -18,7 +18,7 @@ import de.willuhn.jameica.messaging.Message;
  */
 public class ObjectMessage implements Message
 {
-  private GenericObject object = null;
+  private final GenericObject object;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passport/PassportChangeRequest.java
+++ b/src/de/willuhn/jameica/hbci/passport/PassportChangeRequest.java
@@ -20,17 +20,17 @@ public class PassportChangeRequest
   /**
    * Der zu aendernde Passport.
    */
-  public AbstractHBCIPassport passport = null;
+  public final AbstractHBCIPassport passport;
   
   /**
    * Die neue Kundenkennung.
    */
-  public String custId = null;
+  public final String custId;
   
   /**
    * Die neue Benutzerkennung.
    */
-  public String userId = null;
+  public final String userId;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfig.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfig.java
@@ -36,7 +36,7 @@ public class DDVConfig implements Configuration
   public final static String[] PORTS = new String[] {"COM/USB","COM2/USB2","USB3","USB4","USB5","USB6"};
   
   private final static Settings settings = new Settings(DDVConfig.class);
-  private String id = null;
+  private final String id;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/ddv/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/KontoList.java
@@ -31,7 +31,7 @@ import de.willuhn.jameica.hbci.rmi.Konto;
  */
 public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
 {
-  private DDVConfig myConfig = null;
+  private final DDVConfig myConfig;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/ddv/rmi/Reader.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/rmi/Reader.java
@@ -40,8 +40,8 @@ public interface Reader
     
     ;
 
-    private String id = null;
-    private String headerParam = null;
+    private final String id;
+    private final String headerParam;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
@@ -220,7 +220,7 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			}
 
 			ArrayList result = new ArrayList();
-			Konto k = null;
+			Konto k;
 			for (int i=0;i<konten.length;++i)
 			{
 				k = Converter.HBCIKonto2HibiscusKonto(konten[i], PassportImpl.class);

--- a/src/de/willuhn/jameica/hbci/passports/pintan/ChipTANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/ChipTANDialog.java
@@ -63,7 +63,7 @@ public class ChipTANDialog extends TANDialog
   
   private final static String PARAM_AUTOCONTINUE = "usb.autocontinue";
   
-  private String code = null;
+  private String code;
   private boolean usb = false;
   private ChipTanCardService service = null;
   private CheckboxInput autoContinue = null;

--- a/src/de/willuhn/jameica/hbci/passports/pintan/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/Controller.java
@@ -590,7 +590,7 @@ public class Controller extends AbstractControl
    */
   public synchronized void handleCreate()
   {
-    PinTanConfig conf = null;
+    PinTanConfig conf;
     try
     {
       Logger.info("creating new pin/tan config");

--- a/src/de/willuhn/jameica/hbci/passports/pintan/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/KontoList.java
@@ -32,7 +32,7 @@ import de.willuhn.jameica.hbci.rmi.Konto;
  */
 public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
 {
-  private PinTanConfig myConfig = null;
+  private final PinTanConfig myConfig;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PhotoTANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PhotoTANDialog.java
@@ -45,7 +45,7 @@ public class PhotoTANDialog extends TANDialog
 {
   private final static Settings SETTINGS = new Settings(PhotoTANDialog.class);
   
-  private byte[] bytes = null;
+  private byte[] bytes;
   private int initialSize = 0;
   private int currentSize = 0;
   private Image image = null;

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
@@ -252,7 +252,7 @@ public class PinTanConfigFactory
       throw new ApplicationException(i18n.tr("Bitte legen Sie zuerst eine PIN/TAN-Konfiguration an"));
 
     Logger.info("searching config for konto " + konto.getKontonummer() + ", blz: " + konto.getBLZ());
-    PinTanConfig config = null;
+    PinTanConfig config;
 
     ArrayList found = new ArrayList();
     while (i.hasNext())

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PtSecMechDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PtSecMechDialog.java
@@ -45,11 +45,11 @@ public class PtSecMechDialog extends AbstractDialog
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
   private final static Settings SETTINGS = new Settings(PtSecMechDialog.class);
 
-  private String options      = null;
+  private final String options;
 
   private SelectInput type    = null;
   private CheckboxInput save  = null;
-  private PinTanConfig config = null;
+  private final PinTanConfig config;
   
   private PtSecMech choosen   = null;
   

--- a/src/de/willuhn/jameica/hbci/passports/pintan/SelectConfigDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/SelectConfigDialog.java
@@ -36,7 +36,7 @@ public class SelectConfigDialog extends AbstractDialog
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
   private PinTanConfig selected = null;
-  private GenericIterator list  = null;
+  private final GenericIterator list;
   private String text           = null;
 
   /**

--- a/src/de/willuhn/jameica/hbci/passports/pintan/TANDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/TANDialog.java
@@ -62,7 +62,7 @@ public class TANDialog extends AbstractDialog
   protected final static int WINDOW_WIDTH  = 500;
   protected final static int WINDOW_HEIGHT = 550;
 
-  protected PinTanConfig config = null;
+  protected final PinTanConfig config;
   private HibiscusDBObject context = null;
   
   private NotificationPanel panel = null;

--- a/src/de/willuhn/jameica/hbci/passports/pintan/TanMediaDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/TanMediaDialog.java
@@ -49,9 +49,9 @@ public class TanMediaDialog extends AbstractDialog
 
   private SelectInput media   = null;
   private CheckboxInput save  = null;
-  private PinTanConfig config = null;
+  private final PinTanConfig config;
 
-  private String options      = null;
+  private final String options;
   private String choosen      = null;
   
   /**

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
@@ -309,7 +309,7 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			}
 
 			ArrayList result = new ArrayList();
-			Konto k = null;
+			Konto k;
 			for (int i=0;i<konten.length;++i)
 			{
 				k = Converter.HBCIKonto2HibiscusKonto(konten[i], PassportImpl.class);

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PinTanConfigImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PinTanConfigImpl.java
@@ -42,8 +42,8 @@ public class PinTanConfigImpl implements PinTanConfig
 
   private final static Settings settings = new Settings(PinTanConfig.class);
 
-  private PassportLoader loader = null;
-  private File file             = null;
+  private final PassportLoader loader;
+  private final File file;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/rdh/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/Controller.java
@@ -450,7 +450,7 @@ public class Controller extends AbstractControl {
    */
   public synchronized void changePassword()
   {
-    HBCIPassport passport = null;
+    HBCIPassport passport;
     HBCICallback callback = null;
     
     try
@@ -499,7 +499,7 @@ public class Controller extends AbstractControl {
       return;
     }
     
-    HBCIPassport passport = null;
+    HBCIPassport passport;
     try
     {
       if (!Application.getCallback().askUser(i18n.tr("Sind Sie sicher?")))
@@ -691,7 +691,7 @@ public class Controller extends AbstractControl {
   private class ActivateKey extends CheckedContextMenuItem
   {
 
-    private boolean activate;
+    private final boolean activate;
 
     /**
      * @param activate

--- a/src/de/willuhn/jameica/hbci/passports/rdh/InsertKeyDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/InsertKeyDialog.java
@@ -23,7 +23,7 @@ import de.willuhn.util.I18N;
 public class InsertKeyDialog extends WaitDialog
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  private File file = null;
+  private final File file;
 
   /**
    * @param f die Schluesseldatei.

--- a/src/de/willuhn/jameica/hbci/passports/rdh/KeyFormatDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/KeyFormatDialog.java
@@ -42,7 +42,7 @@ public class KeyFormatDialog extends AbstractDialog
   private TablePart table   = null;
   private KeyFormat choosen = null;
   private LabelInput warn   = null;
-  private int neededFeature = KeyFormat.FEATURE_CREATE;
+  private final int neededFeature;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/rdh/KeyPasswordLoadDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/KeyPasswordLoadDialog.java
@@ -85,7 +85,7 @@ public class KeyPasswordLoadDialog extends PasswordDialog
       Logger.error("unable to determine current konto",e);
     }
     
-    String text = null;
+    String text;
     if (s != null)
     {
       setTitle(i18n.tr("Schlüsseldatei. Konto: {0}",s));

--- a/src/de/willuhn/jameica/hbci/passports/rdh/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/KontoList.java
@@ -32,7 +32,7 @@ import de.willuhn.jameica.hbci.rmi.Konto;
  */
 public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
 {
-  private RDHKey myKey = null;
+  private final RDHKey myKey;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
@@ -176,7 +176,7 @@ public class RDHKeyFactory
       final int ft = KeyFormat.FEATURE_CREATE;
       KeyFormat[] formats = RDHKeyFactory.getKeyFormats(ft);
       
-      KeyFormat format = null;
+      KeyFormat format;
       if (formats != null && formats.length == 1)
       {
         format = formats[0];
@@ -232,7 +232,7 @@ public class RDHKeyFactory
 		if (!i.hasNext())
 			throw new ApplicationException(i18n.tr("Bitte erstellen Sie zuerst eine Schlüsseldatei"));
 
-    RDHKey key = null;
+    RDHKey key;
     
 
     ArrayList keys = new ArrayList();

--- a/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
@@ -40,7 +40,7 @@ public class RDHKeyFactory
 
 	private static Settings settings = new Settings(RDHKeyFactory.class);
 
-	private static I18N i18n;
+	private static final I18N i18n;
 	
 	static
 	{

--- a/src/de/willuhn/jameica/hbci/passports/rdh/SelectKeyDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/SelectKeyDialog.java
@@ -176,7 +176,7 @@ public class SelectKeyDialog extends AbstractDialog
   private class KeyObject implements GenericObject
   {
 
-    private RDHKey key = null;
+    private final RDHKey key;
     
     private KeyObject(RDHKey key)
     {

--- a/src/de/willuhn/jameica/hbci/passports/rdh/SelectSizEntryDialog.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/SelectSizEntryDialog.java
@@ -36,7 +36,7 @@ import de.willuhn.util.I18N;
 public class SelectSizEntryDialog extends AbstractDialog
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  private String data     = null;
+  private final String data;
   private Entry selected  = null;
 
   /**
@@ -120,9 +120,9 @@ public class SelectSizEntryDialog extends AbstractDialog
   public class Entry
   {
 
-    private String id     = null;
-    private String userid = null;
-    private String bank   = null;
+    private final String id;
+    private final String userid;
+    private String bank;
     
     private Entry(String data)
     {

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
@@ -243,7 +243,7 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 			}
 
 			ArrayList result = new ArrayList();
-			Konto k = null;
+			Konto k;
 			for (int i=0;i<konten.length;++i)
 			{
 				k = Converter.HBCIKonto2HibiscusKonto(konten[i], PassportImpl.class);

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/RDHKeyImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/RDHKeyImpl.java
@@ -40,7 +40,7 @@ import de.willuhn.util.MultipleClassLoader;
 public class RDHKeyImpl implements RDHKey
 {
 
-  private File file = null;
+  private File file;
   private Settings settings = new Settings(RDHKey.class);
 
   /**

--- a/src/de/willuhn/jameica/hbci/rmi/BatchBookType.java
+++ b/src/de/willuhn/jameica/hbci/rmi/BatchBookType.java
@@ -42,9 +42,9 @@ public enum BatchBookType
    */
   public static BatchBookType DEFAULT = NONE;
   
-  private Boolean bv = null;
-  private String value = null;
-  private String description = null;
+  private final Boolean bv;
+  private final String value;
+  private final String description;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/rmi/KontoType.java
+++ b/src/de/willuhn/jameica/hbci/rmi/KontoType.java
@@ -80,9 +80,9 @@ public enum KontoType
    */
   public final static KontoType DEFAULT = GIRO;
   
-  private int min;
-  private int max;
-  private String name;
+  private final int min;
+  private final int max;
+  private final String name;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/rmi/PurposeCode.java
+++ b/src/de/willuhn/jameica/hbci/rmi/PurposeCode.java
@@ -98,8 +98,8 @@ public enum PurposeCode
   
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private String code;
-  private String name;
+  private final String code;
+  private final String name;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/rmi/SepaLastSequenceType.java
+++ b/src/de/willuhn/jameica/hbci/rmi/SepaLastSequenceType.java
@@ -43,7 +43,7 @@ public enum SepaLastSequenceType
   
   ;
   
-  private String description = null;
+  private final String description;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/rmi/SepaLastType.java
+++ b/src/de/willuhn/jameica/hbci/rmi/SepaLastType.java
@@ -43,9 +43,9 @@ public enum SepaLastType
    */
   public static SepaLastType DEFAULT = CORE;
   
-  private String jobName = null;
-  private String multiJobName = null;
-  private String description = null;
+  private final String jobName;
+  private final String multiJobName;
+  private final String description;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/schedule/Schedule.java
+++ b/src/de/willuhn/jameica/hbci/schedule/Schedule.java
@@ -20,9 +20,9 @@ import de.willuhn.jameica.hbci.rmi.HibiscusDBObject;
  */
 public class Schedule<T extends HibiscusDBObject>
 {
-  private Date date = null;
-  private T context = null;
-  private boolean planned = false;
+  private final Date date;
+  private final T context;
+  private final boolean planned;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/search/AddressbookSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/AddressbookSearchProvider.java
@@ -77,7 +77,7 @@ public class AddressbookSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Address address = null;
+    private final Address address;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/AuslandsUeberweisungSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/AuslandsUeberweisungSearchProvider.java
@@ -73,7 +73,7 @@ public class AuslandsUeberweisungSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private AuslandsUeberweisung u = null;
+    private final AuslandsUeberweisung u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/DauerauftragSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/DauerauftragSearchProvider.java
@@ -76,7 +76,7 @@ public class DauerauftragSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Dauerauftrag u = null;
+    private final Dauerauftrag u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/KontoSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/KontoSearchProvider.java
@@ -71,7 +71,7 @@ public class KontoSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Konto konto = null;
+    private final Konto konto;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/KontoauszugSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/KontoauszugSearchProvider.java
@@ -80,7 +80,7 @@ public class KontoauszugSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Kontoauszug u = null;
+    private final Kontoauszug u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/LastschriftSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/LastschriftSearchProvider.java
@@ -76,7 +76,7 @@ public class LastschriftSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Lastschrift l = null;
+    private final Lastschrift l;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/SammelLastschriftSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SammelLastschriftSearchProvider.java
@@ -91,7 +91,7 @@ public class SammelLastschriftSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private SammelLastschrift u = null;
+    private final SammelLastschrift u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/SammelUeberweisungSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SammelUeberweisungSearchProvider.java
@@ -91,7 +91,7 @@ public class SammelUeberweisungSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private SammelUeberweisung u = null;
+    private final SammelUeberweisung u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/SepaDauerauftragSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SepaDauerauftragSearchProvider.java
@@ -74,7 +74,7 @@ public class SepaDauerauftragSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private SepaDauerauftrag u = null;
+    private final SepaDauerauftrag u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/SepaLastschriftSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SepaLastschriftSearchProvider.java
@@ -75,7 +75,7 @@ public class SepaLastschriftSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private SepaLastschrift u = null;
+    private final SepaLastschrift u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/SepaSammelLastschriftSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SepaSammelLastschriftSearchProvider.java
@@ -92,7 +92,7 @@ public class SepaSammelLastschriftSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private SepaSammelLastschrift u = null;
+    private final SepaSammelLastschrift u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/SepaSammelUeberweisungSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SepaSammelUeberweisungSearchProvider.java
@@ -90,7 +90,7 @@ public class SepaSammelUeberweisungSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private SepaSammelUeberweisung u = null;
+    private final SepaSammelUeberweisung u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/UeberweisungSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/UeberweisungSearchProvider.java
@@ -76,7 +76,7 @@ public class UeberweisungSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Ueberweisung u = null;
+    private final Ueberweisung u;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/search/UmsatzSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/UmsatzSearchProvider.java
@@ -64,7 +64,7 @@ public class UmsatzSearchProvider implements SearchProvider
    */
   private class MyResult implements Result
   {
-    private Umsatz umsatz = null;
+    private final Umsatz umsatz;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
@@ -229,7 +229,7 @@ public abstract class AbstractSammelTransferImpl extends AbstractHibiscusDBObjec
       int count = 0;
       // dann die Dauerauftraege
       DBIterator list = getBuchungen();
-      SammelTransferBuchung b = null;
+      SammelTransferBuchung b;
       while (list.hasNext())
       {
         b = (SammelTransferBuchung) list.next();

--- a/src/de/willuhn/jameica/hbci/server/AddressbookHibiscusImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AddressbookHibiscusImpl.java
@@ -231,7 +231,7 @@ public class AddressbookHibiscusImpl extends UnicastRemoteObject implements Addr
   public class KontoAddress implements Address
   {
 
-    private Konto konto = null;
+    private final Konto konto;
 
     /**
      * Der Konstruktor erwartet ein Konto-Objekt. Dieses wird dann als Adresse bereitgestellt.

--- a/src/de/willuhn/jameica/hbci/server/BPDUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/BPDUtil.java
@@ -79,8 +79,8 @@ public class BPDUtil
     
     ;
     
-    private String query  = null;
-    private String gvcode = null;
+    private final String query;
+    private final String gvcode;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/server/Cache.java
+++ b/src/de/willuhn/jameica/hbci/server/Cache.java
@@ -28,7 +28,7 @@ import de.willuhn.jameica.hbci.Settings;
 class Cache
 {
   private final static de.willuhn.jameica.system.Settings settings = new de.willuhn.jameica.system.Settings(Cache.class);
-  private static int timeout = 0;
+  private static final int timeout;
   
   // Enthaelt alle Caches.
   private final static Map<Class,Cache> caches = new HashMap<Class,Cache>();

--- a/src/de/willuhn/jameica/hbci/server/DBPropertyUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/DBPropertyUtil.java
@@ -41,9 +41,9 @@ import de.willuhn.util.TypedProperties;
 public class DBPropertyUtil
 {
   private final static de.willuhn.jameica.system.Settings settings = new de.willuhn.jameica.system.Settings(DBPropertyUtil.class);
-  private static int timeout = 0;
+  private static final int timeout;
 
-  private static Cache<String,Map<String,DBProperty>> CACHE = null;
+  private static final Cache<String,Map<String,DBProperty>> CACHE;
   
   static
   {
@@ -91,8 +91,8 @@ public class DBPropertyUtil
     
     ;
     
-    private String value = null;
-    private Set<String> filter = null;
+    private final String value;
+    private final Set<String> filter;
     
     /**
      * ct.

--- a/src/de/willuhn/jameica/hbci/server/DBReminderImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/DBReminderImpl.java
@@ -123,7 +123,7 @@ public class DBReminderImpl extends AbstractHibiscusDBObject implements DBRemind
       return;
     }
     
-    XMLEncoder encoder = null;
+    XMLEncoder encoder;
     try
     {
       ByteArrayOutputStream os = new ByteArrayOutputStream();

--- a/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabeTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabeTreeNode.java
@@ -16,9 +16,9 @@ import de.willuhn.jameica.util.DateUtil;
  */
 public class EinnahmeAusgabeTreeNode implements EinnahmeAusgabeZeitraum, GenericObjectNode
 {
-  private Date startdatum;
-  private Date enddatum;
-  private List<EinnahmeAusgabe> children;
+  private final Date startdatum;
+  private final Date enddatum;
+  private final List<EinnahmeAusgabe> children;
 
   /**
    * @param from Startdatum des Zeitraums

--- a/src/de/willuhn/jameica/hbci/server/HBCIDBServiceImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/HBCIDBServiceImpl.java
@@ -43,7 +43,7 @@ import de.willuhn.util.ProgressMonitor;
  */
 public class HBCIDBServiceImpl extends DBServiceImpl implements HBCIDBService
 {
-  private DBSupport driver = null;
+  private DBSupport driver;
   
   /**
    * @throws RemoteException
@@ -134,7 +134,7 @@ public class HBCIDBServiceImpl extends DBServiceImpl implements HBCIDBService
   public void checkConsistency() throws RemoteException, ApplicationException
   {
     Logger.info("determine current database version");
-    Version version = null;
+    Version version;
     try
     {
       version = VersionUtil.getVersion(this,"db");

--- a/src/de/willuhn/jameica/hbci/server/HBCIUpdateProvider.java
+++ b/src/de/willuhn/jameica/hbci/server/HBCIUpdateProvider.java
@@ -30,10 +30,10 @@ import de.willuhn.util.ProgressMonitor;
  */
 public class HBCIUpdateProvider implements UpdateProvider
 {
-  private Version version     = null;
-  private Connection conn     = null;
-  private Manifest manifest   = null;
-  private PluginResources res = null;
+  private final Version version;
+  private final Connection conn;
+  private final Manifest manifest;
+  private final PluginResources res;
 
   /**
    * ct

--- a/src/de/willuhn/jameica/hbci/server/KontoImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/KontoImpl.java
@@ -264,7 +264,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       // BUGZILLA #70 http://www.willuhn.de/bugzilla/show_bug.cgi?id=70
       // Erst die Umsaetze loeschen
       DBIterator list = getUmsaetze();
-      Umsatz um = null;
+      Umsatz um;
       while (list.hasNext())
       {
         um = (Umsatz) list.next();
@@ -273,7 +273,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       
       // Die fest zugeordneten Kategorien loesen
       list = getUmsatzTypen();
-      UmsatzTyp ut = null;
+      UmsatzTyp ut;
       while (list.hasNext())
       {
         ut = (UmsatzTyp) list.next();
@@ -283,7 +283,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       
       // dann die Kontoauszuege
       list = getKontoauszuege();
-      Kontoauszug az = null;
+      Kontoauszug az;
       while (list.hasNext())
       {
         az = (Kontoauszug) list.next();
@@ -292,7 +292,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // dann die Dauerauftraege
       list = getDauerauftraege();
-      Dauerauftrag da = null;
+      Dauerauftrag da;
       while (list.hasNext())
       {
         da = (Dauerauftrag) list.next();
@@ -301,7 +301,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // dann die SEPA-Dauerauftraege
       list = getSepaDauerauftraege();
-      SepaDauerauftrag sda = null;
+      SepaDauerauftrag sda;
       while (list.hasNext())
       {
         sda = (SepaDauerauftrag) list.next();
@@ -310,7 +310,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       
       // noch die Lastschriften
       list = getLastschriften();
-      Lastschrift ls = null;
+      Lastschrift ls;
       while (list.hasNext())
       {
         ls = (Lastschrift) list.next();
@@ -319,7 +319,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // und die Sammel-Lastschriften
       list = getSammelLastschriften();
-      SammelLastschrift sls = null;
+      SammelLastschrift sls;
       while (list.hasNext())
       {
         sls = (SammelLastschrift) list.next();
@@ -328,7 +328,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // und jetzt die Ueberweisungen
       list = getUeberweisungen();
-      Ueberweisung u = null;
+      Ueberweisung u;
       while (list.hasNext())
       {
         u = (Ueberweisung) list.next();
@@ -337,7 +337,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // und jetzt die Sammel-Ueberweisungen
       list = getSammelUeberweisungen();
-      SammelUeberweisung su = null;
+      SammelUeberweisung su;
       while (list.hasNext())
       {
         su = (SammelUeberweisung) list.next();
@@ -346,7 +346,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // und jetzt die Auslandsueberweisungen
       list = getAuslandsUeberweisungen();
-      AuslandsUeberweisung au = null;
+      AuslandsUeberweisung au;
       while (list.hasNext())
       {
         au = (AuslandsUeberweisung) list.next();
@@ -355,7 +355,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // SEPA-Lastschriften
       list = getSepaLastschriften();
-      SepaLastschrift sl = null;
+      SepaLastschrift sl;
       while (list.hasNext())
       {
         sl = (SepaLastschrift) list.next();
@@ -364,7 +364,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // SEPA-Sammellastschriften
       list = getSepaSammelLastschriften();
-      SepaSammelLastschrift ssl = null;
+      SepaSammelLastschrift ssl;
       while (list.hasNext())
       {
         ssl = (SepaSammelLastschrift) list.next();
@@ -373,7 +373,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // SEPA-Sammelueberweisungen
       list = getSepaSammelUeberweisungen();
-      SepaSammelUeberweisung ssu = null;
+      SepaSammelUeberweisung ssu;
       while (list.hasNext())
       {
         ssu = (SepaSammelUeberweisung) list.next();
@@ -382,7 +382,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
 
       // und noch die Protokolle
       list = getProtokolle();
-      Protokoll p = null;
+      Protokoll p;
       while (list.hasNext())
       {
         p = (Protokoll) list.next();

--- a/src/de/willuhn/jameica/hbci/server/Range.java
+++ b/src/de/willuhn/jameica/hbci/server/Range.java
@@ -352,8 +352,8 @@ public abstract class Range
    */
   private abstract static class LastYears extends Range
   {
-    private String text;
-    private int years;
+    private final String text;
+    private final int years;
 
     protected LastYears(int years, String text)
     {

--- a/src/de/willuhn/jameica/hbci/server/TurnusHelper.java
+++ b/src/de/willuhn/jameica/hbci/server/TurnusHelper.java
@@ -122,7 +122,7 @@ public class TurnusHelper
     int tag = turnus.getTag();
     int iv  = turnus.getIntervall();
 
-    Date test = null;
+    Date test;
     
     // eigentlich gehoert hier ein "while true" hin, ich will aber eine
     // Abbruchbedingung, damit das Teil keine 1000 Jahre in die Zukunft

--- a/src/de/willuhn/jameica/hbci/server/UmsatzGroup.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzGroup.java
@@ -31,7 +31,7 @@ public class UmsatzGroup implements GenericObjectNode, Comparable
 {
   private final static transient I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private UmsatzTyp typ = null;
+  private final UmsatzTyp typ;
   private ArrayList umsaetze = new ArrayList();
   
   /**

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTreeNode.java
@@ -35,7 +35,7 @@ public class UmsatzTreeNode implements GenericObjectNode, Comparable
 {
   private final static transient I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
 
-  private UmsatzTyp typ                 = null;
+  private final UmsatzTyp typ;
   private UmsatzTreeNode parent         = null;
   private List<UmsatzTreeNode> children = new ArrayList<UmsatzTreeNode>();
   private List<Umsatz> umsaetze         = new ArrayList<Umsatz>();

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypBean.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypBean.java
@@ -30,7 +30,7 @@ public class UmsatzTypBean implements GenericObjectNode
 {
   private UmsatzTypBean parent = null;
   private List<UmsatzTypBean> children = new LinkedList<UmsatzTypBean>();
-  private UmsatzTyp typ = null;
+  private final UmsatzTyp typ;
   private Integer level = null;
   
   /**

--- a/src/de/willuhn/jameica/hbci/server/hbci/AbstractHBCIJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/AbstractHBCIJob.java
@@ -149,7 +149,7 @@ public abstract class AbstractHBCIJob
   		Object key = i.next();
   		Object value = params.get(key);
   		
-  		String name = null;
+  		String name;
   		Integer idx = null;
   		if (key instanceof SimpleEntry)
   		{

--- a/src/de/willuhn/jameica/hbci/server/hbci/AbstractHBCISepaSammelTransferJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/AbstractHBCISepaSammelTransferJob.java
@@ -35,8 +35,8 @@ import de.willuhn.util.ApplicationException;
 public abstract class AbstractHBCISepaSammelTransferJob<T extends SepaSammelTransfer> extends AbstractHBCIJob
 {
 
-	private T transfer = null;
-	private Konto konto = null;
+	private T transfer;
+	private Konto konto;
 	
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIAuslandsUeberweisungJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIAuslandsUeberweisungJob.java
@@ -35,10 +35,10 @@ import de.willuhn.util.ApplicationException;
 public class HBCIAuslandsUeberweisungJob extends AbstractHBCIJob
 {
 
-	private AuslandsUeberweisung ueberweisung = null;
-  private boolean isTermin                  = false;
-  private boolean isUmb                     = false;
-	private Konto konto                       = null;
+  private AuslandsUeberweisung ueberweisung;
+  private boolean isTermin;
+  private boolean isUmb;
+  private Konto konto;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIKontoauszugJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIKontoauszugJob.java
@@ -45,7 +45,7 @@ import de.willuhn.util.ProgressMonitor;
  */
 public class HBCIKontoauszugJob extends AbstractHBCIJob
 {
-	private Konto konto = null;
+	private Konto konto;
 	
 	private List<AbstractHBCIJob> followers = new ArrayList<AbstractHBCIJob>();
 

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIQuittungJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIQuittungJob.java
@@ -32,7 +32,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class HBCIQuittungJob extends AbstractHBCIJob
 {
-  private Kontoauszug ka = null;
+  private Kontoauszug ka;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISaldoJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISaldoJob.java
@@ -31,7 +31,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class HBCISaldoJob extends AbstractHBCIJob {
 
-	private Konto konto = null;
+	private Konto konto;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragDeleteJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragDeleteJob.java
@@ -33,9 +33,9 @@ import de.willuhn.util.ApplicationException;
  */
 public class HBCISepaDauerauftragDeleteJob extends AbstractHBCIJob
 {
-	private SepaDauerauftrag dauerauftrag = null;
-	private Konto konto 						     	= null;
-	private Date date                     = null;
+	private SepaDauerauftrag dauerauftrag;
+	private Konto konto;
+	private Date date;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragListJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragListJob.java
@@ -37,7 +37,7 @@ import de.willuhn.util.ApplicationException;
 public class HBCISepaDauerauftragListJob extends AbstractHBCIJob
 {
 
-	private Konto konto = null;
+	private Konto konto;
 
   /**
    * @param konto Konto, ueber welches die existierenden SEPA-Dauerauftraege abgerufen werden.
@@ -113,8 +113,8 @@ public class HBCISepaDauerauftragListJob extends AbstractHBCIJob
     DBIterator existing        = konto.getSepaDauerauftraege();
     GVRDauerList.Dauer[] lines = result.getEntries();
 
-    SepaDauerauftrag remote = null;
-    SepaDauerauftrag local  = null;
+    SepaDauerauftrag remote;
+    SepaDauerauftrag local;
     
     // Hier drin merken wir uns alle SepaDauerauftraege, die beim Abgleich
     // gefunden wurden. Denn die muessen garantiert nicht lokal geloescht werden.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
@@ -44,10 +44,10 @@ import de.willuhn.util.ApplicationException;
 public class HBCISepaDauerauftragStoreJob extends AbstractHBCIJob
 {
 
-	private SepaDauerauftrag dauerauftrag = null;
-	private Konto konto 							    = null;
+	private SepaDauerauftrag dauerauftrag;
+	private Konto konto;
 
-	private boolean active = false;
+	private boolean active;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaDauerauftragStoreJob.java
@@ -194,7 +194,7 @@ public class HBCISepaDauerauftragStoreJob extends AbstractHBCIJob
     else
       konto.addToProtokoll(i18n.tr("SEPA-Dauerauftrag ausgeführt an {0} ",empfName),Protokoll.TYP_SUCCESS);
 
-    String orderID = null;
+    String orderID;
     HBCIJobResult result = this.getJobResult();
     if (result instanceof GVRDauerNew)
       orderID = ((GVRDauerNew)result).getOrderId();

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaLastschriftJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaLastschriftJob.java
@@ -39,9 +39,9 @@ import de.willuhn.util.ApplicationException;
 public class HBCISepaLastschriftJob extends AbstractHBCIJob
 {
 
-	private SepaLastschrift lastschrift = null;
-	private SepaLastType type           = null;
-	private Konto konto                 = null;
+	private SepaLastschrift lastschrift;
+	private SepaLastType type;
+	private Konto konto;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaSammelLastschriftJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaSammelLastschriftJob.java
@@ -32,7 +32,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class HBCISepaSammelLastschriftJob extends AbstractHBCISepaSammelTransferJob<SepaSammelLastschrift>
 {
-  private SepaLastType type = null;
+  private SepaLastType type;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaSammelUeberweisungJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCISepaSammelUeberweisungJob.java
@@ -25,7 +25,7 @@ import de.willuhn.util.ApplicationException;
  */
 public class HBCISepaSammelUeberweisungJob extends AbstractHBCISepaSammelTransferJob<SepaSammelUeberweisung>
 {
-  private boolean isTermin = false;
+  private boolean isTermin;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
@@ -60,8 +60,8 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
 {
   private final static Settings settings = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getSettings();
 
-	private Konto konto     = null;
-	private Date saldoDatum = null;
+	private Konto konto;
+	private Date saldoDatum;
 
   /**
 	 * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/tests/CanTermDelRestriction.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/tests/CanTermDelRestriction.java
@@ -23,9 +23,9 @@ import de.willuhn.util.I18N;
  */
 public class CanTermDelRestriction implements Restriction
 {
-	private Properties p  = null;
+	private final Properties p;
 	
-	private I18N i18n;
+	private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/tests/PreTimeRestriction.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/tests/PreTimeRestriction.java
@@ -60,7 +60,7 @@ public class PreTimeRestriction implements Restriction
 
 		Logger.debug("testing first payment date " + date.toString() + " against restriction \"minpretime\": " + min);
 
-		int i = 0;
+		int i;
 		try
 		{
 			i = Integer.parseInt(min);
@@ -89,7 +89,7 @@ public class PreTimeRestriction implements Restriction
 
 		Logger.debug("testing first payment date " + date.toString() + " against restriction \"maxpretime\": " + max);
 
-		int i = 0;
+		int i;
 		try
 		{
 			i = Integer.parseInt(max);

--- a/src/de/willuhn/jameica/hbci/server/hbci/tests/PreTimeRestriction.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/tests/PreTimeRestriction.java
@@ -25,10 +25,10 @@ import de.willuhn.util.I18N;
  */
 public class PreTimeRestriction implements Restriction
 {
-	private Properties p  = null;
-	private Date date     = null;
+	private final Properties p;
+	private final Date date;
 	
-	private I18N i18n;
+	private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/server/hbci/tests/TurnusRestriction.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/tests/TurnusRestriction.java
@@ -25,10 +25,10 @@ import de.willuhn.util.I18N;
  */
 public class TurnusRestriction implements Restriction
 {
-	private Turnus turnus = null;
-	private Properties p  = null;
+	private final Turnus turnus;
+	private final Properties p;
 	
-	private I18N i18n;
+	private final I18N i18n;
 
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/synchronize/AbstractSynchronizeBackend.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/AbstractSynchronizeBackend.java
@@ -309,7 +309,7 @@ public abstract class AbstractSynchronizeBackend<T extends SynchronizeJobProvide
   {
     private ProgressMonitor monitor  = null;
     private JobGroup currentJobGroup = null;
-    private Synchronization sync     = null;
+    private Synchronization sync;
     private boolean interrupted      = false;
     
     /**
@@ -541,7 +541,7 @@ public abstract class AbstractSynchronizeBackend<T extends SynchronizeJobProvide
    */
   protected abstract class JobGroup
   {
-    private Konto konto = null;
+    private final Konto konto;
     protected List<SynchronizeJob> jobs = new ArrayList<SynchronizeJob>();
     
     /**

--- a/src/de/willuhn/jameica/hbci/synchronize/SynchronizeSession.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/SynchronizeSession.java
@@ -23,7 +23,7 @@ import de.willuhn.util.ProgressMonitor;
  */
 public class SynchronizeSession
 {
-  private Worker worker = null;
+  private final Worker worker;
   private int status = ProgressMonitor.STATUS_NONE;
   private double progressWindow = 100d;
   private List<String> warnings = new ArrayList<String>();

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeBackend.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeBackend.java
@@ -508,7 +508,7 @@ public class HBCISynchronizeBackend extends AbstractSynchronizeBackend<HBCISynch
      */
     private class TaskHandleInit extends AbstractTaskWrapper<PassportHandle>
     {
-      private Passport passport = null;
+      private final Passport passport;
 
       /**
        * ct.
@@ -546,7 +546,7 @@ public class HBCISynchronizeBackend extends AbstractSynchronizeBackend<HBCISynch
      */
     private class TaskHandleOpen extends AbstractTaskWrapper<HBCIHandler>
     {
-      private PassportHandle handle = null;
+      private final PassportHandle handle;
 
       /**
        * ct.

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCITraceMessage.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCITraceMessage.java
@@ -48,8 +48,8 @@ public class HBCITraceMessage implements Message
     CLOSE,
   }
   
-  private Type type = null;
-  private String data = null;
+  private final Type type;
+  private final String data;
   
   /**
    * ct.

--- a/src/de/willuhn/jameica/hbci/util/SaldoFinder.java
+++ b/src/de/willuhn/jameica/hbci/util/SaldoFinder.java
@@ -27,7 +27,7 @@ import de.willuhn.jameica.util.DateUtil;
 public class SaldoFinder
 {
   private TreeMap<Date,Double> map = new TreeMap<Date,Double>();
-  private double anfangssaldo = 0.0d;
+  private final double anfangssaldo;
   
   /**
    * ct.


### PR DESCRIPTION
Wenn die Klassenvariable direkt im Konstruktor gesetzt wird, muss sie nicht mit einem Initialwert belegt werden, da dieser sowieso direkt überschrieben wird. Das Gleiche gilt, wenn eine Variable direkt nach ihrer Deklaration gesetzt wird (z.B. durch zwei IF-Möglichkeiten oder eine FOR-Schleife). Auch hier ist eine zuvorige Wertebelegung überflüssig, da sie direkt überschrieben wird.

Zusätzlich wird `final` ergänzt, wenn es nur eine einzige Setzung des Wertes einer Klassenvariable gibt, da sich der Wert ja nicht mehr ändert.