### PR TITLE
DB-Version in den create-Skripten richtig setzen

### DIFF
--- a/sql/h2-create.sql
+++ b/sql/h2-create.sql
@@ -455,6 +455,6 @@ CREATE INDEX idx_umsatz_datum ON umsatz(datum);
 CREATE INDEX idx_umsatz_valuta ON umsatz(valuta);
 CREATE INDEX idx_umsatz_flags ON umsatz(flags);
   
-INSERT INTO version (name,version) values ('db',70);
+INSERT INTO version (name,version) values ('db',71);
   
 COMMIT;

--- a/sql/mysql-create.sql
+++ b/sql/mysql-create.sql
@@ -484,4 +484,4 @@ ALTER TABLE protokoll ADD INDEX (datum);
 ALTER TABLE ueberweisung ADD INDEX (termin);
 ALTER TABLE lastschrift ADD INDEX (termin);
 
-INSERT INTO version (name,version) values ('db',70);
+INSERT INTO version (name,version) values ('db',71);

--- a/sql/postgresql-create.sql
+++ b/sql/postgresql-create.sql
@@ -401,4 +401,4 @@ CREATE INDEX idx_umsatz_datum ON umsatz(datum);
 CREATE INDEX idx_umsatz_valuta ON umsatz(valuta);
 CREATE INDEX idx_umsatz_flags ON umsatz(flags);
   
-INSERT INTO version (name,version) values ('db',70);
+INSERT INTO version (name,version) values ('db',71);


### PR DESCRIPTION
Beim Test mit einer Neuinstallation ist mir aufgefallen, dass die DB-Version aus dem letzten PR nicht aktualisiert wurde. Deshalb kann eine Neuinstallation momentan nicht erfolgreich durchgeführt werden.
Die DB-Version 71 wird jetzt auch in den create-Skripten gesetzt.