### PR TITLE
server: support escaping separator in search terms.

### DIFF
--- a/src/help/de_de/de.willuhn.jameica.hbci.gui.views.Settings.txt
+++ b/src/help/de_de/de.willuhn.jameica.hbci.gui.views.Settings.txt
@@ -29,7 +29,9 @@
 	<li>
 		<b>Umsatz-Kategorien:</b> Sie können auch mehrere Suchbegriffe (durch Komma getrennt)
 		eingeben. Umsätze werden dann bereits dieser Kategorie zugeordnet, wenn nur
-		einer der angegebenen Suchbegriffe gefunden wurde.
+		einer der angegebenen Suchbegriffe gefunden wurde. Soll der Suchbegriff explizit ein
+		Komma enthalten, muss dem Komma ein umgekehrter Schrägstrich (Backslash, <pre>\</pre>)
+		vorangestellt werden.
 	</li>
 
 	<li>


### PR DESCRIPTION
For non-regex search terms, the separator is hardcoded to a comma character (which is fine), but there has been no way to escape it until now. Since commas are legal characters in references (and probably other fields), having a way to search for them can actually be useful.

While one could argue that regular expressions can be used to achieve that, typical users have no idea how that works and often get them wrong, so providing an easy alternative sounds beneficial.