### PR TITLE
C-Style Array Declaration (Teil von #88)

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/action/TerminableMarkExecuted.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/TerminableMarkExecuted.java
@@ -40,7 +40,7 @@ public class TerminableMarkExecuted implements Action
     if (context == null)
       return;
 
-    Terminable t[] = null;
+    Terminable[] t = null;
     if (context instanceof Terminable)
       t = new Terminable[]{(Terminable) context};
     else


### PR DESCRIPTION
In Java gehören die eckigen Klammern an den Typ und nicht nach dem Variablenname.