### PR TITLE
Verwendungszweck mit : und + wurde nicht richtig getrennt

### DIFF
--- a/src/de/willuhn/jameica/hbci/server/VerwendungszweckUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/VerwendungszweckUtil.java
@@ -89,6 +89,11 @@ public class VerwendungszweckUtil
      */
     BIC,
     
+    /**
+     * TAN1 des Gegenkontos.
+     */
+    TAN1,
+    
     ;
     
     /**
@@ -210,7 +215,7 @@ public class VerwendungszweckUtil
     // Jetzt schauen wir, ob wir den Verwendungszweck per ":" noch weiter zerlegen koennen
     String svwz = result.get(Tag.SVWZ);
     if (StringUtils.trimToNull(svwz) != null)
-      result.putAll(parse(false,':',svwz));
+      result.putAll(parse(true,':',svwz));
     
     return result;
   }

--- a/src/de/willuhn/jameica/hbci/server/VerwendungszweckUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/VerwendungszweckUtil.java
@@ -90,9 +90,14 @@ public class VerwendungszweckUtil
     BIC,
     
     /**
-     * TAN1 des Gegenkontos.
+     * TAN1.
      */
     TAN1,
+    
+    /**
+     * TAN.
+     */
+    TAN,
     
     ;
     

--- a/test/de/willuhn/jameica/hbci/server/TestVerwendungszweckUtil.java
+++ b/test/de/willuhn/jameica/hbci/server/TestVerwendungszweckUtil.java
@@ -10,13 +10,14 @@
 
 package de.willuhn.jameica.hbci.server;
 
-import java.util.Map;
-
-import de.willuhn.jameica.hbci.server.VerwendungszweckUtil.Tag;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import de.willuhn.jameica.hbci.server.VerwendungszweckUtil.Tag;
 
 /**
  * Testet die Klasse "VerwendungszweckUtil".
@@ -228,7 +229,7 @@ public class TestVerwendungszweckUtil
     };
 
     Map<Tag,String> map = VerwendungszweckUtil.parse(test);
-    assertEquals("Das geht sogar gemischt IBAN: DE1234567890",map.get(Tag.SVWZ),"SVWZ falsch");
+    assertEquals("Das geht sogar gemischt",map.get(Tag.SVWZ),"SVWZ falsch");
     assertEquals("DE1234567890",map.get(Tag.IBAN),"IBAN falsch");
   }
 


### PR DESCRIPTION
Bei mir wurden die Verwendungszwecke nicht richtig getrennt. Mit dieser Änderung funktioniert es richtig.
Außerdem gibt es bei meiner Bank (GLS) noch den Tag TAN1, den habe ich hinzugefügt, damit der auch getrennt wird.