### PR TITLE
toArray mit 0 besser (Teil von #88)

### DIFF
--- a/src/de/willuhn/jameica/hbci/TextSchluessel.java
+++ b/src/de/willuhn/jameica/hbci/TextSchluessel.java
@@ -120,7 +120,7 @@ public class TextSchluessel
   public static TextSchluessel[] get(String[] codes)
   {
     if (codes == null || codes.length == 0)
-      return list.toArray(new TextSchluessel[list.size()]);
+      return list.toArray(new TextSchluessel[0]);
 
     List<TextSchluessel> l = new ArrayList<TextSchluessel>();
     for (int i=0;i<codes.length;++i)
@@ -136,8 +136,8 @@ public class TextSchluessel
         }
       }
     }
-    
-    return l.toArray(new TextSchluessel[l.size()]);
+
+    return l.toArray(new TextSchluessel[0]);
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/action/SparQuoteExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SparQuoteExport.java
@@ -65,7 +65,7 @@ public class SparQuoteExport implements Action
 			else if (context instanceof List)
 			{
 			  List l = (List) context;
-			  u = l.toArray(new UmsatzEntry[l.size()]);
+			  u = l.toArray(new UmsatzEntry[0]);
 			}
 
 			if (u == null || u.length == 0)

--- a/src/de/willuhn/jameica/hbci/gui/action/UmsatzExport.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/UmsatzExport.java
@@ -58,7 +58,7 @@ public class UmsatzExport implements Action
         UmsatzTreeNode node = (UmsatzTreeNode) context;
         List<Umsatz> result = new ArrayList<Umsatz>();
         collect(node,result);
-        u = result.toArray(new Umsatz[result.size()]);
+        u = result.toArray(new Umsatz[0]);
       }
       else if (context instanceof UmsatzTreeNode[])
       {
@@ -67,7 +67,7 @@ public class UmsatzExport implements Action
         {
           collect(node,result);
         }
-        u = result.toArray(new Umsatz[result.size()]);
+        u = result.toArray(new Umsatz[0]);
       }
 
 		   if (u == null || u.length == 0)

--- a/src/de/willuhn/jameica/hbci/gui/chart/BarChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/BarChart.java
@@ -153,7 +153,7 @@ public class BarChart extends AbstractChart
         continue; // wir haben gar keine Werte
 
       IAxis axis = getChart().getAxisSet().getXAxis(0);
-      axis.setCategorySeries(labelLine.toArray(new String[labelLine.size()]));
+      axis.setCategorySeries(labelLine.toArray(new String[0]));
       axis.enableCategory(true);
 
       IBarSeries barSeries = (IBarSeries) getChart().getSeriesSet().createSeries(SeriesType.BAR,Integer.toString(i));

--- a/src/de/willuhn/jameica/hbci/gui/chart/LineChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/LineChart.java
@@ -102,7 +102,7 @@ public class LineChart extends AbstractChart<LineChartData>
         id += " " + cd.getLabel();
       
       ILineSeries lineSeries = (ILineSeries) getChart().getSeriesSet().createSeries(SeriesType.LINE,id);
-      lineSeries.setXDateSeries(labelLine.toArray(new Date[labelLine.size()]));
+      lineSeries.setXDateSeries(labelLine.toArray(new Date[0]));
       lineSeries.setYSeries(toArray(dataLine));
       
       

--- a/src/de/willuhn/jameica/hbci/gui/chart/VergleichBarChart.java
+++ b/src/de/willuhn/jameica/hbci/gui/chart/VergleichBarChart.java
@@ -201,7 +201,7 @@ public class VergleichBarChart extends AbstractChart
     {
       result.add(this.getLabel(n));
     }
-    return result.toArray(new String[result.size()]);
+    return result.toArray(new String[0]);
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/ErweiterteVerwendungszwecke.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/ErweiterteVerwendungszwecke.java
@@ -169,7 +169,7 @@ public class ErweiterteVerwendungszwecke implements Part
     // Wir sichern die neuen Zeilen als "orig", damit sie wieder
     // da sind, wenn der Dialog ohne geaenderte Daten nochmal
     // geoeffnet wird.
-    this.orig = list.toArray(new String[list.size()]);
+    this.orig = list.toArray(new String[0]);
     return this.orig;
   }
 }

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -770,7 +770,7 @@ public class KontoauszugList extends UmsatzList
       Exporter.SESSION.put("pdf.start",getStart().getValue());
       Exporter.SESSION.put("pdf.end",getEnd().getValue());
 
-      Umsatz[] u = (Umsatz[]) list.toArray(new Umsatz[list.size()]);
+      Umsatz[] u = (Umsatz[]) list.toArray(new Umsatz[0]);
       new UmsatzExport().handleAction(u);
     }
     catch (ApplicationException ae)

--- a/src/de/willuhn/jameica/hbci/gui/parts/PassportPropertyList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PassportPropertyList.java
@@ -108,7 +108,7 @@ public class PassportPropertyList implements Part
     if (props == null)
       return l;
 
-    String[] keys = props.keySet().toArray(new String[props.size()]);
+    String[] keys = props.keySet().toArray(new String[0]);
     // Alphabetisch sortieren
     Arrays.sort(keys);
 

--- a/src/de/willuhn/jameica/hbci/gui/parts/PassportTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/PassportTree.java
@@ -193,7 +193,7 @@ public class PassportTree extends TreePart
       {
         list.add(new PassportObject(p));
       }
-      return PseudoIterator.fromArray(list.toArray(new PassportObject[list.size()]));
+      return PseudoIterator.fromArray(list.toArray(new PassportObject[0]));
     }
     catch (RemoteException re)
     {
@@ -279,7 +279,7 @@ public class PassportTree extends TreePart
       {
         list.add(new ConfigObject(this.passport, c));
       }
-      this.children = PseudoIterator.fromArray(list.toArray(new ConfigObject[list.size()]));
+      this.children = PseudoIterator.fromArray(list.toArray(new ConfigObject[0]));
       return this.children;
     }
 

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTree.java
@@ -224,7 +224,7 @@ public class UmsatzTree extends TreePart
       }
       ////////////////////////////////////////////////////////////////
 
-      super.setList(PseudoIterator.fromArray((GenericObject[])items.toArray(new GenericObject[items.size()])));
+      super.setList(PseudoIterator.fromArray((GenericObject[])items.toArray(new GenericObject[0])));
       this.featureEvent(Feature.Event.REFRESH,null);
     }
     catch (RemoteException re)

--- a/src/de/willuhn/jameica/hbci/gui/views/EinnahmenAusgaben.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/EinnahmenAusgaben.java
@@ -82,7 +82,7 @@ public class EinnahmenAusgaben extends AbstractView
         try
         {
           List data = control.getTree().getItems();
-          new EinnahmeAusgabeExport().handleAction(data.toArray(new EinnahmeAusgabeZeitraum[data.size()]));
+          new EinnahmeAusgabeExport().handleAction(data.toArray(new EinnahmeAusgabeZeitraum[0]));
         }
         catch (RemoteException re)
         {

--- a/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/AbstractSepaImporter.java
@@ -99,8 +99,8 @@ public abstract class AbstractSepaImporter extends AbstractImporter
     List<Properties> props = new ArrayList<Properties>();
     ISEPAParser parser = SEPAParserFactory.get(version);
     parser.parse(new ByteArrayInputStream(bos.toByteArray()),props);
-    
-    return props.toArray(new Properties[props.size()]);
+
+    return props.toArray(new Properties[0]);
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/io/DTAUSUmsatzImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/DTAUSUmsatzImporter.java
@@ -60,8 +60,8 @@ public class DTAUSUmsatzImporter extends AbstractDTAUSImporter
     {
       lines.add(csatz.getVerwendungszweck(i));
     }
-    VerwendungszweckUtil.apply(u,lines.toArray(new String[lines.size()]));
-    
+    VerwendungszweckUtil.apply(u,lines.toArray(new String[0]));
+
     u.store();
   
   }

--- a/src/de/willuhn/jameica/hbci/io/IORegistry.java
+++ b/src/de/willuhn/jameica/hbci/io/IORegistry.java
@@ -84,7 +84,7 @@ public class IORegistry
    */
   public static Exporter[] getExporters()
   {
-    return (Exporter[]) exporters.toArray(new Exporter[exporters.size()]);
+    return (Exporter[]) exporters.toArray(new Exporter[0]);
   }
 
   /**
@@ -93,6 +93,6 @@ public class IORegistry
    */
   public static Importer[] getImporters()
   {
-    return (Importer[]) importers.toArray(new Importer[importers.size()]);
+    return (Importer[]) importers.toArray(new Importer[0]);
   }
 }

--- a/src/de/willuhn/jameica/hbci/io/VelocityExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/VelocityExporter.java
@@ -187,8 +187,8 @@ public class VelocityExporter implements Exporter
       
       l.add(new VelocityFormat(ext,variant,ef));
     }
-    
-    loaded = (IOFormat[]) l.toArray(new IOFormat[l.size()]);
+
+    loaded = (IOFormat[]) l.toArray(new IOFormat[0]);
     this.formats.put(type,loaded);
     return loaded;
     

--- a/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/CsvImporter.java
@@ -328,7 +328,7 @@ public class CsvImporter implements Importer
       Logger.error("no csv formats found");
     }
 
-    return formats.toArray(new IOFormat[formats.size()]);
+    return formats.toArray(new IOFormat[0]);
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/io/ser/ExtendedUsageSerializer.java
+++ b/src/de/willuhn/jameica/hbci/io/ser/ExtendedUsageSerializer.java
@@ -70,7 +70,7 @@ public class ExtendedUsageSerializer extends DefaultSerializer<String[]>
       lines.add(value);
     }
     
-    return lines.toArray(new String[lines.size()]);
+    return lines.toArray(new String[0]);
 
   }
 

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfig.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfig.java
@@ -289,7 +289,7 @@ public class DDVConfig implements Configuration
     if (fixedIds.size() != ids.length)
     {
       Logger.info("fixing list of assigned accounts");
-      settings.setAttribute(getPrefix() + "konto",fixedIds.toArray(new String[fixedIds.size()]));
+      settings.setAttribute(getPrefix() + "konto",fixedIds.toArray(new String[0]));
     }
     return konten;
   }

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
@@ -144,7 +144,7 @@ public class DDVConfigFactory
       newIds.add(config.getId());
     
     // Speichern der aktualisierten Liste
-    settings.setAttribute("config",newIds.toArray(new String[newIds.size()]));
+    settings.setAttribute("config",newIds.toArray(new String[0]));
   }
   
   /**
@@ -173,7 +173,7 @@ public class DDVConfigFactory
     }
     
     // Speichern der aktualisierten Liste
-    settings.setAttribute("config",newIds.toArray(new String[newIds.size()]));
+    settings.setAttribute("config",newIds.toArray(new String[0]));
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/passports/ddv/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/KontoList.java
@@ -74,7 +74,7 @@ public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
         linked.add(k);
       }
     }
-    GenericIterator exclude = PseudoIterator.fromArray((GenericObject[])linked.toArray(new GenericObject[linked.size()]));
+    GenericIterator exclude = PseudoIterator.fromArray((GenericObject[])linked.toArray(new GenericObject[0]));
     /////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////
@@ -102,7 +102,7 @@ public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
     {
       List<Konto> k = myConfig.getKonten();
       if (k != null && k.size() > 0)
-        checked = PseudoIterator.fromArray(k.toArray(new Konto[k.size()]));
+        checked = PseudoIterator.fromArray(k.toArray(new Konto[0]));
     }
 
     for (Konto k:konten)

--- a/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/server/PassportHandleImpl.java
@@ -227,7 +227,7 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 				Logger.debug("found account " + k.getKontonummer());
 				result.add(k);
 			}
-			return (Konto[]) result.toArray(new Konto[result.size()]);
+			return (Konto[]) result.toArray(new Konto[0]);
 		}
 		finally
 		{

--- a/src/de/willuhn/jameica/hbci/passports/pintan/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/Controller.java
@@ -632,7 +632,7 @@ public class Controller extends AbstractControl
       Konto[] konten = null;
       List checked = getKontoAuswahl().getItems();
       if (checked != null && checked.size() > 0)
-        konten = (Konto[]) checked.toArray(new Konto[checked.size()]);
+        konten = (Konto[]) checked.toArray(new Konto[0]);
       config.setKonten(konten);
       
       String version = (String) getHBCIVersion().getValue();

--- a/src/de/willuhn/jameica/hbci/passports/pintan/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/KontoList.java
@@ -78,7 +78,7 @@ public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
         linked.add(konten[i]);
       }
     }
-    GenericIterator exclude = PseudoIterator.fromArray((GenericObject[])linked.toArray(new GenericObject[linked.size()]));
+    GenericIterator exclude = PseudoIterator.fromArray((GenericObject[])linked.toArray(new GenericObject[0]));
     /////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////
@@ -99,7 +99,7 @@ public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
     
     /////////////////////////////////////////////////////////////////
     // Tabelle erzeugen und nur die relevanten markieren
-    GenericIterator all = PseudoIterator.fromArray((Konto[]) konten.toArray(new Konto[konten.size()]));
+    GenericIterator all = PseudoIterator.fromArray((Konto[]) konten.toArray(new Konto[0]));
 
     // Die derzeit markierten
     GenericIterator checked = null;

--- a/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/PinTanConfigFactory.java
@@ -134,8 +134,8 @@ public class PinTanConfigFactory
       }
       
       Logger.debug("new number of configs: " + newList.size());
-      settings.setAttribute("config",(String[]) newList.toArray(new String[newList.size()]));
-      
+      settings.setAttribute("config",(String[]) newList.toArray(new String[0]));
+
       // Jetzt noch die Datei loeschen
       File f = new File(config.getFilename());
       if (f.exists() && f.isFile() && f.canWrite())
@@ -298,7 +298,7 @@ public class PinTanConfigFactory
     }
     
     // Wir haben mehrere zur Auswahl. Lassen wir den User entscheiden.
-    GenericIterator list = PseudoIterator.fromArray((PinTanConfig[]) found.toArray(new PinTanConfig[found.size()]));
+    GenericIterator list = PseudoIterator.fromArray((PinTanConfig[]) found.toArray(new PinTanConfig[0]));
     SelectConfigDialog d = new SelectConfigDialog(SelectConfigDialog.POSITION_CENTER,list);
     d.setText(text);
     try
@@ -346,7 +346,7 @@ public class PinTanConfigFactory
         }
       }
     }
-    return PseudoIterator.fromArray((PinTanConfig[]) configs.toArray(new PinTanConfig[configs.size()]));
+    return PseudoIterator.fromArray((PinTanConfig[]) configs.toArray(new PinTanConfig[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PassportHandleImpl.java
@@ -316,7 +316,7 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 				Logger.debug("found account " + k.getKontonummer());
 				result.add(k);
 			}
-			return (Konto[]) result.toArray(new Konto[result.size()]);
+			return (Konto[]) result.toArray(new Konto[0]);
 		}
 		finally
 		{

--- a/src/de/willuhn/jameica/hbci/passports/pintan/server/PinTanConfigImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/pintan/server/PinTanConfigImpl.java
@@ -365,9 +365,9 @@ public class PinTanConfigImpl implements PinTanConfig
     if (fixedIds.size() != ids.length)
     {
       Logger.info("fixing list of assigned accounts");
-      settings.setAttribute(getID() + ".konto",fixedIds.toArray(new String[fixedIds.size()]));
+      settings.setAttribute(getID() + ".konto",fixedIds.toArray(new String[0]));
     }
-    return konten.toArray(new Konto[konten.size()]);
+    return konten.toArray(new Konto[0]);
   }
 
   /**
@@ -573,7 +573,7 @@ public class PinTanConfigImpl implements PinTanConfig
     list.add(0,name);
 
     // Abspeichern
-    this.setTanMedias(list.toArray(new String[list.size()]));
+    this.setTanMedias(list.toArray(new String[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/passports/rdh/Controller.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/Controller.java
@@ -584,7 +584,7 @@ public class Controller extends AbstractControl {
       Konto[] konten = null;
       List checked = getKontoAuswahl().getItems();
       if (checked != null && checked.size() > 0)
-        konten = (Konto[]) checked.toArray(new Konto[checked.size()]);
+        konten = (Konto[]) checked.toArray(new Konto[0]);
       key.setKonten(konten);
       
       key.setHBCIVersion((String)getHBCIVersion().getValue());

--- a/src/de/willuhn/jameica/hbci/passports/rdh/KontoList.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/KontoList.java
@@ -79,7 +79,7 @@ public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
         linked.add(konten[i]);
       }
     }
-    GenericIterator exclude = PseudoIterator.fromArray((GenericObject[])linked.toArray(new GenericObject[linked.size()]));
+    GenericIterator exclude = PseudoIterator.fromArray((GenericObject[])linked.toArray(new GenericObject[0]));
     /////////////////////////////////////////////////////////////////
 
     /////////////////////////////////////////////////////////////////
@@ -100,7 +100,7 @@ public class KontoList extends de.willuhn.jameica.hbci.gui.parts.KontoList
     
     /////////////////////////////////////////////////////////////////
     // Tabelle erzeugen und nur die relevanten markieren
-    GenericIterator all = PseudoIterator.fromArray((Konto[]) konten.toArray(new Konto[konten.size()]));
+    GenericIterator all = PseudoIterator.fromArray((Konto[]) konten.toArray(new Konto[0]));
 
     // Die derzeit markierten
     GenericIterator checked = null;

--- a/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/RDHKeyFactory.java
@@ -87,7 +87,7 @@ public class RDHKeyFactory
     }
     
     Collections.sort(list);
-    return (KeyFormat[]) list.toArray(new KeyFormat[list.size()]);
+    return (KeyFormat[]) list.toArray(new KeyFormat[0]);
   }
 
 	/**
@@ -300,7 +300,7 @@ public class RDHKeyFactory
 			  continue;
       readable.add(new RDHKeyImpl(new File(found[i])));
 		}
-		return PseudoIterator.fromArray((RDHKey[]) readable.toArray(new RDHKey[readable.size()]));
+		return PseudoIterator.fromArray((RDHKey[]) readable.toArray(new RDHKey[0]));
 	}
 
 	/**
@@ -363,7 +363,7 @@ public class RDHKeyFactory
         newList.add(f.getAbsolutePath());
         
       }
-      settings.setAttribute("key",(String[]) newList.toArray(new String[newList.size()]));
+      settings.setAttribute("key",(String[]) newList.toArray(new String[0]));
     }
     catch (RemoteException re)
     {

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/PassportHandleImpl.java
@@ -250,7 +250,7 @@ public class PassportHandleImpl extends UnicastRemoteObject implements PassportH
 				Logger.debug("found account " + k.getKontonummer());
 				result.add(k);
 			}
-			return (Konto[]) result.toArray(new Konto[result.size()]);
+			return (Konto[]) result.toArray(new Konto[0]);
 		}
 		finally
 		{

--- a/src/de/willuhn/jameica/hbci/passports/rdh/server/RDHKeyImpl.java
+++ b/src/de/willuhn/jameica/hbci/passports/rdh/server/RDHKeyImpl.java
@@ -227,7 +227,7 @@ public class RDHKeyImpl implements RDHKey
         throw re;
       }
     }
-    return (Konto[])konten.toArray(new Konto[konten.size()]);
+    return (Konto[])konten.toArray(new Konto[0]);
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/reminder/ReminderStorageProviderHibiscus.java
+++ b/src/de/willuhn/jameica/hbci/reminder/ReminderStorageProviderHibiscus.java
@@ -128,8 +128,8 @@ public class ReminderStorageProviderHibiscus extends AbstractReminderStorageProv
         {
           list.add(rs.getString(1));
         }
-        
-        return list.toArray(new String[list.size()]);
+
+        return list.toArray(new String[0]);
       }
     });
   }

--- a/src/de/willuhn/jameica/hbci/search/KontoauszugSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/KontoauszugSearchProvider.java
@@ -124,8 +124,8 @@ public class KontoauszugSearchProvider implements SearchProvider
         {
           params.add(HBCI.DATEFORMAT.format(erstellt));
         }
-        
-        String[] s = params.toArray(new String[params.size()]);
+
+        String[] s = params.toArray(new String[0]);
         if (s.length == 4)
           return i18n.tr("Kontoauszug {2}-{3}, abgerufen am {0} ({1})",s);
         

--- a/src/de/willuhn/jameica/hbci/search/SammelLastschriftSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SammelLastschriftSearchProvider.java
@@ -83,7 +83,7 @@ public class SammelLastschriftSearchProvider implements SearchProvider
       hash.put(ueb.getID(),new MyResult(ueb));
     }
 
-    return Arrays.asList(hash.values().toArray(new MyResult[hash.size()]));
+    return Arrays.asList(hash.values().toArray(new MyResult[0]));
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/search/SammelUeberweisungSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SammelUeberweisungSearchProvider.java
@@ -83,7 +83,7 @@ public class SammelUeberweisungSearchProvider implements SearchProvider
       hash.put(ueb.getID(),new MyResult(ueb));
     }
 
-    return Arrays.asList(hash.values().toArray(new MyResult[hash.size()]));
+    return Arrays.asList(hash.values().toArray(new MyResult[0]));
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/search/SepaSammelLastschriftSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SepaSammelLastschriftSearchProvider.java
@@ -84,7 +84,7 @@ public class SepaSammelLastschriftSearchProvider implements SearchProvider
       hash.put(ueb.getID(),new MyResult(ueb));
     }
 
-    return Arrays.asList(hash.values().toArray(new MyResult[hash.size()]));
+    return Arrays.asList(hash.values().toArray(new MyResult[0]));
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/search/SepaSammelUeberweisungSearchProvider.java
+++ b/src/de/willuhn/jameica/hbci/search/SepaSammelUeberweisungSearchProvider.java
@@ -82,7 +82,7 @@ public class SepaSammelUeberweisungSearchProvider implements SearchProvider
       hash.put(ueb.getID(),new MyResult(ueb));
     }
 
-    return Arrays.asList(hash.values().toArray(new MyResult[hash.size()]));
+    return Arrays.asList(hash.values().toArray(new MyResult[0]));
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AbstractSammelTransferImpl.java
@@ -350,7 +350,7 @@ public abstract class AbstractSammelTransferImpl extends AbstractHibiscusDBObjec
     {
       buchungen.add(list.next());
     }
-    return (SammelTransferBuchung[]) buchungen.toArray(new SammelTransferBuchung[buchungen.size()]);
+    return (SammelTransferBuchung[]) buchungen.toArray(new SammelTransferBuchung[0]);
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/AddressbookServiceImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/AddressbookServiceImpl.java
@@ -122,7 +122,7 @@ public class AddressbookServiceImpl extends UnicastRemoteObject implements Addre
             Logger.error("unable to load addressbook " + found[i] + ", skipping");
           }
         }
-        this.books = (Addressbook[]) list.toArray(new Addressbook[list.size()]);
+        this.books = (Addressbook[]) list.toArray(new Addressbook[0]);
       }
       catch (ClassNotFoundException e)
       {

--- a/src/de/willuhn/jameica/hbci/server/Converter.java
+++ b/src/de/willuhn/jameica/hbci/server/Converter.java
@@ -116,7 +116,7 @@ public class Converter
     //    "999" drin, dann sind diese Variablen alle null, und der ungeparste 
     //    Inhalt des Feldes :86: steht komplett in "additional".
 
-    String[] lines = (String[]) u.usage.toArray(new String[u.usage.size()]);
+    String[] lines = (String[]) u.usage.toArray(new String[0]);
 
     if (u.isCamt && u.usage != null)
     {

--- a/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabeTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/EinnahmeAusgabeTreeNode.java
@@ -158,7 +158,7 @@ public class EinnahmeAusgabeTreeNode implements EinnahmeAusgabeZeitraum, Generic
   @Override
   public GenericIterator getChildren() throws RemoteException
   {
-    return PseudoIterator.fromArray((EinnahmeAusgabe[]) children.toArray(new EinnahmeAusgabe[children.size()]));
+    return PseudoIterator.fromArray((EinnahmeAusgabe[]) children.toArray(new EinnahmeAusgabe[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/UmsatzGroup.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzGroup.java
@@ -66,7 +66,7 @@ public class UmsatzGroup implements GenericObjectNode, Comparable
    */
   public GenericIterator getChildren() throws RemoteException
   {
-    return PseudoIterator.fromArray((GenericObject[])umsaetze.toArray(new GenericObject[umsaetze.size()]));
+    return PseudoIterator.fromArray((GenericObject[])umsaetze.toArray(new GenericObject[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTreeNode.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTreeNode.java
@@ -109,7 +109,7 @@ public class UmsatzTreeNode implements GenericObjectNode, Comparable
     Collections.sort(children);
     all.addAll(children);
     all.addAll(this.umsaetze);
-    return PseudoIterator.fromArray((GenericObject[])all.toArray(new GenericObject[all.size()]));
+    return PseudoIterator.fromArray((GenericObject[])all.toArray(new GenericObject[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypBean.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypBean.java
@@ -192,7 +192,7 @@ public class UmsatzTypBean implements GenericObjectNode
   @Override
   public GenericIterator getChildren() throws RemoteException
   {
-    return PseudoIterator.fromArray(this.children.toArray(new UmsatzTypBean[this.children.size()]));
+    return PseudoIterator.fromArray(this.children.toArray(new UmsatzTypBean[0]));
   }
 
   /**
@@ -213,8 +213,8 @@ public class UmsatzTypBean implements GenericObjectNode
       result.add(parent);
       parent = parent.getParent();
     }
-    
-    return PseudoIterator.fromArray(result.toArray(new UmsatzTypBean[result.size()]));
+
+    return PseudoIterator.fromArray(result.toArray(new UmsatzTypBean[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypImpl.java
@@ -170,7 +170,7 @@ public class UmsatzTypImpl extends AbstractDBObjectNode implements UmsatzTyp, Du
       if (u.isAssigned() || matches(u)) // entweder fest zugeordnet oder passt via Suchfilter
         result.add(u);
     }
-    return PseudoIterator.fromArray((Umsatz[]) result.toArray(new Umsatz[result.size()]));
+    return PseudoIterator.fromArray((Umsatz[]) result.toArray(new Umsatz[0]));
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypUtil.java
@@ -138,7 +138,7 @@ public class UmsatzTypUtil
         root.add(t);
       }
     }
-    return PseudoIterator.fromArray(root.toArray(new UmsatzTypBean[root.size()]));
+    return PseudoIterator.fromArray(root.toArray(new UmsatzTypBean[0]));
   }
 
   /**
@@ -574,7 +574,7 @@ public class UmsatzTypUtil
         if (matches(u))
           result.add(u);
       }
-      return PseudoIterator.fromArray((Umsatz[]) result.toArray(new Umsatz[result.size()]));
+      return PseudoIterator.fromArray((Umsatz[]) result.toArray(new Umsatz[0]));
     }
 
     /**

--- a/src/de/willuhn/jameica/hbci/server/VerwendungszweckUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/VerwendungszweckUtil.java
@@ -335,7 +335,7 @@ public class VerwendungszweckUtil
     List<String> l = clean(true,lines);
     if (l.size() > 0) t.setZweck(l.remove(0));  // Zeile 1
     if (l.size() > 0) t.setZweck2(l.remove(0)); // Zeile 2
-    if (l.size() > 0) t.setWeitereVerwendungszwecke(l.toArray(new String[l.size()])); // Zeile 3 - x
+    if (l.size() > 0) t.setWeitereVerwendungszwecke(l.toArray(new String[0])); // Zeile 3 - x
   }
 
   /**
@@ -462,10 +462,10 @@ public class VerwendungszweckUtil
       for (String s:wvz)
         lines.add(s);
     }
-    
-    String[] list = lines.toArray(new String[lines.size()]);
+
+    String[] list = lines.toArray(new String[0]);
     List<String> result = clean(false,list);
-    return result.toArray(new String[result.size()]);
+    return result.toArray(new String[0]);
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIUmsatzJob.java
@@ -374,7 +374,7 @@ public class HBCIUmsatzJob extends AbstractHBCIJob
         // aktuellen Durchlauf nicht mehr uebertragen wurden.
         // Das muessen dann die vom Vortag sein
         Logger.info("clean obsolete notbooked entries");
-        GenericIterator newList = PseudoIterator.fromArray((Umsatz[]) fetched.toArray(new Umsatz[fetched.size()]));
+        GenericIterator newList = PseudoIterator.fromArray((Umsatz[]) fetched.toArray(new Umsatz[0]));
         int deleted = 0;
         existingUnbooked.begin();
         while (existingUnbooked.hasNext())

--- a/src/de/willuhn/jameica/hbci/server/hbci/rewriter/DeutscheBankUmsatzRewriter.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/rewriter/DeutscheBankUmsatzRewriter.java
@@ -103,7 +103,7 @@ public class DeutscheBankUmsatzRewriter implements UmsatzRewriter
           if (list.size() == 0) return; // haben wir noch was uebrig?
 
           // 3. weitere Verwendungszwecke
-          u.setWeitereVerwendungszwecke(list.toArray(new String[list.size()]));
+          u.setWeitereVerwendungszwecke(list.toArray(new String[0]));
         }
       }
     }

--- a/src/de/willuhn/jameica/hbci/server/hbci/rewriter/NetbankUmsatzRewriter.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/rewriter/NetbankUmsatzRewriter.java
@@ -99,7 +99,7 @@ public class NetbankUmsatzRewriter implements UmsatzRewriter
     if (lines.size() == 0) return; // haben wir noch was uebrig?
 
     // 3. weitere Verwendungszwecke
-    u.setWeitereVerwendungszwecke(lines.toArray(new String[lines.size()]));
+    u.setWeitereVerwendungszwecke(lines.toArray(new String[0]));
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszug.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszug.java
@@ -45,7 +45,7 @@ public class HBCISynchronizeJobKontoauszug extends SynchronizeJobKontoauszug imp
     if (o.getSyncSaldo() || (forceSaldo != null && forceSaldo.booleanValue())) jobs.add(new HBCISaldoJob(k));
     if (o.getSyncKontoauszuege() || (forceUmsatz != null && forceUmsatz.booleanValue())) jobs.add(new HBCIUmsatzJob(k));
 
-    return jobs.toArray(new AbstractHBCIJob[jobs.size()]);
+    return jobs.toArray(new AbstractHBCIJob[0]);
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszugPdf.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszugPdf.java
@@ -52,7 +52,7 @@ public class HBCISynchronizeJobKontoauszugPdf extends SynchronizeJobKontoauszugP
     if (o.getSyncKontoauszuegePdf() || (force != null && force.booleanValue()))
       jobs.add(new HBCIKontoauszugJob(k));
 
-    return jobs.toArray(new AbstractHBCIJob[jobs.size()]);
+    return jobs.toArray(new AbstractHBCIJob[0]);
   }
   
   /**


### PR DESCRIPTION
Der Beschreibungstext der Code Inspection lautet:
> In older Java versions, using a pre-sized array was recommended, as the
> reflection call necessary to create an array of proper size was quite slow.
> However, since late updates of *OpenJDK 6*, this call was intrinsified, making
> the performance of the empty array version the same, and sometimes even better,
> compared to the pre-sized version.
> Also, passing a pre-sized array is dangerous for a concurrent or synchronized
> collection as a data race is possible between the size and toArray calls.