### PR TITLE
neue Abhängigkeit für QR-Code auch in `gradle.build` ergänzt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     // see <https://sourceforge.net/projects/obantoo/> (last update: 2015-05-10)
     // new version (Java13+) see <https://github.com/jverein/obantoo2>
     implementation urlFile('obantoo-bin-2.1.12', 'https://downloads.sourceforge.net/project/obantoo/obantoo-bin-2.1.12.jar')
+    // see <https://github.com/nayuki/QR-Code-generator/tree/master/java-fast/>
+    implementation files( "${projectDir}/lib/fastqrcodegen/fastqrcodegen-1.0.jar")
 }
 
 // solange noch die Logik des ANT-Builds benötigt wird, nutze einen Unterordner


### PR DESCRIPTION
In 57f700f4a08946da7d3f4dd82f27cc791d094e41 wurde ein zusätzliches JAR für einen QR-Code-Generator ergänzt. In der Konfiguration für _ANT_ wurde jene Anpassung durchgeführt, in der Konfiguration für _Gradle_ jedoch nicht. Dieser Pullrequest holt dies nach.