### PR TITLE
Fix 'mandateId' in UmsatzFormat.java

### DIFF
--- a/src/de/willuhn/jameica/hbci/io/csv/UmsatzFormat.java
+++ b/src/de/willuhn/jameica/hbci/io/csv/UmsatzFormat.java
@@ -75,7 +75,7 @@ public class UmsatzFormat implements Format<Umsatz>
       list.add(new Column("weitereVerwendungszwecke",i18n.tr("Weitere Verwendungszwecke"),i++,new ExtendedUsageSerializer()));
       list.add(new Column("art",i18n.tr("Art der Buchung"),i++,ts));
       list.add(new Column("endToEndId",i18n.tr("End-to-End ID"),i++,ts));
-      list.add(new Column("mandateid",i18n.tr("Kunden-/Mandatsreferenz"),i++,ts));
+      list.add(new Column("mandateId",i18n.tr("Kunden-/Mandatsreferenz"),i++,ts));
     
     }
     return this.profile;
@@ -120,7 +120,7 @@ public class UmsatzFormat implements Format<Umsatz>
             if (context != null && (context instanceof Konto))
               u.setKonto((Konto)context);
             
-            // Betr‰ge ggf. umkehren
+            // Betr√§ge ggf. umkehren
             if (event.profile.isInvert())
               u.setBetrag(-u.getBetrag());
           }


### PR DESCRIPTION
Ich glaube die Spalte 'mandateid' in der Liste der unterstützen Felder sollte vermutlich  'mandateId' heißen. Jedenfalls bekomme ich mit der aktuellen Version folgenden Fehler, wenn ich eine CSV Datei mit "Kunden-/Mandatsreferenz" importieren will:
```
[Sun Sep 08 20:19:34 CEST 2024][ERROR][bg-task:][de.willuhn.jameica.hbci.io.csv.CsvImporter.doImport] unable to apply property mandateid for line 19, value: 169500
java.rmi.RemoteException: unable to set attribute mandateid; nested exception is: 
	java.lang.NoSuchMethodException: <unbound>=UmsatzImpl.setMandateid("169500");
	at de.willuhn.datasource.BeanUtil.set(BeanUtil.java:161)
	at de.willuhn.datasource.BeanUtil.set(BeanUtil.java:139)
	at de.willuhn.jameica.hbci.io.csv.CsvImporter.doImport(CsvImporter.java:209)
	at de.willuhn.jameica.hbci.gui.dialogs.ImportDialog$3.run(ImportDialog.java:182)
	at de.willuhn.jameica.gui.GUI$7.run(GUI.java:1107)
Caused by: java.lang.NoSuchMethodException: <unbound>=UmsatzImpl.setMandateid("169500");
	at java.desktop/java.beans.Statement.invokeInternal(Statement.java:327)
	at java.desktop/java.beans.Statement$2.run(Statement.java:189)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
	at java.desktop/java.beans.Statement.invoke(Statement.java:186)
	at java.desktop/java.beans.Expression.getValue(Expression.java:155)
	at de.willuhn.datasource.BeanUtil.invoke(BeanUtil.java:250)
	at de.willuhn.datasource.BeanUtil.set(BeanUtil.java:153)
	... 4 more
```

Mit dem vorgeschlagenen Fix, funktioniert es.