### PR TITLE
direktes Sortieren mit Java8 (Teil von #88)

### DIFF
--- a/src/de/willuhn/jameica/hbci/io/AbstractPDFUmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractPDFUmsatzExporter.java
@@ -84,12 +84,7 @@ public abstract class AbstractPDFUmsatzExporter<T extends GenericObject> impleme
       T group = this.getGroup(u);
       String key = group != null ? group.getID() : null;
       groupMap.put(key,group);
-      List<Umsatz> list = umsaetze.get(key);
-      if (list == null)
-      {
-        list = new ArrayList<Umsatz>();
-        umsaetze.put(key,list);
-      }
+      List<Umsatz> list = umsaetze.computeIfAbsent(key, k -> new ArrayList<Umsatz>());
       list.add(u);
     }
 

--- a/src/de/willuhn/jameica/hbci/io/print/PrintSupportUmsatzList.java
+++ b/src/de/willuhn/jameica/hbci/io/print/PrintSupportUmsatzList.java
@@ -103,12 +103,7 @@ public class PrintSupportUmsatzList extends AbstractPrintSupport
         }
 
         Konto k = u.getKonto();
-        List<Umsatz> list = groups.get(k.getID());
-        if (list == null)
-        {
-          list = new LinkedList<Umsatz>();
-          groups.put(k.getID(),list);
-        }
+        List<Umsatz> list = groups.computeIfAbsent(k.getID(), k1 -> new LinkedList<Umsatz>());
         list.add(u);
       }
       


### PR DESCRIPTION
Seit Java 8 gibt es die Methode `map.computeIfAbsent()`, um den Code
schlanker und weniger fehleranfällig zu gestalten.