### PR TITLE
Test vergleicht Bildeigenschaften und Pixel der erzeugten QR-Codes mit erwartetem Bild

### DIFF
--- a/test/de/willuhn/jameica/hbci/passports/pintan/TestFlickerToQrConverter.java
+++ b/test/de/willuhn/jameica/hbci/passports/pintan/TestFlickerToQrConverter.java
@@ -10,6 +10,13 @@
 
 package de.willuhn.jameica.hbci.passports.pintan;
 
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.imageio.ImageIO;
 import javax.xml.bind.DatatypeConverter;
 
 import org.junit.Assert;
@@ -22,6 +29,28 @@ import org.kapott.hbci.manager.QRCode;
 public class TestFlickerToQrConverter
 {
   /**
+   * Wandelt binäre Bilddaten aus Byte-Array in Bild um.
+   * @param imageData Byte-Array der binären Bilddaten
+   * @return aus Byte-Array erzeugtes Bild
+   * @throws IOException
+   */
+  private static BufferedImage getImage(final byte[] imageData) throws IOException
+  {
+    final InputStream is = new ByteArrayInputStream(imageData);
+    return ImageIO.read(is);
+  }
+  
+  /**
+   * Gibt Pixel-Array des Bildes zurück.
+   * @param img Bild, dessen Pixel-Array ermittelt werden soll
+   * @return in Bild enthaltenes Pixel-Array
+   */
+  private static byte[] getPixels(final BufferedImage img)
+  {
+    return ((DataBufferByte) img.getRaster().getDataBuffer()).getData();
+  }
+  
+  /**
    * @throws Exception
    */
   @Test
@@ -30,10 +59,18 @@ public class TestFlickerToQrConverter
     // Bankauftrag allgemein
     final String png = FlickerToQrConverter.convert("058201100F40");
     final QRCode code = new QRCode(png, "Bankauftrag allgemein");
+    final BufferedImage imgActual = getImage(code.getImage());
     
     final byte[] pngData = DatatypeConverter.parseHexBinary("89504E470D0A1A0A0000000D49484452000000940000009401000000005D473D790000010D4944415478DACD96511283300844F706DCFF96B9C19685A0E9F4CFF5A341477DCED4082F58F0672CFC1503108BA888BAF058303744872E5C966717D2FE025BE8E04B8C57BCC0F4DAECE09197A74C65B9C651B7A74CE328D1E5D55396E7B9B5444B793059D6660D5322C2649AE4E434EF064D96475EA89EE331AC5A291532204CC644B8250F97C99BA3E895038B1D4D224A778FE521EE26165D73832167C9C3219A8C33D58AE83568B010C23854D25B2C275C89DD0EF53A7298A68DB1A87B98C372BF1D02DA2183690932BE1D72D868C369B726D3D84EDE8E1B4C3F8CED507D444DA62588ED90EA4E97F527AA1D9ABC988CED5069CE17D894BC6C7719397057C96355A3E939EA1826FBEFFFBB1FC496DF9420864B350000000049454E44AE426082");
-    Assert.assertArrayEquals(pngData, code.getImage());
-  }
+    final BufferedImage imgExpected = getImage(pngData);
+    
+    Assert.assertEquals(imgExpected.getHeight(), imgActual.getHeight());
+    Assert.assertEquals(imgExpected.getWidth(), imgActual.getWidth());
+    Assert.assertEquals(imgExpected.getTransparency(), imgActual.getTransparency());
+    // Comparing pixels is only valid if types are equal since monochrome images store more than one pixel per byte.
+    Assert.assertEquals(imgExpected.getType(), imgActual.getType());
+    Assert.assertArrayEquals(getPixels(imgExpected), getPixels(imgActual));
+}
 
   /**
    * @throws Exception
@@ -44,8 +81,16 @@ public class TestFlickerToQrConverter
     // Startcode 82112345, Konto/IBAN 0123456789, Überweisung 100 Euro
     final String png = FlickerToQrConverter.convert("1DC80138323131323334354A30313233343536373839463130302C303002");
     final QRCode code = new QRCode(png, "Überweisung 100 Euro");
+    final BufferedImage imgActual = getImage(code.getImage());
 
     byte[] pngData = DatatypeConverter.parseHexBinary("89504E470D0A1A0A0000000D49484452000000940000009401000000005D473D79000001264944415478DACD96510EC33008437D03EE7F4B6EE0619C6E93F657F763895429AF5248C040C09FD1F82B06A0AA35D1BB085991054F2F52362668D4A5C513ECCCA7D86CAFD97C82CDB5AB39B3658D29DB185DE33B6E3799C60911EA4B5777D96C5A581171FCB05A8A98AE7F314A46212B6A67DAABE2215B492E92A966CEE6986D11CDFAF8E53EEBF6C9F58BCA9E904DA8E1A08B3518B289F855245A699D32A5B2FE68B56913B25179BB28AE29C72860FA1C692AA1AB42D6EF2CE17A9721531DC4A521384C09A384738AEC38B553367BA3DE1A62CC2C72D7B06D2B21D3B5B931374DD9D6586B12457CEAEE4D76B67566ABFD856C7BBC35B43267CA5414ADA0B157A827D8B679E5A27D9032555A3F41ACA1886D8FF79B06A766270CBEB89E707BF894FDF77BF705E26AE87C5D161C770000000049454E44AE426082");
-    Assert.assertArrayEquals(pngData, code.getImage());
+    final BufferedImage imgExpected = getImage(pngData);
+    
+    Assert.assertEquals(imgExpected.getHeight(), imgActual.getHeight());
+    Assert.assertEquals(imgExpected.getWidth(), imgActual.getWidth());
+    Assert.assertEquals(imgExpected.getTransparency(), imgActual.getTransparency());
+    // Comparing pixels is only valid if types are equal since monochrome images store more than one pixel per byte.
+    Assert.assertEquals(imgExpected.getType(), imgActual.getType());
+    Assert.assertArrayEquals(getPixels(imgExpected), getPixels(imgActual));
   }
 }

--- a/test/de/willuhn/jameica/hbci/passports/pintan/TestFlickerToQrConverter.java
+++ b/test/de/willuhn/jameica/hbci/passports/pintan/TestFlickerToQrConverter.java
@@ -10,13 +10,7 @@
 
 package de.willuhn.jameica.hbci.passports.pintan;
 
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
-import java.util.Iterator;
-
-import javax.imageio.ImageIO;
-import javax.imageio.ImageReader;
-import javax.imageio.stream.ImageInputStream;
+import javax.xml.bind.DatatypeConverter;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,7 +30,9 @@ public class TestFlickerToQrConverter
     // Bankauftrag allgemein
     final String png = FlickerToQrConverter.convert("058201100F40");
     final QRCode code = new QRCode(png, "Bankauftrag allgemein");
-    this.testPng(code);
+    
+    final byte[] pngData = DatatypeConverter.parseHexBinary("89504E470D0A1A0A0000000D49484452000000940000009401000000005D473D790000010D4944415478DACD96511283300844F706DCFF96B9C19685A0E9F4CFF5A341477DCED4082F58F0672CFC1503108BA888BAF058303744872E5C966717D2FE025BE8E04B8C57BCC0F4DAECE09197A74C65B9C651B7A74CE328D1E5D55396E7B9B5444B793059D6660D5322C2649AE4E434EF064D96475EA89EE331AC5A291532204CC644B8250F97C99BA3E895038B1D4D224A778FE521EE26165D73832167C9C3219A8C33D58AE83568B010C23854D25B2C275C89DD0EF53A7298A68DB1A87B98C372BF1D02DA2183690932BE1D72D868C369B726D3D84EDE8E1B4C3F8CED507D444DA62588ED90EA4E97F527AA1D9ABC988CED5069CE17D894BC6C7719397057C96355A3E939EA1826FBEFFFBB1FC496DF9420864B350000000049454E44AE426082");
+    Assert.assertArrayEquals(pngData, code.getImage());
   }
 
   /**
@@ -48,29 +44,8 @@ public class TestFlickerToQrConverter
     // Startcode 82112345, Konto/IBAN 0123456789, Überweisung 100 Euro
     final String png = FlickerToQrConverter.convert("1DC80138323131323334354A30313233343536373839463130302C303002");
     final QRCode code = new QRCode(png, "Überweisung 100 Euro");
-    this.testPng(code);
-  }
-  
-  /**
-   * Testet, ob das Bild in dem QR-Code als PNG gelesen werden kann.
-   * @param code der Code.
-   * @throws Exception
-   */
-  private void testPng(QRCode code) throws Exception
-  {
-    // Das Schliessen der Streams ist nicht noetig, da das ohnehin alles in-memory passiert
-    
-    // Testen, ob es sich um ein PNG handelt
-    final ImageInputStream stream = ImageIO.createImageInputStream(new ByteArrayInputStream(code.getImage()));
-    final Iterator<ImageReader> readers = ImageIO.getImageReaders(stream);
-    Assert.assertTrue(readers.hasNext());
-    final ImageReader r = readers.next();
-    Assert.assertEquals("png",r.getFormatName().toLowerCase());
 
-    // Testen, ob es gelesen werden kann.
-    stream.reset();
-    r.setInput(stream);
-    final BufferedImage img = r.read(0);
-    Assert.assertNotNull(img);
+    byte[] pngData = DatatypeConverter.parseHexBinary("89504E470D0A1A0A0000000D49484452000000940000009401000000005D473D79000001264944415478DACD96510EC33008437D03EE7F4B6EE0619C6E93F657F763895429AF5248C040C09FD1F82B06A0AA35D1BB085991054F2F52362668D4A5C513ECCCA7D86CAFD97C82CDB5AB39B3658D29DB185DE33B6E3799C60911EA4B5777D96C5A581171FCB05A8A98AE7F314A46212B6A67DAABE2215B492E92A966CEE6986D11CDFAF8E53EEBF6C9F58BCA9E904DA8E1A08B3518B289F855245A699D32A5B2FE68B56913B25179BB28AE29C72860FA1C692AA1AB42D6EF2CE17A9721531DC4A521384C09A384738AEC38B553367BA3DE1A62CC2C72D7B06D2B21D3B5B931374DD9D6586B12457CEAEE4D76B67566ABFD856C7BBC35B43267CA5414ADA0B157A827D8B679E5A27D9032555A3F41ACA1886D8FF79B06A766270CBEB89E707BF894FDF77BF705E26AE87C5D161C770000000049454E44AE426082");
+    Assert.assertArrayEquals(pngData, code.getImage());
   }
 }


### PR DESCRIPTION
Dieser PR ersetzt den groben Test auf die Existenz eines png-Bildes (https://github.com/willuhn/hibiscus/commit/dfb9ff82bba904d7aba475082ef6e3e3ca5fe0a2) und betrachtet nun die Bildinhalte (Pixel) sowie weitere Bildeigenschaften zum Testen der Flicker-zu-QR-Code-Umwandlung (https://github.com/willuhn/hibiscus/commit/57f700f4a08946da7d3f4dd82f27cc791d094e41).