### PR TITLE
Gläubiger-ID in der Datenbank zu Umsätzen ergänzen und aus hbci4java ergänzen

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -23,7 +23,7 @@
 	<classpathentry kind="lib" path="lib/itext-pdfa-5.5.2.jar"/>
 	<classpathentry kind="lib" path="lib/itextpdf-5.5.2.jar"/>
 	<classpathentry kind="lib" path="lib/konik/validation-api-1.1.0.Final.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/hbci4j-core-3.1.73-SNAPSHOT.jar" sourcepath="/hbci4j-core"/>
+	<classpathentry exported="true" kind="lib" path="lib/hbci4j-core-3.1.72.jar" sourcepath="/hbci4j-core"/>
 	<classpathentry kind="lib" path="lib/qrcodegen/qrcodegen-1.8.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/apache_httpclient/httpclient5-5.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/apache_httpclient/httpcore5-5.2.jar"/>

--- a/.classpath
+++ b/.classpath
@@ -23,7 +23,7 @@
 	<classpathentry kind="lib" path="lib/itext-pdfa-5.5.2.jar"/>
 	<classpathentry kind="lib" path="lib/itextpdf-5.5.2.jar"/>
 	<classpathentry kind="lib" path="lib/konik/validation-api-1.1.0.Final.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/hbci4j-core-3.1.72.jar" sourcepath="/hbci4j-core"/>
+	<classpathentry exported="true" kind="lib" path="lib/hbci4j-core-3.1.73-SNAPSHOT.jar" sourcepath="/hbci4j-core"/>
 	<classpathentry kind="lib" path="lib/qrcodegen/qrcodegen-1.8.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/apache_httpclient/httpclient5-5.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/apache_httpclient/httpcore5-5.2.jar"/>

--- a/sql/h2-create.sql
+++ b/sql/h2-create.sql
@@ -199,6 +199,7 @@ CREATE TABLE umsatz (
   endtoendid varchar(100),
   mandateid varchar(100),
   empfaenger_name2 varchar(255),
+  creditorid varchar(35),
   UNIQUE (id),
   PRIMARY KEY (id)
 );

--- a/sql/mysql-create.sql
+++ b/sql/mysql-create.sql
@@ -311,6 +311,7 @@ CREATE TABLE umsatz (
      , endtoendid varchar(100)
      , mandateid varchar(100)
      , empfaenger_name2 varchar(255)
+     , creditorid varchar(35)
      , UNIQUE (id)
      , PRIMARY KEY (id)
 ) ENGINE=InnoDB;

--- a/sql/postgresql-create.sql
+++ b/sql/postgresql-create.sql
@@ -178,7 +178,8 @@ CREATE TABLE umsatz (
   purposecode varchar(10),
   endtoendid varchar(100),
   mandateid varchar(100),
-  empfaenger_name2 varchar(255)
+  empfaenger_name2 varchar(255),
+  creditorid varchar(35)
 );
 
 CREATE TABLE umsatztyp (

--- a/src/de/willuhn/jameica/hbci/rmi/Umsatz.java
+++ b/src/de/willuhn/jameica/hbci/rmi/Umsatz.java
@@ -268,4 +268,19 @@ public interface Umsatz extends HibiscusTransfer, HibiscusDBObject, Checksum, Fl
    */
   public void setGegenkontoName2(String name) throws RemoteException;
 
+  /**
+   * Liefert die Gläubiger-ID des Gegenkontos.
+   * Nur bei Umsaetzen vorhanden, die per CAMT abgerufen werden.
+   * @return Gläubiger-ID des Gegenkontos
+   * @throws RemoteException
+   */
+  public String getCreditorId() throws RemoteException;
+
+  
+  /**
+   * Setzt die Gläubiger-ID des Gegenkontos.
+   * @param id Gläubiger-ID des Gegenkontos
+   * @throws RemoteException
+   */
+  public void setCreditorId(String id) throws RemoteException;
 }

--- a/src/de/willuhn/jameica/hbci/server/Converter.java
+++ b/src/de/willuhn/jameica/hbci/server/Converter.java
@@ -158,6 +158,16 @@ public class Converter
         if (mid != null && mid.length() > 0 && mid.length() <= 100)
           umsatz.setMandateId(mid);
       }
+      
+      //Wir checken mal, ob wir eine GläubigerID haben. Falls ja, tragen wir die gleich
+      //in das dedizierte Feld ein. Aber nur, wenn wir noch keine haben
+      String creditorId = umsatz.getCreditorId();
+      if (creditorId == null || creditorId.length() == 0)
+      {
+         creditorId = cleanSepaId(VerwendungszweckUtil.getTag(umsatz, Tag.CRED));
+         if (creditorId != null && creditorId.length() > 0 && creditorId.length() <= 35)
+           umsatz.setCreditorId(creditorId);
+      }
 
     }
     //

--- a/src/de/willuhn/jameica/hbci/server/Converter.java
+++ b/src/de/willuhn/jameica/hbci/server/Converter.java
@@ -170,7 +170,10 @@ public class Converter
     {
       umsatz.setGegenkonto(HBCIKonto2Address(u.other,u.isCamt));
       if (u.isCamt)
+      {
         umsatz.setGegenkontoName2(u.other.name2);
+        umsatz.setCreditorId(u.other.creditorid);
+      }
     }
 
     if (!HBCIProperties.HBCI_SEPA_PARSE_TAGS)

--- a/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzImpl.java
@@ -99,6 +99,8 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
       // Und die kommen schema-validiert im XML-Format. Hier extra nochmal zu pruefen, waere redundant.
       // Zumal die korrespondierenden Datebank-Felder vorsorglich ohnehin deutlich laenger definiert
       // sind als es das Schema zulaesst
+      
+      HBCIProperties.checkLength(getCreditorId(), HBCIProperties.HBCI_SEPA_CREDITORID_MAXLENGTH);
 		}
 		catch (RemoteException e)
 		{
@@ -781,6 +783,7 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
     copy.setPurposeCode(this.getPurposeCode());
     copy.setEndToEndId(this.getEndToEndId());
     copy.setMandateId(this.getMandateId());
+    copy.setCreditorId(this.getCreditorId());
 
     // Das Duplizieren von Umsatzbuchungen machen wir z.Bsp. dann, wenn ein User
     // per Hand eine Gegenbuchung erzeugt (per Kontextmenu-Eintrag "Gegenbuchung erzeugen auf...").
@@ -880,4 +883,23 @@ public class UmsatzImpl extends AbstractHibiscusDBObject implements Umsatz
   {
     this.setAttribute("empfaenger_name2",name);
   }
+  
+  /**
+   * @see de.willuhn.jameica.hbci.rmi.Umsatz#getCreditorId()
+   */
+  @Override
+  public String getCreditorId() throws RemoteException
+  {
+    return (String) this.getAttribute("creditorid");
+  }
+  
+  /**
+   * @see de.willuhn.jameica.hbci.rmi.Umsatz#setCreditorId(java.lang.String)
+   */
+  @Override
+  public void setCreditorId(String name) throws RemoteException
+  {
+    this.setAttribute("creditorid",name);
+  }
+  
 }

--- a/updates/update0071.sql
+++ b/updates/update0071.sql
@@ -1,0 +1,5 @@
+-- ----------------------------------------------------------------------
+-- Erweitert die Tabelle "umsatz" um eine Spalte "creditorid"
+-- ----------------------------------------------------------------------
+
+ALTER TABLE umsatz ADD creditorid varchar(35);


### PR DESCRIPTION
Ergänzung der Datenbank und der Umsatz-Klassen um Gläubiger-ID

Dies ist ein weiterer Schritt beim langsamen "Herantasten" an die Integration der Gläubiger-ID in Hibiscus.
Zur Datenbank:
* update0071.sql ergänzt die Tabelle Umsatz um die Spalte creditorid
* die create-*.sql werden auch um die entsprechende Spalte erweitert

Anpassungen im Source-Code
* hbci4j-core mit der creditorid wird eingebunden
* Umsatz und UmsatzImpl werden um die Methoden zum Lesen und Schreiben der creditorID ergänzt
* Plausi und copy-Methode wurden auch ergänzt
* Im Converter wird die GläubigerID aus der UmsatzLine aus hbci4java übernommen, wenn es ein Gegenkonto gibt und per camt abgerufen wurde
* An der Stelle wo die MandatsID aus dem MT940-Verwendungszweck bestimmt wird, wird auch entsprechend die Gläubiger-ID bestimmt.

Anmerkung:
* Bei der Übernahme der Gläubiger-ID aus hbci4java prüfe ich nicht auf die maximale Länge 35, da sowohl bei Version 001 als auch bei Version 009 das ID-Tag laut Schema auf 35 Zeichen begrenzt ist. Ich habe jetzt nicht die dazwischenliegenden Schemadateien geprüft, gehe aber davon aus, dass es da auch passen wird.
* Bei der Übernahme aus MT940 bin ich mir beim Parsen des Verwendungszweckes nicht sicher, ob ich das korrekt gemacht habe bzw. bestimmte Fälle übersehen habe.
* Die Übernahme auf die Oberfläche folgt noch.