### PR TITLE
Anpassung an Umsatz- und Saldenabfrage für Targobank KK-Konto.

### DIFF
--- a/sql/h2-create.sql
+++ b/sql/h2-create.sql
@@ -1,6 +1,6 @@
 CREATE TABLE konto (
   id IDENTITY(1),
-  kontonummer varchar(15) NOT NULL,
+  kontonummer varchar(16) NOT NULL,
   unterkonto varchar(30) null,
   blz varchar(15) NOT NULL,
   name varchar(255) NOT NULL,
@@ -454,6 +454,6 @@ CREATE INDEX idx_umsatz_datum ON umsatz(datum);
 CREATE INDEX idx_umsatz_valuta ON umsatz(valuta);
 CREATE INDEX idx_umsatz_flags ON umsatz(flags);
   
-INSERT INTO version (name,version) values ('db',69);
+INSERT INTO version (name,version) values ('db',70);
   
 COMMIT;

--- a/sql/mysql-create.sql
+++ b/sql/mysql-create.sql
@@ -1,6 +1,6 @@
 CREATE TABLE konto (
        id int(10) AUTO_INCREMENT
-     , kontonummer VARCHAR(15) NOT NULL
+     , kontonummer VARCHAR(16) NOT NULL
      , unterkonto varchar(30) null
      , blz VARCHAR(15) NOT NULL
      , name VARCHAR(255) NOT NULL
@@ -483,4 +483,4 @@ ALTER TABLE protokoll ADD INDEX (datum);
 ALTER TABLE ueberweisung ADD INDEX (termin);
 ALTER TABLE lastschrift ADD INDEX (termin);
 
-INSERT INTO version (name,version) values ('db',69);
+INSERT INTO version (name,version) values ('db',70);

--- a/sql/postgresql-create.sql
+++ b/sql/postgresql-create.sql
@@ -1,6 +1,6 @@
 CREATE TABLE konto (
   id serial primary key,
-  kontonummer varchar(15) NOT NULL,
+  kontonummer varchar(16) NOT NULL,
   unterkonto varchar(30) null,
   blz varchar(15) NOT NULL,
   name varchar(255) NOT NULL,
@@ -400,4 +400,4 @@ CREATE INDEX idx_umsatz_datum ON umsatz(datum);
 CREATE INDEX idx_umsatz_valuta ON umsatz(valuta);
 CREATE INDEX idx_umsatz_flags ON umsatz(flags);
   
-INSERT INTO version (name,version) values ('db',69);
+INSERT INTO version (name,version) values ('db',70);

--- a/src/de/willuhn/jameica/hbci/HBCIProperties.java
+++ b/src/de/willuhn/jameica/hbci/HBCIProperties.java
@@ -157,7 +157,7 @@ public class HBCIProperties
    * VISA-Konten unterstuetzt werden, lass ich es vorerst mal auf
    * 15 Stellen stehen und deklarieren es als "weiches" Limit.
    */
-  public final static int HBCI_KTO_MAXLENGTH_SOFT = settings.getInt("hbci.kto.maxlength.soft",15);
+  public final static int HBCI_KTO_MAXLENGTH_SOFT = settings.getInt("hbci.kto.maxlength.soft",16);
   
   /**
    * Das harte Limit fuer Kontonummern, die CRC-Checks bestehen sollen
@@ -457,7 +457,7 @@ public class HBCIProperties
     // Haben wir eine gueltige Kontonummer?
     if (kontonummer == null || 
         kontonummer.length() == 0 ||
-        kontonummer.length() > HBCI_KTO_MAXLENGTH_HARD)
+        kontonummer.length() > HBCI_KTO_MAXLENGTH_SOFT)
     {
       Logger.warn("account number [" + kontonummer + "] not defined out of range, skip crc check");
       return true;

--- a/src/de/willuhn/jameica/hbci/gui/controller/KontoControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/KontoControl.java
@@ -212,7 +212,7 @@ public class KontoControl extends AbstractControl
 	{
 		if (kontonummer != null)
 			return kontonummer;
-		kontonummer = new TextInput(getKonto().getKontonummer(),HBCIProperties.HBCI_KTO_MAXLENGTH_HARD);
+		kontonummer = new TextInput(getKonto().getKontonummer(),HBCIProperties.HBCI_KTO_MAXLENGTH_SOFT);
     // BUGZILLA 280
     kontonummer.setValidChars(HBCIProperties.HBCI_KTO_VALIDCHARS);
     kontonummer.setMandatory(true);

--- a/src/de/willuhn/jameica/hbci/server/Converter.java
+++ b/src/de/willuhn/jameica/hbci/server/Converter.java
@@ -493,6 +493,31 @@ public class Converter
     k.acctype    = accType != null ? accType.toString() : null;
     return k;  	
   }
+  
+  /**
+   * Konvertiert ein Hibiscus-Konto in ein HBCI4Java Konto.
+   * Spezielle Funktion für die Saldenabfrage eines Kreditkartenkonto
+   * bei der Targobank. Die 16 stellige Kartennummer wird als Pseudo-IBAN dargestellt.
+   * @param konto unser Konto.
+   * @return das HBCI4Java Konto.
+   * @throws RemoteException
+   */
+  public static Konto HibiscusKonto2HBCIKontoTargoBankKK(de.willuhn.jameica.hbci.rmi.Konto konto) throws RemoteException
+  {
+    org.kapott.hbci.structures.Konto k = new org.kapott.hbci.structures.Konto(konto.getBLZ(),konto.getKontonummer());
+    k.country    = "DE";
+    k.curr       = konto.getWaehrung();
+    k.customerid = konto.getKundennummer();
+    k.type       = konto.getBezeichnung(); // BUGZILLA 338
+    k.name       = konto.getName();
+    k.subnumber  = konto.getUnterkonto(); // BUGZILLA 355
+    k.iban       = "DE0000" + konto.getKontonummer(); // Stellt die Kreditkartennummer als IBAN dar. Ohne Prüfziffer!
+    k.bic        = konto.getBic();
+
+    Integer accType = konto.getAccountType();
+    k.acctype    = accType != null ? accType.toString() : null;
+    return k;   
+  }
 
   /**
    * Konvertiert ein HBCI4Java-Konto in ein Hibiscus Konto.

--- a/src/de/willuhn/jameica/hbci/server/KontoImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/KontoImpl.java
@@ -98,7 +98,7 @@ public class KontoImpl extends AbstractHibiscusDBObject implements Konto
       // BUGZILLA 280
       HBCIProperties.checkChars(getBLZ(), HBCIProperties.HBCI_BLZ_VALIDCHARS);
       HBCIProperties.checkChars(getKontonummer(),HBCIProperties.HBCI_KTO_VALIDCHARS);
-      HBCIProperties.checkLength(getKontonummer(), HBCIProperties.HBCI_KTO_MAXLENGTH_HARD);
+      HBCIProperties.checkLength(getKontonummer(), HBCIProperties.HBCI_KTO_MAXLENGTH_SOFT);
       HBCIProperties.checkLength(getUnterkonto(), HBCIProperties.HBCI_ID_MAXLENGTH);
 
       if (getKundennummer() == null || getKundennummer().length() == 0)

--- a/updates/update0070.java
+++ b/updates/update0070.java
@@ -1,0 +1,40 @@
+/**********************************************************************
+ *
+ * Copyright (c) by Olaf Willuhn
+ * All rights reserved
+ *
+ **********************************************************************/
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import de.willuhn.jameica.hbci.rmi.DBSupport;
+import de.willuhn.jameica.hbci.server.AbstractUpdate;
+import de.willuhn.jameica.hbci.server.DBSupportH2Impl;
+import de.willuhn.jameica.hbci.server.DBSupportMySqlImpl;
+import de.willuhn.jameica.hbci.server.DBSupportPostgreSQLImpl;
+
+
+/**
+ * Erweitert die Tabelle "aueberweisung" um die Spalte "instantpayment"
+ */
+public class update0070 extends AbstractUpdate
+{
+  private Map<Class<? extends DBSupport>,List<String>> statements = new HashMap()
+  {{
+    put(DBSupportH2Impl.class,        Arrays.asList("ALTER TABLE konto ALTER COLUMN kontonummer VARCHAR(16) NOT NULL;\n"));
+    put(DBSupportMySqlImpl.class,     Arrays.asList("ALTER TABLE konto CHANGE kontonummer kontonummer VARCHAR(16) NOT NULL;\n"));
+    put(DBSupportPostgreSQLImpl.class,Arrays.asList("ALTER TABLE konto ALTER COLUMN kontonummer TYPE VARCHAR(16), ALTER COLUMN kontonummer SET NOT NULL;\n"));
+  }};
+
+  /**
+   * @see de.willuhn.jameica.hbci.server.AbstractUpdate#getStatements(java.lang.Class)
+   */
+  @Override
+  protected List<String> getStatements(Class<? extends DBSupport> driverClass)
+  {
+    return statements.get(driverClass);
+  }
+}

--- a/updates/update0070.sql
+++ b/updates/update0070.sql
@@ -1,0 +1,5 @@
+-- ------------------------------------------------------------------------
+-- Vergroessert die Spalte kontonummer in der Tabelle konto auf 16 Zeichen
+-- Update auf DB Version 70
+-- ------------------------------------------------------------------------
+ALTER TABLE `konto` CHANGE `kontonummer` `kontonummer` VARCHAR(16) NOT NULL; 


### PR DESCRIPTION
Die Targobank bietet die Umsatz- und Saldenabfrage für ihre
Kreditkartenkonten per HBCI/FinTS 3.0 an.
Dabei verwendet Sie als Kontonummer die 16 stellige Kreditkartennummer.
=> Kontonummer von 15 auf 16 Stellen erweitert 
=> Hard- und Soft-Limit Abfragen angepasst

Für die Saldenabfrage per HKSAL wird eine IBAN benötigt. Die Targobank
benutzt dazu eine nicht gültige IBAN in dem Format DE00 00 + KK-Nummer.
=> Abfrage beim Salden-Job ob Targobank BLZ und Kontotyp Kreditkarte ist => dann spezielle Konto-Konvert-Funktion.

Update-Dateien für DB Anpassung angepasst. Hab aber keine Ahnung ob die funktionieren....