### PR TITLE
Builder für Abfrage von Auftragslisten (zu 800990c)

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractSepaSammelTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractSepaSammelTransferList.java
@@ -15,6 +15,9 @@ import java.rmi.RemoteException;
 import java.util.Date;
 import java.util.List;
 
+import de.willuhn.jameica.hbci.rmi.TransferQueryBuilder;
+import de.willuhn.jameica.hbci.rmi.TransferQueryBuilderWithDBService;
+import de.willuhn.jameica.hbci.rmi.TransferQueryBuilderWithStatusbarMessage;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.widgets.Composite;
@@ -45,19 +48,15 @@ import de.willuhn.jameica.hbci.messaging.ImportMessage;
 import de.willuhn.jameica.hbci.messaging.ObjectChangedMessage;
 import de.willuhn.jameica.hbci.messaging.ObjectMessage;
 import de.willuhn.jameica.hbci.reminder.ReminderStorageProviderHibiscus;
-import de.willuhn.jameica.hbci.rmi.HBCIDBService;
 import de.willuhn.jameica.hbci.rmi.HibiscusDBObject;
-import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.rmi.SepaSammelTransfer;
 import de.willuhn.jameica.hbci.rmi.SepaSammelTransferBuchung;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
-import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.reminder.Reminder;
 import de.willuhn.jameica.reminder.ReminderStorageProvider;
 import de.willuhn.jameica.services.BeanService;
 import de.willuhn.jameica.system.Application;
-import de.willuhn.jameica.util.DateUtil;
 import de.willuhn.logging.Logger;
 
 /**
@@ -210,58 +209,19 @@ public abstract class AbstractSepaSammelTransferList extends AbstractFromToList
    */
   protected DBIterator getList(Object konto, Date from, Date to, String text) throws RemoteException
   {
-    int filterCount = 0;
-
-    HBCIDBService service = (HBCIDBService) Settings.getDBService();
-    
-    DBIterator list = service.createList(getObjectType());
-    if (from != null)
-    {
-      list.addFilter("termin >= ?", new java.sql.Date(DateUtil.startOfDay(from).getTime()));
-      filterCount++;
-    }
-    if (to != null)
-    {
-      list.addFilter("termin <= ?", new java.sql.Date(DateUtil.endOfDay(to).getTime()));
-      filterCount++;
-    }
-    
-    if (text != null && text.length() > 0)
-    {
-      list.addFilter("LOWER(bezeichnung) like ?", "%" + text.toLowerCase() + "%");
-      filterCount++;
-    }
-    
-    if (konto != null)
-    {
-      if (konto instanceof Konto)
-        list.addFilter("konto_id = " + ((Konto) konto).getID());
-      else if (konto instanceof String)
-        list.addFilter("konto_id in (select id from konto where kategorie = ?)", (String) konto);
-      
-      filterCount++;
-    }
-
-    boolean pending = ((Boolean) this.getPending().getValue()).booleanValue();
-    if (pending)
-    {
-      list.addFilter("ausgefuehrt = 0");
-      filterCount++;
-    }
-
-    list.setOrder("ORDER BY " + service.getSQLTimestamp("termin") + " DESC, id DESC");
-
-    if (filterCount > 0)
-    {
-      final int all = service.createList(getObjectType()).size();
-      final int size = list.size();
-      if (all != size)
-        Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Suchkriterien: {0} - Anzeige: {1} von {2} Aufträgen",Integer.toString(filterCount), Integer.toString(size), Integer.toString(all)),StatusBarMessage.TYPE_INFO));
-      else
-        Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Suchkriterien: {0}",Integer.toString(filterCount)),StatusBarMessage.TYPE_INFO));
-    }
-
-    return list;
+    TransferQueryBuilder builder = new TransferQueryBuilderWithStatusbarMessage(
+            new TransferQueryBuilderWithDBService(Settings.getDBService(), getObjectType()),
+            i18n
+    );
+    //@formatter:off
+    return builder.withStartDate(from)
+                  .withEndDate(to)
+                  .withTextLike(text)
+                  .withAccount(konto)
+                  .withOnlyPendingTransactions((Boolean) this.getPending().getValue())
+                  .orderedByDateDesc()
+                  .build();
+    //@formatter:on
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/gui/parts/AbstractTransferList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/AbstractTransferList.java
@@ -13,6 +13,9 @@ package de.willuhn.jameica.hbci.gui.parts;
 import java.rmi.RemoteException;
 import java.util.Date;
 
+import de.willuhn.jameica.hbci.rmi.TransferQueryBuilder;
+import de.willuhn.jameica.hbci.rmi.TransferQueryBuilderWithDBService;
+import de.willuhn.jameica.hbci.rmi.TransferQueryBuilderWithStatusbarMessage;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.widgets.Composite;
@@ -45,18 +48,14 @@ import de.willuhn.jameica.hbci.messaging.ImportMessage;
 import de.willuhn.jameica.hbci.messaging.ObjectChangedMessage;
 import de.willuhn.jameica.hbci.messaging.ObjectMessage;
 import de.willuhn.jameica.hbci.reminder.ReminderStorageProviderHibiscus;
-import de.willuhn.jameica.hbci.rmi.HBCIDBService;
 import de.willuhn.jameica.hbci.rmi.HibiscusDBObject;
-import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.rmi.Terminable;
 import de.willuhn.jameica.messaging.Message;
 import de.willuhn.jameica.messaging.MessageConsumer;
-import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.reminder.Reminder;
 import de.willuhn.jameica.reminder.ReminderStorageProvider;
 import de.willuhn.jameica.services.BeanService;
 import de.willuhn.jameica.system.Application;
-import de.willuhn.jameica.util.DateUtil;
 import de.willuhn.logging.Logger;
 
 /**
@@ -205,52 +204,18 @@ public abstract class AbstractTransferList extends AbstractFromToList
    */
   protected DBIterator getList(Object konto, Date from, Date to, String text) throws RemoteException
   {
-    int filterCount = 0;
-    
-    HBCIDBService service = (HBCIDBService) Settings.getDBService();
-    
-    DBIterator list = service.createList(getObjectType());
-    if (from != null)
-    {
-      list.addFilter("termin >= ?", new java.sql.Date(DateUtil.startOfDay(from).getTime()));
-      filterCount++;
-    }
-    if (to != null)
-    {
-      list.addFilter("termin <= ?", new java.sql.Date(DateUtil.endOfDay(to).getTime()));
-      filterCount++;
-    }
-
-    if (konto != null)
-    {
-      if (konto instanceof Konto)
-        list.addFilter("konto_id = " + ((Konto) konto).getID());
-      else if (konto instanceof String)
-        list.addFilter("konto_id in (select id from konto where kategorie = ?)", (String) konto);
-      
-      filterCount++;
-    }
-    
-    boolean pending = ((Boolean) this.getPending().getValue()).booleanValue();
-    if (pending)
-    {
-      list.addFilter("ausgefuehrt = 0");
-      filterCount++;
-    }
-
-    list.setOrder("ORDER BY " + service.getSQLTimestamp("termin") + " DESC, id DESC");
-
-    if (filterCount > 0)
-    {
-      final int all = service.createList(getObjectType()).size();
-      final int size = list.size();
-      if (all != size)
-        Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Suchkriterien: {0} - Anzeige: {1} von {2} Aufträgen",Integer.toString(filterCount), Integer.toString(size), Integer.toString(all)),StatusBarMessage.TYPE_INFO));
-      else
-        Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Suchkriterien: {0}",Integer.toString(filterCount)),StatusBarMessage.TYPE_INFO));
-    }
-
-    return list;
+    TransferQueryBuilder builder = new TransferQueryBuilderWithStatusbarMessage(
+            new TransferQueryBuilderWithDBService(Settings.getDBService(), getObjectType()),
+            i18n
+    );
+    //@formatter:off
+    return builder.withStartDate(from)
+                  .withEndDate(to)
+                  .withAccount(konto)
+                  .withOnlyPendingTransactions((Boolean) this.getPending().getValue())
+                  .orderedByDateDesc()
+                  .build();
+    //@formatter:on
   }
   
   /**

--- a/src/de/willuhn/jameica/hbci/rmi/TransferQueryBuilder.java
+++ b/src/de/willuhn/jameica/hbci/rmi/TransferQueryBuilder.java
@@ -1,0 +1,21 @@
+package de.willuhn.jameica.hbci.rmi;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+
+import de.willuhn.datasource.rmi.DBIterator;
+
+public interface TransferQueryBuilder
+{
+  DBIterator build() throws RemoteException;
+
+  int getElementCount() throws RemoteException;
+  int getElementCountWithoutFilter() throws RemoteException;
+
+  TransferQueryBuilder orderedByDateDesc();
+  TransferQueryBuilder withAccount(Object konto);
+  TransferQueryBuilder withEndDate(Date to);
+  TransferQueryBuilder withOnlyPendingTransactions(boolean yes);
+  TransferQueryBuilder withStartDate(Date from);
+  TransferQueryBuilder withTextLike(String text);
+}

--- a/src/de/willuhn/jameica/hbci/rmi/TransferQueryBuilderWithDBService.java
+++ b/src/de/willuhn/jameica/hbci/rmi/TransferQueryBuilderWithDBService.java
@@ -1,0 +1,190 @@
+package de.willuhn.jameica.hbci.rmi;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.datasource.rmi.DBObject;
+import de.willuhn.jameica.util.DateUtil;
+
+public class TransferQueryBuilderWithDBService implements TransferQueryBuilder
+{
+  private final HBCIDBService service;
+  private final Class<? extends DBObject> objectType;
+  private final List<FilterArgument> filters = new LinkedList<>();
+
+  private boolean orderByDateDesc = false;
+
+  public TransferQueryBuilderWithDBService(final HBCIDBService service, final Class<? extends DBObject> objectType) throws RemoteException
+  {
+    this.service = service;
+    this.objectType = objectType;
+  }
+
+  @Override
+  public TransferQueryBuilderWithDBService withStartDate(final Date from)
+  {
+    if (from != null)
+    {
+      addFilter("termin >= ?", new java.sql.Date(DateUtil.startOfDay(from).getTime()));
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithDBService withEndDate(final Date to)
+  {
+    if (to != null)
+    {
+      addFilter("termin <= ?", new java.sql.Date(DateUtil.endOfDay(to).getTime()));
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithDBService withTextLike(final String text)
+  {
+    if (text != null && text.length() > 0)
+    {
+      addFilter("LOWER(bezeichnung) like ?", "%" + text.toLowerCase() + "%");
+    }
+    return this;
+  }
+
+  private TransferQueryBuilderWithDBService withAccount(final Konto konto)
+  {
+    if (konto != null)
+    {
+      try
+      {
+        final String id = konto.getID();
+        addFilter("konto_id = " + id);
+      }
+      catch (RemoteException e)
+      {
+        // Should never happen since KontoImpl#getID() today only returns
+        // an internally stored string. But if this behaviour changes,
+        // this exception will indicate it.
+        throw new RuntimeException(e);
+      }
+    }
+    return this;
+  }
+
+  private TransferQueryBuilderWithDBService withAccount(final String konto)
+  {
+    if (konto != null)
+    {
+      addFilter("konto_id in (select id from konto where kategorie = ?)", konto);
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithDBService withAccount(final Object konto)
+  {
+    if (konto != null)
+    {
+      if (konto instanceof Konto)
+        return withAccount((Konto) konto);
+      else if (konto instanceof String)
+        return withAccount((String) konto);
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithDBService withOnlyPendingTransactions(final boolean yes)
+  {
+    if (yes)
+    {
+      addFilter("ausgefuehrt = 0");
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithDBService orderedByDateDesc()
+  {
+    orderByDateDesc = true;
+    return this;
+  }
+
+  @Override
+  public DBIterator build() throws RemoteException
+  {
+    final DBIterator list = service.createList(objectType);
+    for (FilterArgument f : filters)
+    {
+      if (f.isPreparedStatement())
+        list.addFilter(f.sql, f.values);
+      else
+        list.addFilter(f.sql);
+    }
+    if (orderByDateDesc)
+    {
+      list.setOrder("ORDER BY " + service.getSQLTimestamp("termin") + " DESC, id DESC");
+    }
+
+    return list;
+  }
+
+  @Override
+  public int getElementCount() throws RemoteException
+  {
+    return this.build().size();
+  }
+
+  @Override
+  public int getElementCountWithoutFilter() throws RemoteException
+  {
+    return service.createList(objectType).size();
+  }
+
+  private void addFilter(final String sql, final Date date)
+  {
+    filters.add(new FilterArgument(sql, date));
+  }
+
+  private void addFilter(final String sql, final String value)
+  {
+    filters.add(new FilterArgument(sql, value));
+  }
+
+  private void addFilter(final String sql)
+  {
+    filters.add(new FilterArgument(sql));
+  }
+
+  private static class FilterArgument
+  {
+    private final String sql;
+    private final Object[] values;
+
+    FilterArgument(String sql)
+    {
+      this.sql = Objects.requireNonNull(sql);
+      this.values = null;
+    }
+
+    FilterArgument(String preparedStatement, String... values)
+    {
+      this.sql = Objects.requireNonNull(preparedStatement);
+      this.values = Objects.requireNonNull(values);
+    }
+
+    FilterArgument(final String preparedStatement, final Date... values)
+    {
+      this.sql = Objects.requireNonNull(preparedStatement);
+      this.values = Objects.requireNonNull(values);
+    }
+
+    public boolean isPreparedStatement()
+    {
+      return values == null;
+    }
+  }
+}

--- a/src/de/willuhn/jameica/hbci/rmi/TransferQueryBuilderWithStatusbarMessage.java
+++ b/src/de/willuhn/jameica/hbci/rmi/TransferQueryBuilderWithStatusbarMessage.java
@@ -1,0 +1,143 @@
+package de.willuhn.jameica.hbci.rmi;
+
+import java.rmi.RemoteException;
+import java.util.Date;
+import java.util.Objects;
+
+import de.willuhn.datasource.rmi.DBIterator;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.util.I18N;
+
+public class TransferQueryBuilderWithStatusbarMessage implements TransferQueryBuilder
+{
+  private TransferQueryBuilder inner;
+  private final I18N i18n;
+  private int filterCount;
+
+  public TransferQueryBuilderWithStatusbarMessage(final TransferQueryBuilder inner, final I18N i18n)
+  {
+    filterCount = 0;
+    this.inner = Objects.requireNonNull(inner);
+    this.i18n = Objects.requireNonNull(i18n);
+  }
+
+  @Override
+  public DBIterator build() throws RemoteException
+  {
+    DBIterator list = inner.build();
+    if (filterCount > 0)
+    {
+      sendMessageToStatusbar();
+    }
+    return list;
+  }
+
+  private void sendMessageToStatusbar() throws RemoteException
+  {
+    final int all = inner.getElementCountWithoutFilter();
+    final int filtered = inner.getElementCount();
+    final String message;
+    //@formatter:off
+    if (all != filtered)
+    {
+      message = i18n.tr("Suchkriterien: {0} - Anzeige: {1} von {2} Aufträgen",
+                        Integer.toString(filterCount),
+                        Integer.toString(filtered),
+                        Integer.toString(all)
+                       );
+    }
+    else
+    {
+      message = i18n.tr("Suchkriterien: {0}",
+                        Integer.toString(filterCount)
+                       );
+    }
+    //@formatter:on
+
+    Application.getMessagingFactory()
+               .sendMessage(new StatusBarMessage(message, StatusBarMessage.TYPE_INFO));
+  }
+
+  //region Delegation with counter
+
+  @Override
+  public TransferQueryBuilderWithStatusbarMessage withStartDate(final Date from)
+  {
+    if (from != null)
+    {
+      filterCount++;
+      inner = inner.withStartDate(from);
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithStatusbarMessage withEndDate(final Date to)
+  {
+    if (to != null)
+    {
+      filterCount++;
+      inner = inner.withEndDate(to);
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithStatusbarMessage withTextLike(final String text)
+  {
+    if (text != null && text.length() > 0)
+    {
+      filterCount++;
+      inner = inner.withTextLike(text);
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithStatusbarMessage withAccount(final Object konto)
+  {
+    if (konto != null)
+    {
+      filterCount++;
+      inner = inner.withAccount(konto);
+    }
+    return this;
+  }
+
+  @Override
+  public TransferQueryBuilderWithStatusbarMessage withOnlyPendingTransactions(final boolean yes)
+  {
+    if (yes)
+    {
+      filterCount++;
+      inner = inner.withOnlyPendingTransactions(yes);
+    }
+    return this;
+  }
+
+  //endregion
+
+  //region Delegation without counter
+
+  @Override
+  public TransferQueryBuilder orderedByDateDesc()
+  {
+    inner = inner.orderedByDateDesc();
+    return this;
+  }
+
+  @Override
+  public int getElementCount() throws RemoteException
+  {
+    return inner.getElementCount();
+  }
+
+  @Override
+  public int getElementCountWithoutFilter() throws RemoteException
+  {
+    return inner.getElementCountWithoutFilter();
+  }
+
+  //endregion
+}


### PR DESCRIPTION
Durch das Builder-Pattern können die technischen Details der fachlichen Businesslogik versteckt/ gekapselt werden. So wird ein einheitliches Abstraktionsniveau ("Flughöhe") innerhalb der Methode erreicht.

In Commit 800990c wurden in drei Klassen die Methode `getList` um eine Ausgabe auf der Statusleiste ergänzt. Hierbei fällt auf, dass diese drei Methoden zu 95% identisch sind (nur der Textfilter fehlt in `AbstractTransferList`).

Diese Redundanz kann durch den Einsatz des Builders deutlich reduziert werden. Die Zentralisierung senkt die Fehleranfälligkeit (falls eine Implementierung bei Anpassungen vergessen wird) und die Kapselung erhöht die Verständlichkeit (da andere Abstraktionsebene).