### PR TITLE
Refactoring im Exportdialog

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -274,14 +274,14 @@ public class ExportDialog extends AbstractDialog implements Extendable
     return this.openFile;
   }
 
-	/**
-	 * Liefert eine Liste der verfuegbaren Exporter.
+  /**
+   * Liefert eine Liste der verfuegbaren Exporter.
    * @return Liste der Exporter.
    */
   public Input getExporterList()
-	{
-		if (this.exporterListe != null)
-			return this.exporterListe;
+  {
+    if (this.exporterListe != null)
+      return this.exporterListe;
 
     Exporter[] exporters = IORegistry.getExporters();
 
@@ -310,18 +310,18 @@ public class ExportDialog extends AbstractDialog implements Extendable
       }
     }
 
-		if (supportedExportFormats.isEmpty())
-		{
-		  this.exporterListe = new LabelInput(i18n.tr("Keine Export-Filter verfügbar"));
-		}
-		else
-		{
-		  Collections.sort(supportedExportFormats);
-		  this.exporterListe = new SelectInput(supportedExportFormats, selected);
-		}
-		this.exporterListe.setName(i18n.tr("Verfügbare Formate"));
-		return this.exporterListe;
-	}
+    if (supportedExportFormats.isEmpty())
+    {
+      this.exporterListe = new LabelInput(i18n.tr("Keine Export-Filter verfügbar"));
+    }
+    else
+    {
+      Collections.sort(supportedExportFormats);
+      this.exporterListe = new SelectInput(supportedExportFormats, selected);
+    }
+    this.exporterListe.setName(i18n.tr("Verfügbare Formate"));
+    return this.exporterListe;
+  }
 
   @Override
   protected Object getData() throws Exception
@@ -353,19 +353,19 @@ public class ExportDialog extends AbstractDialog implements Extendable
     return this.type;
   }
 
-	/**
-	 * Hilfsklasse zur Anzeige der Exporter.
+  /**
+   * Hilfsklasse zur Anzeige der Exporter.
    */
   public static class ExportFormat implements GenericObject, Comparable<ExportFormat>
-	{
-		private final Exporter exporter;
-		private final IOFormat format;
+  {
+    private final Exporter exporter;
+    private final IOFormat format;
 
-		private ExportFormat(Exporter exporter, IOFormat format)
-		{
-			this.exporter = exporter;
+    private ExportFormat(Exporter exporter, IOFormat format)
+    {
+      this.exporter = exporter;
       this.format = format;
-		}
+    }
 
     @Override
     public Object getAttribute(String arg0) throws RemoteException
@@ -394,9 +394,9 @@ public class ExportDialog extends AbstractDialog implements Extendable
     @Override
     public boolean equals(GenericObject arg0) throws RemoteException
     {
-    	if (arg0 == null)
-	      return false;
-	    return this.getID().equals(arg0.getID());
+      if (arg0 == null)
+        return false;
+      return this.getID().equals(arg0.getID());
     }
 
     /**

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -285,7 +285,6 @@ public class ExportDialog extends AbstractDialog implements Extendable
 
     Exporter[] exporters = IORegistry.getExporters();
 
-    int size             = 0;
     ArrayList<ExportFormat> supportedExportFormats = new ArrayList<>();
     String lastFormat    = SETTINGS.getString("lastformat",null);
     ExportFormat selected = null;
@@ -303,7 +302,6 @@ public class ExportDialog extends AbstractDialog implements Extendable
       }
       for (IOFormat format : formats)
       {
-        size++;
         ExportFormat e = new ExportFormat(exp, format);
         supportedExportFormats.add(e);
 
@@ -312,7 +310,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
       }
     }
 
-		if (size == 0)
+		if (supportedExportFormats.isEmpty())
 		{
 		  this.exporterListe = new LabelInput(i18n.tr("Keine Export-Filter verfügbar"));
 		}

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 
 import de.willuhn.datasource.GenericObject;
-import de.willuhn.datasource.pseudo.PseudoIterator;
 import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
@@ -321,9 +320,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
 		}
 		else
 		{
-	    Collections.sort(l);
-	    ExportFormat[] exp = l.toArray(new ExportFormat[0]);
-	    this.exporterListe = new SelectInput(PseudoIterator.fromArray(exp),selected);
+		  Collections.sort(l);
+		  this.exporterListe = new SelectInput(l, selected);
 		}
 		this.exporterListe.setName(i18n.tr("Verfügbare Formate"));
 		return this.exporterListe;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -362,7 +362,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
 	/**
 	 * Hilfsklasse zur Anzeige der Exporter.
    */
-  public static class ExportFormat implements GenericObject, Comparable
+  public static class ExportFormat implements GenericObject, Comparable<ExportFormat>
 	{
 		private final Exporter exporter;
 		private final IOFormat format;
@@ -415,13 +415,14 @@ public class ExportDialog extends AbstractDialog implements Extendable
     }
 
     @Override
-    public int compareTo(Object o)
+    public int compareTo(ExportFormat other)
     {
-      if (o == null || !(o instanceof ExpotFormat))
+      if (other == null)
         return -1;
+
       try
       {
-        return this.format.getName().compareTo(((ExpotFormat)o).format.getName());
+        return this.format.getName().compareTo(other.format.getName());
       }
       catch (Exception e)
       {
@@ -429,5 +430,5 @@ public class ExportDialog extends AbstractDialog implements Extendable
       }
       return 0;
     }
-	}
+  }
 }

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
 
 import de.willuhn.datasource.GenericObject;
-import de.willuhn.jameica.gui.Action;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.dialogs.AbstractDialog;
 import de.willuhn.jameica.gui.extension.Extendable;
@@ -111,24 +110,10 @@ public class ExportDialog extends AbstractDialog implements Extendable
     ExtensionRegistry.extend(this);
 
 		ButtonArea buttons = new ButtonArea();
-		Button button = new Button(i18n.tr("Export starten"),new Action()
-		{
-			@Override
-                        public void handleAction(Object context) throws ApplicationException
-			{
-				export();
-			}
-		},null,true,"ok.png");
+		Button button = new Button(i18n.tr("Export starten"), x -> export(), null, true, "ok.png");
     button.setEnabled(exportEnabled);
     buttons.addButton(button);
-		buttons.addButton(i18n.tr("Abbrechen"), new Action()
-		{
-			@Override
-                        public void handleAction(Object context) throws ApplicationException
-			{
-				close();
-			}
-		},null,false,"process-stop.png");
+		buttons.addButton(i18n.tr("Abbrechen"), x -> close(), null, false, "process-stop.png");
 		this.group.addButtonArea(buttons);
 
     getShell().setMinimumSize(getShell().computeSize(WINDOW_WIDTH,SWT.DEFAULT));

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -110,9 +110,9 @@ public class ExportDialog extends AbstractDialog implements Extendable
     ExtensionRegistry.extend(this);
 
 		ButtonArea buttons = new ButtonArea();
-		Button button = new Button(i18n.tr("Export starten"), x -> export(), null, true, "ok.png");
-    button.setEnabled(exportEnabled);
-    buttons.addButton(button);
+		Button expBtn = new Button(i18n.tr("Export starten"), x -> export(), null, true, "ok.png");
+    expBtn.setEnabled(exportEnabled);
+    buttons.addButton(expBtn);
 		buttons.addButton(i18n.tr("Abbrechen"), x -> close(), null, false, "process-stop.png");
 		this.group.addButtonArea(buttons);
 

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -277,9 +277,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
 	/**
 	 * Liefert eine Liste der verfuegbaren Exporter.
    * @return Liste der Exporter.
-	 * @throws Exception
    */
-  public Input getExporterList() throws Exception
+  public Input getExporterList()
 	{
 		if (this.exporterListe != null)
 			return this.exporterListe;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -94,8 +94,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
   @Override
   protected void paint(Composite parent) throws Exception
   {
-		this.group = new SimpleContainer(parent);
-		this.group.addText(i18n.tr("Bitte wählen Sie das gewünschte Dateiformat aus für den Export aus"),true);
+    this.group = new SimpleContainer(parent);
+    this.group.addText(i18n.tr("Bitte wählen Sie das gewünschte Dateiformat aus für den Export aus"),true);
 
     Input formats = getExporterList();
     this.group.addInput(formats);
@@ -109,12 +109,12 @@ public class ExportDialog extends AbstractDialog implements Extendable
     // BUGZILLA 789
     ExtensionRegistry.extend(this);
 
-		ButtonArea buttons = new ButtonArea();
-		Button expBtn = new Button(i18n.tr("Export starten"), x -> export(), null, true, "ok.png");
+    ButtonArea buttons = new ButtonArea();
+    Button expBtn = new Button(i18n.tr("Export starten"), x -> export(), null, true, "ok.png");
     expBtn.setEnabled(exportEnabled);
     buttons.addButton(expBtn);
-		buttons.addButton(i18n.tr("Abbrechen"), x -> close(), null, false, "process-stop.png");
-		this.group.addButtonArea(buttons);
+    buttons.addButton(i18n.tr("Abbrechen"), x -> close(), null, false, "process-stop.png");
+    this.group.addButtonArea(buttons);
 
     getShell().setMinimumSize(getShell().computeSize(WINDOW_WIDTH,SWT.DEFAULT));
   }

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -308,8 +308,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
         ExportFormat e = new ExportFormat(exp, format);
         l.add(e);
 
-        String lf = e.format.getName();
-        if (lastFormat != null && lf != null && lf.equals(lastFormat))
+        if (lastFormat != null && lastFormat.equals(e.format.getName()))
           selected = e;
       }
     }

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -286,7 +286,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
     Exporter[] exporters = IORegistry.getExporters();
 
     int size             = 0;
-    ArrayList<ExportFormat> l = new ArrayList<>();
+    ArrayList<ExportFormat> supportedExportFormats = new ArrayList<>();
     String lastFormat    = SETTINGS.getString("lastformat",null);
     ExportFormat selected = null;
 
@@ -305,7 +305,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
       {
         size++;
         ExportFormat e = new ExportFormat(exp, format);
-        l.add(e);
+        supportedExportFormats.add(e);
 
         if (lastFormat != null && lastFormat.equals(e.format.getName()))
           selected = e;
@@ -318,8 +318,8 @@ public class ExportDialog extends AbstractDialog implements Extendable
 		}
 		else
 		{
-		  Collections.sort(l);
-		  this.exporterListe = new SelectInput(l, selected);
+		  Collections.sort(supportedExportFormats);
+		  this.exporterListe = new SelectInput(supportedExportFormats, selected);
 		}
 		this.exporterListe.setName(i18n.tr("Verfügbare Formate"));
 		return this.exporterListe;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -141,11 +141,11 @@ public class ExportDialog extends AbstractDialog implements Extendable
    */
   private void export() throws ApplicationException
   {
-    ExpotFormat exp;
+    ExportFormat exp;
 
     try
     {
-      exp = (ExpotFormat) getExporterList().getValue();
+      exp = (ExportFormat) getExporterList().getValue();
     }
     catch (Exception e)
     {
@@ -288,9 +288,9 @@ public class ExportDialog extends AbstractDialog implements Extendable
     Exporter[] exporters = IORegistry.getExporters();
 
     int size             = 0;
-    ArrayList<ExpotFormat> l = new ArrayList<>();
+    ArrayList<ExportFormat> l = new ArrayList<>();
     String lastFormat    = SETTINGS.getString("lastformat",null);
-    ExpotFormat selected = null;
+    ExportFormat selected = null;
 
     for (Exporter exp : exporters)
     {
@@ -306,7 +306,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
       for (IOFormat format : formats)
       {
         size++;
-        ExpotFormat e = new ExpotFormat(exp, format);
+        ExportFormat e = new ExportFormat(exp, format);
         l.add(e);
 
         String lf = e.format.getName();
@@ -322,7 +322,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
 		else
 		{
 	    Collections.sort(l);
-	    ExpotFormat[] exp = (ExpotFormat[]) l.toArray(new ExpotFormat[size]);
+	    ExportFormat[] exp = l.toArray(new ExportFormat[0]);
 	    this.exporterListe = new SelectInput(PseudoIterator.fromArray(exp),selected);
 		}
 		this.exporterListe.setName(i18n.tr("Verfügbare Formate"));
@@ -362,12 +362,12 @@ public class ExportDialog extends AbstractDialog implements Extendable
 	/**
 	 * Hilfsklasse zur Anzeige der Exporter.
    */
-  public class ExpotFormat implements GenericObject, Comparable
+  public static class ExportFormat implements GenericObject, Comparable
 	{
 		private final Exporter exporter;
 		private final IOFormat format;
 
-		private ExpotFormat(Exporter exporter, IOFormat format)
+		private ExportFormat(Exporter exporter, IOFormat format)
 		{
 			this.exporter = exporter;
       this.format = format;

--- a/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
+++ b/src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java
@@ -299,7 +299,7 @@ public class ExportDialog extends AbstractDialog implements Extendable
       IOFormat[] formats = exp.getIOFormats(type);
       if (formats == null || formats.length == 0)
       {
-        Logger.debug("exporter " + exp.getName() + " provides no export formats for " + type + " skipping");
+        Logger.debug("Exporter " + exp.getName() + " provides no export formats for " + type + ". Skipping");
         continue;
       }
       for (IOFormat format : formats)

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
@@ -81,7 +81,7 @@ public class ExportAddSumRowExtension implements Extension
         @Override
         public void handleEvent(Event event)
         {
-          ExportDialog.ExpotFormat exp = (ExportDialog.ExpotFormat) format.getValue();
+          ExportDialog.ExportFormat exp = (ExportDialog.ExportFormat) format.getValue();
           if (exp == null)
             return;
 

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportAddSumRowExtension.java
@@ -38,29 +38,28 @@ public class ExportAddSumRowExtension implements Extension
    * Der Context-Schluessel fuer die Option zum Ausblenden des Saldo im Export.
    */
   public final static String KEY_SUMROW_ADD = "sumrow.add";
-  
+
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  
-  /**
-   * @see de.willuhn.jameica.gui.extension.Extension#extend(de.willuhn.jameica.gui.extension.Extendable)
-   */
+
+  @Override
   public void extend(Extendable extendable)
   {
     if (!(extendable instanceof ExportDialog))
       return;
-    
+
     ExportDialog e = (ExportDialog) extendable;
-    
+
     Class type = e.getType();
     if (!type.isAssignableFrom(Umsatz.class) && !type.isAssignableFrom(UmsatzTree.class))
       return;
 
     boolean initial = ExportDialog.SETTINGS.getBoolean(KEY_SUMROW_ADD,false);
     Exporter.SESSION.put(KEY_SUMROW_ADD,initial);
-    
+
     final CheckboxInput check = new CheckboxInput(initial);
     check.setName(i18n.tr("Summe-Zeile am Ende der Datei anfügen"));
     check.addListener(new Listener() {
+      @Override
       public void handleEvent(Event event)
       {
         Boolean value = (Boolean) check.getValue();
@@ -68,7 +67,7 @@ public class ExportAddSumRowExtension implements Extension
         ExportDialog.SETTINGS.setAttribute(KEY_SUMROW_ADD,value.booleanValue());
       }
     });
-    
+
     final Container c = e.getContainer();
     c.addInput(check);
 
@@ -79,21 +78,20 @@ public class ExportAddSumRowExtension implements Extension
     {
       final Input format = e.getExporterList();
       Listener l = new Listener() {
-        
         @Override
         public void handleEvent(Event event)
         {
           ExportDialog.ExpotFormat exp = (ExportDialog.ExpotFormat) format.getValue();
           if (exp == null)
             return;
-          
+
           Exporter exporter = exp.getExporter();
           check.setEnabled(exporter.suppportsExtension(KEY_SUMROW_ADD));
         }
       };
-      
+
       format.getControl().addListener(SWT.Selection,l);
-      
+
       // Einmal initial ausloesen
       l.handleEvent(null);
     }
@@ -103,5 +101,3 @@ public class ExportAddSumRowExtension implements Extension
     }
   }
 }
-
-

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportSaldoExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportSaldoExtension.java
@@ -37,30 +37,29 @@ public class ExportSaldoExtension implements Extension
    * Der Context-Schluessel fuer die Option zum Ausblenden des Saldo im Export.
    */
   public final static String KEY_SALDO_SHOW = "saldo.show";
-  
+
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
-  
-  /**
-   * @see de.willuhn.jameica.gui.extension.Extension#extend(de.willuhn.jameica.gui.extension.Extendable)
-   */
+
+  @Override
   public void extend(Extendable extendable)
   {
     if (!(extendable instanceof ExportDialog))
       return;
-    
+
     ExportDialog e = (ExportDialog) extendable;
-    
+
     Class type = e.getType();
     if (!type.isAssignableFrom(Umsatz.class))
       return;
-    
+
     // Erstmal per Default einblenden
     boolean initial = ExportDialog.SETTINGS.getBoolean(KEY_SALDO_SHOW,true);
     Exporter.SESSION.put(KEY_SALDO_SHOW,initial);
-    
+
     final CheckboxInput check = new CheckboxInput(initial);
     check.setName(i18n.tr("Spalte \"Saldo\" in der Datei anzeigen"));
     check.addListener(new Listener() {
+      @Override
       public void handleEvent(Event event)
       {
         Boolean value = (Boolean) check.getValue();
@@ -68,10 +67,10 @@ public class ExportSaldoExtension implements Extension
         ExportDialog.SETTINGS.setAttribute(KEY_SALDO_SHOW,value.booleanValue());
       }
     });
-    
+
     final Container c = e.getContainer();
     c.addInput(check);
-    
+
     // Jetzt noch ein Listener an die Auswahl-Box mit dem Format.
     // Wenn das aktuell ausgewaehlte Format diese Extension nicht unterstuetzt,
     // dann deaktivieren wir uns selbst
@@ -79,21 +78,20 @@ public class ExportSaldoExtension implements Extension
     {
       final Input format = e.getExporterList();
       Listener l = new Listener() {
-        
         @Override
         public void handleEvent(Event event)
         {
           ExportDialog.ExpotFormat exp = (ExportDialog.ExpotFormat) format.getValue();
           if (exp == null)
             return;
-          
+
           Exporter exporter = exp.getExporter();
           check.setEnabled(exporter.suppportsExtension(KEY_SALDO_SHOW));
         }
       };
-      
+
       format.getControl().addListener(SWT.Selection,l);
-      
+
       // Einmal initial ausloesen
       l.handleEvent(null);
     }
@@ -103,5 +101,3 @@ public class ExportSaldoExtension implements Extension
     }
   }
 }
-
-

--- a/src/de/willuhn/jameica/hbci/gui/ext/ExportSaldoExtension.java
+++ b/src/de/willuhn/jameica/hbci/gui/ext/ExportSaldoExtension.java
@@ -81,7 +81,7 @@ public class ExportSaldoExtension implements Extension
         @Override
         public void handleEvent(Event event)
         {
-          ExportDialog.ExpotFormat exp = (ExportDialog.ExpotFormat) format.getValue();
+          ExportDialog.ExportFormat exp = (ExportDialog.ExportFormat) format.getValue();
           if (exp == null)
             return;
 

--- a/src/de/willuhn/jameica/hbci/io/Exporter.java
+++ b/src/de/willuhn/jameica/hbci/io/Exporter.java
@@ -30,7 +30,7 @@ public interface Exporter extends IO
    * Eine Session fuer zusaetzliche Parameter.
    */
   public final static Session SESSION = new Session();
-  
+
   /**
    * Exportiert die genannten Objekte in den angegebenen OutputStream.
    * @param objects die zu exportierenden Objekte.
@@ -43,7 +43,7 @@ public interface Exporter extends IO
    * @throws ApplicationException 
    */
   public void doExport(Object[] objects, IOFormat format, OutputStream os, ProgressMonitor monitor) throws RemoteException, ApplicationException;
-  
+
   /**
    * Liefert true, wenn der Exporter die angegebene Extension unterstuetzt.
    * Hintergrund: Im Export-Dialog koennen verschiedene Optionen (wie etwa "Spalte Saldo ausblenden") angezeigt

--- a/src/de/willuhn/jameica/hbci/io/Exporter.java
+++ b/src/de/willuhn/jameica/hbci/io/Exporter.java
@@ -19,10 +19,13 @@ import de.willuhn.util.Session;
 
 /**
  * Basis-Interface aller Exporter.
+ * <p>
  * Alle Klassen, die dieses Interface implementieren, werden automatisch
  * von Hibiscus erkannt und dem Benutzer als Export-Moeglichkeit angeboten
  * insofern sie einen parameterlosen Konstruktor mit dem Modifier "public"
  * besitzen (Java-Bean-Konvention).
+ *
+ * @see de.willuhn.jameica.hbci.io.IORegistry
  */
 public interface Exporter extends IO
 {
@@ -33,12 +36,14 @@ public interface Exporter extends IO
 
   /**
    * Exportiert die genannten Objekte in den angegebenen OutputStream.
+   *
    * @param objects die zu exportierenden Objekte.
    * @param format das vom User ausgewaehlte Export-Format.
    * @param os der Ziel-Ausgabe-Stream.
    * Der Exporter muss den OutputStream selbst schliessen!
    * @param monitor ein Monitor, an den der Exporter Ausgaben ueber seinen
    * Bearbeitungszustand ausgeben kann.
+   *
    * @throws RemoteException
    * @throws ApplicationException 
    */
@@ -46,10 +51,12 @@ public interface Exporter extends IO
 
   /**
    * Liefert true, wenn der Exporter die angegebene Extension unterstuetzt.
+   * <p>
    * Hintergrund: Im Export-Dialog koennen verschiedene Optionen (wie etwa "Spalte Saldo ausblenden") angezeigt
    * werden. Manche Export-Formate unterstuetzen diese Option jedoch gar nicht, sodass sie ignoriert werden wuerde.
    * Aus dem Grund kann der Exporter selbst mitteilen, ob er die angegebene Option unterstuetzt.
    * Unterstuetzt er sie nicht, wir die Option automatisch deaktiviert.
+   *
    * @param ext der Name der Extension.
    * @return true, wenn er die Extension unterstuetzt.
    */

--- a/src/de/willuhn/jameica/hbci/io/Importer.java
+++ b/src/de/willuhn/jameica/hbci/io/Importer.java
@@ -19,12 +19,20 @@ import de.willuhn.util.ProgressMonitor;
 
 /**
  * Basis-Interface aller Importer.
+ * <p>
+ * Alle Klassen, die dieses Interface implementieren, werden automatisch
+ * von Hibiscus erkannt und dem Benutzer als Import-Möglichkeit angeboten,
+ * wenn sie einen parameterlosen Konstruktor mit dem Modifier "public"
+ * besitzen (Java-Bean-Konvention).
+ *
+ * @see de.willuhn.jameica.hbci.io.IORegistry
  */
 public interface Importer extends IO
 {
 
   /**
    * Importiert Daten aus dem InputStream.
+   *
    * @param context Context, der dem Importer hilft, den Zusammenhang zu erkennen,
    * in dem er aufgerufen wurde. Das kann zum Beispiel ein Konto sein.
    * @param format das vom User ausgewaehlte Import-Format.
@@ -33,6 +41,7 @@ public interface Importer extends IO
    * Bearbeitungszustand ausgeben kann.
    * Der Importer muss den Import-Stream selbst schliessen!
    * @param t der {@link BackgroundTask}
+   *
    * @throws RemoteException
    * @throws ApplicationException 
    */


### PR DESCRIPTION
Im Zuge meiner Recherche zur Anpassung für die neuen Anpassungen der SEPA-PAIN habe ich mit `src/de/willuhn/jameica/hbci/gui/dialogs/ExportDialog.java` als Beginn eines Exports aus Sicht des Users begonnen. Hierbei fiel mir der fehlende Buchstabe im Name der Klasse `ExpotFormat` auf. Im Sinne der [Boyscout-Rule](https://www.oreilly.com/library/view/97-things-every/9780596809515/ch08.html) habe ich deswegen ein bisschen aufgeräumt, den Boden gewischt und die Fenster geputzt 😅  