### PR TITLE
Collections sortieren mit Java8 (Teil von #88)

### DIFF
--- a/src/de/willuhn/jameica/hbci/HasName.java
+++ b/src/de/willuhn/jameica/hbci/HasName.java
@@ -1,0 +1,24 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ *
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details.
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci;
+
+/**
+ * Interface für alle Objekte, die einen sprechenden Namen ausgeben können sollen.
+ */
+public interface HasName
+{
+  /**
+   * Liefert einen sprechenden Namen für die Objektinstanz.
+   *
+   * @return Name oder leerer String (niemals {@code NULL})
+   */
+  String getName();
+}

--- a/src/de/willuhn/jameica/hbci/accounts/AccountProvider.java
+++ b/src/de/willuhn/jameica/hbci/accounts/AccountProvider.java
@@ -11,18 +11,20 @@
 package de.willuhn.jameica.hbci.accounts;
 
 import de.willuhn.jameica.gui.parts.InfoPanel;
+import de.willuhn.jameica.hbci.HasName;
 import de.willuhn.util.ApplicationException;
 
 /**
  * Interface fuer einen Account-Provider.
  * Wird typischerweise einmal pro SynchronizeBackend implementiert.
  */
-public interface AccountProvider
+public interface AccountProvider extends HasName
 {
   /**
    * Liefert einen sprechenden Namen fuer den Provider.
    * @return sprechender Name fuer den Provider.
    */
+  @Override
   public String getName();
   
   /**

--- a/src/de/willuhn/jameica/hbci/accounts/AccountService.java
+++ b/src/de/willuhn/jameica/hbci/accounts/AccountService.java
@@ -69,7 +69,8 @@ public class AccountService
       }
       
       // Wir sortieren die Provider so, dass der Primaer-Provider immer Vorrang hat
-      Collections.sort(this.providers,new Comparator<AccountProvider>() {
+      this.providers.sort(new Comparator<AccountProvider>()
+      {
         public int compare(AccountProvider o1, AccountProvider o2)
         {
           

--- a/src/de/willuhn/jameica/hbci/accounts/AccountService.java
+++ b/src/de/willuhn/jameica/hbci/accounts/AccountService.java
@@ -10,8 +10,6 @@
 
 package de.willuhn.jameica.hbci.accounts;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -69,19 +67,13 @@ public class AccountService
       }
       
       // Wir sortieren die Provider so, dass der Primaer-Provider immer Vorrang hat
-      this.providers.sort(new Comparator<AccountProvider>()
-      {
-        public int compare(AccountProvider o1, AccountProvider o2)
-        {
-          
-          if (PRIMARY.isInstance(o1))
-            return -1;
-          if (PRIMARY.isInstance(o2))
-            return 1;
-          
-          // Ansonsten alphabetisch nach Name
-          return o1.getName().compareTo(o2.getName());
-        }
+      this.providers.sort((p1, p2) -> {
+        if (PRIMARY.isInstance(p1))
+          return -1;
+        if (PRIMARY.isInstance(p2))
+          return 1;
+        // Ansonsten alphabetisch nach Name
+        return p1.getName().compareTo(p2.getName());
       });
     }
     catch (ClassNotFoundException e)

--- a/src/de/willuhn/jameica/hbci/accounts/AccountService.java
+++ b/src/de/willuhn/jameica/hbci/accounts/AccountService.java
@@ -17,6 +17,7 @@ import de.willuhn.annotation.Lifecycle;
 import de.willuhn.annotation.Lifecycle.Type;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.accounts.hbci.HBCIAccountProvider;
+import de.willuhn.jameica.hbci.util.ProviderComparator;
 import de.willuhn.jameica.services.BeanService;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
@@ -35,7 +36,7 @@ public class AccountService
   /**
    * Der Primaer-Provider. Der steht immer oben.
    */
-  private final static Class<? extends HBCIAccountProvider> PRIMARY = HBCIAccountProvider.class;
+  private final static Class<? extends AccountProvider> PRIMARY = HBCIAccountProvider.class;
 
   /**
    * Liefert eine Liste der gefundenen Provider.
@@ -67,14 +68,7 @@ public class AccountService
       }
       
       // Wir sortieren die Provider so, dass der Primaer-Provider immer Vorrang hat
-      this.providers.sort((p1, p2) -> {
-        if (PRIMARY.isInstance(p1))
-          return -1;
-        if (PRIMARY.isInstance(p2))
-          return 1;
-        // Ansonsten alphabetisch nach Name
-        return p1.getName().compareTo(p2.getName());
-      });
+      this.providers.sort(new ProviderComparator<>(PRIMARY, true));
     }
     catch (ClassNotFoundException e)
     {

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
@@ -19,6 +19,7 @@ import de.willuhn.jameica.gui.parts.InfoPanel;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.accounts.AccountProvider;
 import de.willuhn.jameica.hbci.accounts.hbci.action.HBCIAccountNew;
+import de.willuhn.jameica.hbci.util.ProviderComparator;
 import de.willuhn.jameica.services.BeanService;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
@@ -93,13 +94,8 @@ public class HBCIAccountProvider implements AccountProvider
         }
       }
 
-      this.variants.sort((v1, v2) -> {
-        if (PRIMARY.isInstance(v1))
-          return -1;
-        if (PRIMARY.isInstance(v2))
-          return 1;
-        return v1.getName().compareTo(v2.getName());
-      });
+      // Wir sortieren die Provider so, dass der Primaer-Provider immer Vorrang hat
+      this.variants.sort(new ProviderComparator<>(PRIMARY, true));
     }
     catch (ClassNotFoundException e)
     {

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
@@ -10,8 +10,6 @@
 
 package de.willuhn.jameica.hbci.accounts.hbci;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -95,16 +93,12 @@ public class HBCIAccountProvider implements AccountProvider
         }
       }
 
-      this.variants.sort(new Comparator<HBCIVariant>()
-      {
-        public int compare(HBCIVariant o1, HBCIVariant o2)
-        {
-          if (PRIMARY.isInstance(o1))
-            return -1;
-          if (PRIMARY.isInstance(o2))
-            return 1;
-          return o1.getName().compareTo(o2.getName());
-        }
+      this.variants.sort((v1, v2) -> {
+        if (PRIMARY.isInstance(v1))
+          return -1;
+        if (PRIMARY.isInstance(v2))
+          return 1;
+        return v1.getName().compareTo(v2.getName());
       });
     }
     catch (ClassNotFoundException e)

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIAccountProvider.java
@@ -94,8 +94,9 @@ public class HBCIAccountProvider implements AccountProvider
           Logger.error("unable to load hbci varian " + c.getName() + ", skipping",e);
         }
       }
-      
-      Collections.sort(this.variants,new Comparator<HBCIVariant>() {
+
+      this.variants.sort(new Comparator<HBCIVariant>()
+      {
         public int compare(HBCIVariant o1, HBCIVariant o2)
         {
           if (PRIMARY.isInstance(o1))

--- a/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIVariant.java
+++ b/src/de/willuhn/jameica/hbci/accounts/hbci/HBCIVariant.java
@@ -11,17 +11,19 @@
 package de.willuhn.jameica.hbci.accounts.hbci;
 
 import de.willuhn.jameica.gui.parts.InfoPanel;
+import de.willuhn.jameica.hbci.HasName;
 import de.willuhn.util.ApplicationException;
 
 /**
  * Interface fuer eine HBCI-Zugangsvariante.
  */
-public interface HBCIVariant
+public interface HBCIVariant extends HasName
 {
   /**
    * Liefert einen sprechenden Namen fuer die HBCI-Variante.
    * @return sprechender Name fuer die HBCI-Variante.
    */
+  @Override
   public String getName();
   
   /**

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -19,8 +19,6 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -243,28 +241,23 @@ public class MT940UmsatzExporter implements Exporter
    */
   protected void sort(List<Umsatz> list)
   {
-    list.sort(new Comparator<Umsatz>()
-    {
-      @Override
-      public int compare(Umsatz o1, Umsatz o2)
+    list.sort((u1, u2) -> {
+      try
       {
-        try
-        {
-          Date d1 = (Date) o1.getAttribute("datum_pseudo");
-          Date d2 = (Date) o2.getAttribute("datum_pseudo");
-          if (d1 == d2)
-            return 0;
-          if (d1 == null)
-            return -1;
-          if (d2 == null)
-            return 1;
-          return d1.compareTo(d2);
-        }
-        catch (RemoteException re)
-        {
-          Logger.error("unable to sort data",re);
+        Date d1 = (Date) u1.getAttribute("datum_pseudo");
+        Date d2 = (Date) u2.getAttribute("datum_pseudo");
+        if (d1 == d2)
           return 0;
-        }
+        if (d1 == null)
+          return -1;
+        if (d2 == null)
+          return 1;
+        return d1.compareTo(d2);
+      }
+      catch (RemoteException re)
+      {
+        Logger.error("unable to sort data",re);
+        return 0;
       }
     });
   }

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -243,10 +243,8 @@ public class MT940UmsatzExporter implements Exporter
    */
   protected void sort(List<Umsatz> list)
   {
-    Collections.sort(list,new Comparator<Umsatz>() {
-      /**
-       * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-       */
+    list.sort(new Comparator<Umsatz>()
+    {
       @Override
       public int compare(Umsatz o1, Umsatz o2)
       {

--- a/src/de/willuhn/jameica/hbci/io/PDFUmsatzByTypeExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/PDFUmsatzByTypeExporter.java
@@ -11,8 +11,6 @@
 package de.willuhn.jameica.hbci.io;
 
 import java.rmi.RemoteException;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import de.willuhn.jameica.hbci.rmi.Umsatz;
@@ -51,21 +49,16 @@ public class PDFUmsatzByTypeExporter extends AbstractPDFUmsatzExporter<UmsatzTyp
   {
     try
     {
-      groups.sort(new Comparator<UmsatzTyp>()
-      {
-        @Override
-        public int compare(UmsatzTyp o1, UmsatzTyp o2)
+      groups.sort((typ1, typ2) -> {
+        try
         {
-          try
-          {
-            return UmsatzTypUtil.compare(o1,o2);
-          }
-          catch (RemoteException re)
-          {
-            Logger.error("unable to compare categories",re);
-          }
-          return 0;
+          return UmsatzTypUtil.compare(typ1,typ2);
         }
+        catch (RemoteException re)
+        {
+          Logger.error("unable to compare categories",re);
+        }
+        return 0;
       });
     }
     catch (Exception e)

--- a/src/de/willuhn/jameica/hbci/io/PDFUmsatzByTypeExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/PDFUmsatzByTypeExporter.java
@@ -51,10 +51,8 @@ public class PDFUmsatzByTypeExporter extends AbstractPDFUmsatzExporter<UmsatzTyp
   {
     try
     {
-      Collections.sort(groups,new Comparator<UmsatzTyp>() {
-        /**
-         * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
-         */
+      groups.sort(new Comparator<UmsatzTyp>()
+      {
         @Override
         public int compare(UmsatzTyp o1, UmsatzTyp o2)
         {

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
@@ -13,7 +13,6 @@ package de.willuhn.jameica.hbci.passports.ddv;
 import java.io.File;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -108,13 +107,7 @@ public class DDVConfigFactory
     }
 
     // Alphabetisch sortieren
-    presets.sort(new Comparator<Reader>()
-    {
-      public int compare(Reader r1, Reader r2)
-      {
-        return r1.getName().compareTo(r2.getName());
-      }
-    });
+    presets.sort(Comparator.comparing(Reader::getName));
     return presets;
   }
 

--- a/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
+++ b/src/de/willuhn/jameica/hbci/passports/ddv/DDVConfigFactory.java
@@ -108,7 +108,8 @@ public class DDVConfigFactory
     }
 
     // Alphabetisch sortieren
-    Collections.sort(presets,new Comparator<Reader>() {
+    presets.sort(new Comparator<Reader>()
+    {
       public int compare(Reader r1, Reader r2)
       {
         return r1.getName().compareTo(r2.getName());

--- a/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceProvider.java
+++ b/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceProvider.java
@@ -17,12 +17,13 @@ import java.util.List;
 import de.willuhn.jameica.hbci.gui.chart.AbstractChartDataSaldo;
 import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.server.Value;
+import de.willuhn.jameica.hbci.HasName;
 
 /**
  * Interface fuer einen AccountBalance-Provider.
  * Der Provider liefert Salden fuer ein Konto, was bei einem Fonds/Depot anders funktioniert als bei einem Girokonto. 
  */
-public interface AccountBalanceProvider
+public interface AccountBalanceProvider extends HasName
 {
 
   /**
@@ -54,6 +55,7 @@ public interface AccountBalanceProvider
    * Liefert einen Namen für Anzeige und Sortierung
    * @return einen Namen für Anzeige und Sortierung
    */
+  @Override
   public String getName();
 }
 

--- a/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
+++ b/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
@@ -18,6 +18,7 @@ import de.willuhn.annotation.Lifecycle;
 import de.willuhn.annotation.Lifecycle.Type;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.util.ProviderComparator;
 import de.willuhn.jameica.services.BeanService;
 import de.willuhn.jameica.system.Application;
 import de.willuhn.logging.Logger;
@@ -66,14 +67,7 @@ public class AccountBalanceService
       Logger.info("  found " + this.providers.size() + " provider(s)");
       
       // Wir sortieren die Provider so, dass der Standard-Provider immer als letzter an die Reihe kommt.
-      this.providers.sort((provider1, provider2) -> {
-        if (DEFAULT.isInstance(provider1))
-          return 1;
-        if (DEFAULT.isInstance(provider2))
-          return -1;
-        // Ansonsten alphabetisch nach Name
-        return provider1.getName().compareTo(provider2.getName());
-      });
+      this.providers.sort(new ProviderComparator<>(DEFAULT, false));
     }
     catch (ClassNotFoundException e)
     {

--- a/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
+++ b/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
@@ -11,8 +11,6 @@
 
 package de.willuhn.jameica.hbci.report.balance;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -68,20 +66,13 @@ public class AccountBalanceService
       Logger.info("  found " + this.providers.size() + " provider(s)");
       
       // Wir sortieren die Provider so, dass der Standard-Provider immer als letzter an die Reihe kommt.
-      this.providers.sort(new Comparator<AccountBalanceProvider>()
-      {
-        @Override
-        public int compare(AccountBalanceProvider o1, AccountBalanceProvider o2)
-        {
-          
-          if (DEFAULT.isInstance(o1))
-            return 1;
-          if (DEFAULT.isInstance(o2))
-            return -1;
-          
-          // Ansonsten alphabetisch nach Name
-          return o1.getName().compareTo(o2.getName());
-        }
+      this.providers.sort((provider1, provider2) -> {
+        if (DEFAULT.isInstance(provider1))
+          return 1;
+        if (DEFAULT.isInstance(provider2))
+          return -1;
+        // Ansonsten alphabetisch nach Name
+        return provider1.getName().compareTo(provider2.getName());
       });
     }
     catch (ClassNotFoundException e)

--- a/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
+++ b/src/de/willuhn/jameica/hbci/report/balance/AccountBalanceService.java
@@ -68,7 +68,9 @@ public class AccountBalanceService
       Logger.info("  found " + this.providers.size() + " provider(s)");
       
       // Wir sortieren die Provider so, dass der Standard-Provider immer als letzter an die Reihe kommt.
-      Collections.sort(this.providers,new Comparator<AccountBalanceProvider>() {
+      this.providers.sort(new Comparator<AccountBalanceProvider>()
+      {
+        @Override
         public int compare(AccountBalanceProvider o1, AccountBalanceProvider o2)
         {
           

--- a/src/de/willuhn/jameica/hbci/synchronize/SynchronizeBackend.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/SynchronizeBackend.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.synchronize.jobs.SynchronizeJob;
+import de.willuhn.jameica.hbci.HasName;
 import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.util.ApplicationException;
 
@@ -23,7 +24,7 @@ import de.willuhn.util.ApplicationException;
  * Die Standard-Implementierung von Hibiscus verwendet HBCI. Es koennen aber
  * weitere hinzugefuegt werden. Eine weitere verwendet z.Bsp. die Scripting-Funktionen.
  */
-public interface SynchronizeBackend
+public interface SynchronizeBackend extends HasName
 {
   /**
    * Queue, an die der aktuelle Prozess-Status der Synchronisierung (RUNNING, ERROR, DONE, CANCEL) geschickt wird.
@@ -100,6 +101,7 @@ public interface SynchronizeBackend
    * Liefert einen sprechenden Namen fuer das Backend.
    * @return sprechender Name fuer das Backend.
    */
+  @Override
   public String getName();
 }
 

--- a/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
@@ -11,8 +11,6 @@
 package de.willuhn.jameica.hbci.synchronize;
 
 import java.rmi.RemoteException;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -80,18 +78,12 @@ public class SynchronizeEngine
       }
       
       // Wir sortieren die Backends so, dass das Primaer-Backend immer Vorrang hat
-      this.backends.sort(new Comparator<SynchronizeBackend>()
-      {
-        @Override
-        public int compare(SynchronizeBackend o1, SynchronizeBackend o2)
-        {
-          
-          if (PRIMARY.isInstance(o1))
-            return -1;
-          if (PRIMARY.isInstance(o2))
-            return 1;
-          return 0;
-        }
+      this.backends.sort((o1, o2) -> {
+        if (PRIMARY.isInstance(o1))
+          return -1;
+        if (PRIMARY.isInstance(o2))
+          return 1;
+        return 0;
       });
     }
     catch (ClassNotFoundException e)

--- a/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
@@ -80,7 +80,9 @@ public class SynchronizeEngine
       }
       
       // Wir sortieren die Backends so, dass das Primaer-Backend immer Vorrang hat
-      Collections.sort(this.backends,new Comparator<SynchronizeBackend>() {
+      this.backends.sort(new Comparator<SynchronizeBackend>()
+      {
+        @Override
         public int compare(SynchronizeBackend o1, SynchronizeBackend o2)
         {
           

--- a/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/SynchronizeEngine.java
@@ -14,6 +14,7 @@ import java.rmi.RemoteException;
 import java.util.LinkedList;
 import java.util.List;
 
+import de.willuhn.jameica.hbci.util.ProviderComparator;
 import org.apache.commons.lang.StringUtils;
 
 import de.willuhn.annotation.Lifecycle;
@@ -78,13 +79,7 @@ public class SynchronizeEngine
       }
       
       // Wir sortieren die Backends so, dass das Primaer-Backend immer Vorrang hat
-      this.backends.sort((o1, o2) -> {
-        if (PRIMARY.isInstance(o1))
-          return -1;
-        if (PRIMARY.isInstance(o2))
-          return 1;
-        return 0;
-      });
+      this.backends.sort(new ProviderComparator<>(PRIMARY, true));
     }
     catch (ClassNotFoundException e)
     {

--- a/src/de/willuhn/jameica/hbci/util/ProviderComparator.java
+++ b/src/de/willuhn/jameica/hbci/util/ProviderComparator.java
@@ -1,0 +1,56 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2004 Olaf Willuhn
+ * All rights reserved.
+ *
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details.
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci.util;
+
+import de.willuhn.jameica.hbci.HasName;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Ein {@link Comparator}, um Provider (nach Namen) zu sortieren.
+ *
+ * <p>Hierbei wird ein Vergleichsobjekt mitgegeben, der Standardprovider, welches
+ * je nach Wunsch entweder ganz vorn oder ganz hinten in der Aufzählung einsortiert wird.
+ *
+ * @param <T> Klasse der zu sortierenden Provider
+ */
+public class ProviderComparator<T extends HasName> implements Comparator<T>
+{
+  /** Standardprovider */
+  private final Class<? extends T> PRIMARY;
+  /** Gibt an, ob der Standardprovider ganz vorn oder ganz hinten einsortiert werden soll. */
+  private final boolean PRIMARY_ZUERST;
+
+  /**
+   * Erzeugt einen {@link Comparator} zum Sortieren von Providern.
+   *
+   * @param primary Der Standardprovider.
+   * @param alsErstes Bei {@code true} wird der Standardprovider ganz vorn einsortiert, bei {@code false} ganz
+   *         hinten.
+   */
+  public ProviderComparator(final Class<? extends T> primary, boolean alsErstes)
+  {
+    PRIMARY = Objects.requireNonNull(primary);
+    PRIMARY_ZUERST = alsErstes;
+  }
+
+  @Override
+  public int compare(final T o1, final T o2)
+  {
+    if (PRIMARY.isInstance(o1))
+      return PRIMARY_ZUERST ? -1 : 1;
+    if (PRIMARY.isInstance(o2))
+      return PRIMARY_ZUERST ? 1 : -1;
+    // Ansonsten alphabetisch nach Name
+    return o1.getName().compareTo(o2.getName());
+  }
+}


### PR DESCRIPTION
- Seit Java 8 kann direkt auf einer Liste sortieren ohne Umweg über Collections
- Benutze Lambda-Ausdrücke zum Sortieren
- DRY: extrahiere Comparator-Logik
   In den Klassen wird die identische Logik mehrfach implementiert.
   Um die Fehleranfälligkeit zu senken und die Lesbarkeit zu erhöhen,
   wird jene in eine eigene Klasse `ProviderComparator` ausgelagert.