### PR TITLE
GUI für Gläubiger-ID

### DIFF
--- a/lib/velocity/de.willuhn.jameica.hbci.rmi.Umsatz.csv.vm
+++ b/lib/velocity/de.willuhn.jameica.hbci.rmi.Umsatz.csv.vm
@@ -2,12 +2,12 @@
 #set($hideSaldo = $!hs.booleanValue())
 #set($uda       = $session.get("usage.display.all"))
 #set($fullUsage = $!uda.booleanValue())
-"#";"IBAN";"BIC";"Konto";"Gegenkonto";"Gegenkonto BLZ";"Gegenkonto Inhaber";"Betrag";"Valuta";"Datum";"Verwendungszweck";"Verwendungszweck 2";#if(!$hideSaldo)"Zwischensumme";#end"Primanota";"Kundenreferenz";"Kategorie";"Notiz";"Weitere Verwendungszwecke";"Art";"Vormerkbuchung";"End-to-End ID";"Kategorie-Pfad"
+"#";"IBAN";"BIC";"Konto";"Gegenkonto";"Gegenkonto BLZ";"Gegenkonto Inhaber";"Betrag";"Valuta";"Datum";"Verwendungszweck";"Verwendungszweck 2";#if(!$hideSaldo)"Zwischensumme";#end"Primanota";"Kundenreferenz";"Kategorie";"Notiz";"Weitere Verwendungszwecke";"Art";"Vormerkbuchung";"End-to-End ID";"Kategorie-Pfad";"Mandatsreferenz";"Gläubiger ID"
 #foreach($umsatz in $objects)
 #set($konto = $umsatz.Konto)
 #set($kat = "")
 #set($kat = $!{umsatz.UmsatzTyp.Name})
 #set($path = "")
 #set($path = $!{umsatz.getUmsatzTyp().getPath("/")})
-"$!{umsatz.ID}";"$!{konto.Iban}";"$!{konto.Bic}";"$!{konto.Bezeichnung}";"$!{umsatz.GegenkontoNummer}";"$!{umsatz.GegenkontoBLZ}";"$!{umsatz.getAttribute('empfaenger')}";"$!{decimalformat.format(${umsatz.Betrag})}";"$!{dateformat.format(${umsatz.Valuta})}";"$!{dateformat.format(${umsatz.Datum})}";#if($fullUsage)"$!{filter.escape($!{umsatz.Zweck})}"#else"$!{filter.escape($!{umsatz.getAttribute("SVWZ")})}"#end;"#if($fullUsage)$!{filter.escape($!{umsatz.Zweck2})}#end";#if(!$hideSaldo)"$!{decimalformat.format(${umsatz.Saldo})}";#end"$!{umsatz.Primanota}";"$!{umsatz.CustomerRef}";"$!{kat}";"$!{filter.escape($!{umsatz.Kommentar})}";"#if($fullUsage)#foreach($ewz in $umsatz.WeitereVerwendungszwecke)$!{filter.escape($!{ewz})} #end#end";"$!{umsatz.Art}";#if($umsatz.hasFlag(2))"ja"#end;"$!{umsatz.endToEndId}";"$!{path}"
+"$!{umsatz.ID}";"$!{konto.Iban}";"$!{konto.Bic}";"$!{konto.Bezeichnung}";"$!{umsatz.GegenkontoNummer}";"$!{umsatz.GegenkontoBLZ}";"$!{umsatz.getAttribute('empfaenger')}";"$!{decimalformat.format(${umsatz.Betrag})}";"$!{dateformat.format(${umsatz.Valuta})}";"$!{dateformat.format(${umsatz.Datum})}";#if($fullUsage)"$!{filter.escape($!{umsatz.Zweck})}"#else"$!{filter.escape($!{umsatz.getAttribute("SVWZ")})}"#end;"#if($fullUsage)$!{filter.escape($!{umsatz.Zweck2})}#end";#if(!$hideSaldo)"$!{decimalformat.format(${umsatz.Saldo})}";#end"$!{umsatz.Primanota}";"$!{umsatz.CustomerRef}";"$!{kat}";"$!{filter.escape($!{umsatz.Kommentar})}";"#if($fullUsage)#foreach($ewz in $umsatz.WeitereVerwendungszwecke)$!{filter.escape($!{ewz})} #end#end";"$!{umsatz.Art}";#if($umsatz.hasFlag(2))"ja"#end;"$!{umsatz.endToEndId}";"$!{path}";"$!{umsatz.mandateId}";"$!{umsatz.creditorId}"
 #end

--- a/lib/velocity/de.willuhn.jameica.hbci.rmi.Umsatz.html.vm
+++ b/lib/velocity/de.willuhn.jameica.hbci.rmi.Umsatz.html.vm
@@ -181,6 +181,8 @@
         <th>Primanota</th>
         <th>Referenz</th>
         <th>Vormerkbuchung</th>
+        <th>Mandatsreferenz</th>
+        <th>Gläubiger ID</th>
       </tr>
       
       #foreach($t in $objects)
@@ -209,6 +211,8 @@
           <td>$!t.primanota</td>
           <td>$!t.customerRef</td>
           <td>#if(!$umsatz.hasFlag(2))ja#end</td>
+          <td>$!t.mandateId</td>
+          <td>$!t.creditorId</td>
         </tr>
       #end
     </table>

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -79,6 +79,7 @@ public class UmsatzDetailControl extends AbstractControl
 	private TextInput endToEndId  = null;
   private TextInput mandateId   = null;
 	private TextInput gvcode      = null;
+	private TextInput creditorId  = null;
   
   private Input kommentar       = null;
   
@@ -428,10 +429,33 @@ public class UmsatzDetailControl extends AbstractControl
      this.mandateId = new TextInput(mref,HBCIProperties.HBCI_SEPA_MANDATEID_MAXLENGTH);
      this.mandateId.setValidChars(HBCIProperties.HBCI_SEPA_VALIDCHARS);
      this.mandateId.setEnabled(false);
-
    }
    return this.mandateId;
  }
+ 
+  /**
+   * Liefert ein Eingabe-Feld für die Gläubiger-ID.
+   * @return Eingabe-Feld
+   * @throws RemoteException
+   */
+  public Input getCreditorId() throws RemoteException
+  {
+    if (this.creditorId == null)
+    {
+      String credId = StringUtils.trimToNull(getUmsatz().getCreditorId());
+      
+      // Fuer die Abwaertskompatibilitaet (TODO: ist dies notwendig?)
+      if (credId == null)
+        credId = VerwendungszweckUtil.getTag(getUmsatz(), Tag.CRED);
+      
+      this.creditorId = new TextInput(credId, HBCIProperties.HBCI_SEPA_CREDITORID_MAXLENGTH);
+      this.creditorId.setValidChars(HBCIProperties.HBCI_SEPA_VALIDCHARS); //TODO: korrekt?
+      this.creditorId.setName(i18n.tr("Gläubiger ID"));
+      this.creditorId.setEnabled(false);
+    }
+    return this.creditorId;
+  }
+ 
 
 	/**
 	 * Liefert ein Eingabe-Feld fuer den GV-Code.

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailEditControl.java
@@ -267,6 +267,18 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
       input.setEnabled(true);
     return input;
 	}
+	
+	/**
+	 * @see de.willuhn.jameica.hbci.gui.controller.UmsatzDetailControl#getCreditorId()
+	 */
+	@Override
+	public Input getCreditorId() throws RemoteException
+	{
+	  Input input = super.getCreditorId();
+	  if (!input.isEnabled())
+	    input.setEnabled(true);
+	  return input;
+	}
 
   /**
    * @see de.willuhn.jameica.hbci.gui.controller.UmsatzDetailControl#getGvCode()
@@ -364,6 +376,7 @@ public class UmsatzDetailEditControl extends UmsatzDetailControl
       u.setPrimanota((String)getPrimanota().getValue());
       u.setEndToEndId((String)getEndToEndId().getValue());
       u.setMandateId((String)getMandateId().getValue());
+      u.setCreditorId((String)getCreditorId().getValue());
       
       Date valuta = (Date) getValuta().getValue();
       Date datum  = (Date) getDatum().getValue();

--- a/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
@@ -89,9 +89,10 @@ public abstract class AbstractUmsatzDetail extends AbstractView
     right.addHeadline(i18n.tr("Sonstige Informationen"));
     right.addLabelPair(i18n.tr("Art der Buchung"),              control.getArt());
     right.addInput(control.getEndToEndId());
+    right.addInput(control.getCreditorId());
     right.addLabelPair(i18n.tr("Kunden-/Mandatsreferenz"),      new MultiInput(control.getCustomerRef(),control.getMandateId()));
     right.addLabelPair(i18n.tr("Primanota/GV-Code"),new MultiInput(control.getPrimanota(),control.getGvCode()));
-
+    
     right.addHeadline(i18n.tr("Notizen"));
     right.addPart(control.getKommentar());
 

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporter.java
@@ -193,6 +193,7 @@ public class MT940UmsatzExporter implements Exporter
         m = addRef(out,m,VerwendungszweckUtil.Tag.EREF,u.getEndToEndId());
         m = addRef(out,m,VerwendungszweckUtil.Tag.KREF,u.getCustomerRef());
         m = addRef(out,m,VerwendungszweckUtil.Tag.MREF,u.getMandateId());
+        m = addRef(out,m,VerwendungszweckUtil.Tag.CRED,u.getCreditorId());
 
         String blz = StringUtils.trimToNull(u.getGegenkontoBLZ());
         String kto = StringUtils.trimToNull(u.getGegenkontoNummer());

--- a/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporterMerged.java
+++ b/src/de/willuhn/jameica/hbci/io/MT940UmsatzExporterMerged.java
@@ -161,6 +161,7 @@ public class MT940UmsatzExporterMerged extends MT940UmsatzExporter
         m = addRef(out,m,VerwendungszweckUtil.Tag.EREF,u.getEndToEndId());
         m = addRef(out,m,VerwendungszweckUtil.Tag.KREF,u.getCustomerRef());
         m = addRef(out,m,VerwendungszweckUtil.Tag.MREF,u.getMandateId());
+        m = addRef(out,m,VerwendungszweckUtil.Tag.CRED,u.getCreditorId());
         
         String blz = StringUtils.trimToNull(u.getGegenkontoBLZ());
         String kto = StringUtils.trimToNull(u.getGegenkontoNummer());

--- a/src/de/willuhn/jameica/hbci/server/Converter.java
+++ b/src/de/willuhn/jameica/hbci/server/Converter.java
@@ -67,7 +67,8 @@ public class Converter
     umsatz.setPurposeCode(u.purposecode);
     umsatz.setEndToEndId(u.endToEndId);
     umsatz.setMandateId(u.mandateId);
-
+    umsatz.setCreditorId(u.other.creditorid);
+    
     //BUGZILLA 67 http://www.willuhn.de/bugzilla/show_bug.cgi?id=67
     Saldo s = u.saldo;
     if (s != null)
@@ -164,6 +165,7 @@ public class Converter
       String creditorId = umsatz.getCreditorId();
       if (creditorId == null || creditorId.length() == 0)
       {
+        
         // Wir checken erst, ob wir die ID direkt im passenden Feld haben. Das ist nur
         // dann der Fall, wenn der Umsatz per CAMT empfangen wurde. Bei MT940 findet er sich
         // im Verwendungszweck


### PR DESCRIPTION
Hier kommt der GUI-Teil für die Gläubiger-ID (unter Anderem)

* Es fehlte noch eine Stelle, an der die creditorID bei der Umwandlung von hbci4java nach hibiscus gesetzt werden musste. Ohne dies blieb die Datenbankspalte leer.
* Auf dem UmsatzDetail-View wir es oben rechts in einer eigenen Zeile angezeigt.
* Evtl. wäre hier eine Umstrukturierung ganz gut, damit es z.B. mit der Mandats-ID in einer gleichen Zeile zusammen steht.
* CRED auch in MT940 Export aufnehmen
* In HTML- und CSV-Export Mandatsreferenz und Gläubiger-ID aufnehmen
* Bei allen Export-Varianten taucht es jetzt nur nicht in PDF auf.