### PR TITLE
UmsatzTypInput: Dropdown, Dialog-Auswahl und Pfadanzeige für große Ka…

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzDetailControl.java
@@ -30,6 +30,7 @@ import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.HBCIProperties;
 import de.willuhn.jameica.hbci.Settings;
 import de.willuhn.jameica.hbci.gui.ColorUtil;
+import de.willuhn.jameica.hbci.gui.dialogs.UmsatzTypListDialog;
 import de.willuhn.jameica.hbci.gui.input.AddressInput;
 import de.willuhn.jameica.hbci.gui.input.BICInput;
 import de.willuhn.jameica.hbci.gui.input.BLZInput;
@@ -84,6 +85,7 @@ public class UmsatzDetailControl extends AbstractControl
   private Input kommentar       = null;
   
   private SelectInput umsatzTyp = null;
+  private Input umsatzTypField  = null;
   
   private CheckboxInput zweckSwitch = null;
 
@@ -217,10 +219,27 @@ public class UmsatzDetailControl extends AbstractControl
     // Ansonsten alle - damit die zugeordnete Kategorie auch dann noch
     // noch angeboten wird, der User nachtraeglich den Kat-Typ geaendert hat.
     this.umsatzTyp = new UmsatzTypInput(ut,typ, false);
+    ((UmsatzTypInput) this.umsatzTyp).setShowPathName(true);
     this.umsatzTyp.setComment("");
     
     this.umsatzTyp.setEnabled(!u.hasFlag(Umsatz.FLAG_NOTBOOKED));
     return this.umsatzTyp;
+  }
+
+  /**
+   * Liefert das Kategorie-Eingabefeld als Dropdown mit zusaetzlichem Dialog-Button.
+   * @return Umsatz-Kategorie als Eingabefeld.
+   * @throws RemoteException
+   */
+  public Input getUmsatzTypField() throws RemoteException
+  {
+    if (this.umsatzTypField != null)
+      return this.umsatzTypField;
+
+    UmsatzTypInput input = (UmsatzTypInput) this.getUmsatzTyp();
+    this.umsatzTypField = input.getSelectionWithDialogButton(UmsatzTypListDialog.POSITION_CENTER,UmsatzTyp.TYP_EGAL);
+    this.umsatzTypField.setEnabled(input.isEnabled());
+    return this.umsatzTypField;
   }
 
   /**

--- a/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/UmsatzTypControl.java
@@ -26,11 +26,13 @@ import de.willuhn.jameica.gui.AbstractView;
 import de.willuhn.jameica.gui.GUI;
 import de.willuhn.jameica.gui.input.CheckboxInput;
 import de.willuhn.jameica.gui.input.ColorInput;
+import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.gui.input.TextAreaInput;
 import de.willuhn.jameica.gui.input.TextInput;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.Settings;
+import de.willuhn.jameica.hbci.gui.dialogs.UmsatzTypListDialog;
 import de.willuhn.jameica.hbci.gui.filter.KontoFilter;
 import de.willuhn.jameica.hbci.gui.input.KontoInput;
 import de.willuhn.jameica.hbci.gui.input.UmsatzTypInput;
@@ -58,6 +60,7 @@ public class UmsatzTypControl extends AbstractControl
   private CheckboxInput regex       = null;
   private SelectInput art           = null;
   private UmsatzTypInput parent     = null;
+  private Input parentField          = null;
   private TextInput kommentar       = null;
   private KontoInput konto          = null;
   private CheckboxInput skipReport  = null;
@@ -276,10 +279,27 @@ public class UmsatzTypControl extends AbstractControl
       return this.parent;
     
     this.parent = new UmsatzTypInput((UmsatzTyp)getUmsatzTyp().getParent(),getUmsatzTyp(),UmsatzTyp.TYP_EGAL, false);
+    this.parent.setShowPathName(true);
     this.parent.setComment("");
     return this.parent;
   }
   
+  /**
+   * Liefert die Eltern-Kategorie als Dropdown mit zusaetzlichem Dialog-Button.
+   * @return Auswahlfeld.
+   * @throws RemoteException
+   */
+  public Input getParentField() throws RemoteException
+  {
+    if (this.parentField != null)
+      return this.parentField;
+
+    UmsatzTypInput input = this.getParent();
+    this.parentField = input.getSelectionWithDialogButton(UmsatzTypListDialog.POSITION_CENTER,UmsatzTyp.TYP_EGAL);
+    this.parentField.setEnabled(input.isEnabled());
+    return this.parentField;
+  }
+
   /**
    * Liefert ein Auswahlfeld fuer das Konto.
    * @return Auswahl-Feld.

--- a/src/de/willuhn/jameica/hbci/gui/input/UmsatzTypInput.java
+++ b/src/de/willuhn/jameica/hbci/gui/input/UmsatzTypInput.java
@@ -17,17 +17,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ControlAdapter;
+import org.eclipse.swt.events.ControlEvent;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
 import de.willuhn.datasource.rmi.ResultSetExtractor;
+import de.willuhn.jameica.gui.input.ButtonInput;
+import de.willuhn.jameica.gui.input.Input;
 import de.willuhn.jameica.gui.input.SelectInput;
 import de.willuhn.jameica.hbci.HBCI;
 import de.willuhn.jameica.hbci.Settings;
+import de.willuhn.jameica.hbci.gui.dialogs.UmsatzTypListDialog;
 import de.willuhn.jameica.hbci.rmi.UmsatzTyp;
 import de.willuhn.jameica.hbci.server.UmsatzTypBean;
 import de.willuhn.jameica.hbci.server.UmsatzTypUtil;
 import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
 import de.willuhn.logging.Logger;
 import de.willuhn.util.I18N;
 
@@ -37,10 +49,15 @@ import de.willuhn.util.I18N;
 public class UmsatzTypInput extends SelectInput
 {
   private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+  private final static String DATAKEY_RESIZE_LISTENER = "jameica.hbci.umsatztypinput.path.listener";
 
   private boolean haveComments      = false;
   private boolean haveCustomComment = false;
   private boolean haveAutoComment   = false;
+  private boolean showPathName      = false;
+  private Combo combo               = null;
+  private int pathDisplayWidth      = -1;
+  private boolean refreshingPath    = false;
 
   /**
    * ct.
@@ -129,6 +146,16 @@ public class UmsatzTypInput extends SelectInput
 
     super.setPreselected(preselected);
   }
+
+  /**
+   * Aktiviert optional die Anzeige des vollstaendigen Pfads der Kategorie.
+   * @param showPathName true, wenn statt eingerueckter Bezeichnung der volle Pfad angezeigt werden soll.
+   */
+  public void setShowPathName(boolean showPathName)
+  {
+    this.showPathName = showPathName;
+    this.refreshPathDisplay(); // Anzeige bei bereits gezeichneter Combo aktualisieren
+  }
   
   /**
    * @see de.willuhn.jameica.gui.input.SelectInput#getValue()
@@ -138,6 +165,30 @@ public class UmsatzTypInput extends SelectInput
   {
     UmsatzTypBean b = (UmsatzTypBean) super.getValue();
     return b != null ? b.getTyp() : null;
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.input.SelectInput#format(java.lang.Object)
+   */
+  @Override
+  protected String format(Object bean)
+  {
+    if (!this.showPathName || !(bean instanceof UmsatzTypBean))
+      return super.format(bean);
+
+    try
+    {
+      String path = ((UmsatzTypBean) bean).getPathName();
+      String s = StringUtils.trimToNull(path);
+      if (s != null)
+        return this.abbreviateLeadingToFit(s);
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to format category path",e);
+    }
+
+    return super.format(bean);
   }
   
   /**
@@ -187,6 +238,243 @@ public class UmsatzTypInput extends SelectInput
     catch (Exception e)
     {
       Logger.error("unable to refresh comment",e);
+    }
+  }
+
+  /**
+   * @see de.willuhn.jameica.gui.input.SelectInput#getControl()
+   */
+  @Override
+  public Control getControl()
+  {
+    Control control = super.getControl();
+    if (!(control instanceof Combo))
+      return control;
+
+    this.combo = (Combo) control;
+    if (this.combo.getData(DATAKEY_RESIZE_LISTENER) == null)
+    {
+      this.combo.setData(DATAKEY_RESIZE_LISTENER,Boolean.TRUE);
+      this.combo.addControlListener(new ControlAdapter() {
+        @Override
+        public void controlResized(ControlEvent e)
+        {
+          refreshPathDisplay();
+        }
+      });
+      this.combo.addListener(SWT.Selection,e -> updateTooltip());
+    }
+    this.refreshPathDisplay();
+    this.updateTooltip();
+    return control;
+  }
+
+  /**
+   * Aktualisiert die Pfad-Darstellung in Abhaengigkeit von der aktuellen Feldbreite.
+   */
+  private void refreshPathDisplay()
+  {
+    if (!this.showPathName || this.refreshingPath)
+      return;
+
+    if (this.combo == null || this.combo.isDisposed())
+      return;
+
+    // Platz fuer den Pfeil der Combo plus etwas Innenabstand freilassen,
+    // damit rechts nichts unter dem Dropdown-Symbol abgeschnitten wird.
+    int arrowWidth = this.combo.getItemHeight();
+    int textPadding = 24;
+    int width = Math.max(0,this.combo.getClientArea().width - arrowWidth - textPadding);
+    if (width <= 0 || width == this.pathDisplayWidth)
+      return;
+
+    Object selectedBean = super.getValue();
+    try
+    {
+      this.refreshingPath = true;
+      this.pathDisplayWidth = width;
+      this.setList(this.getList());
+      super.setPreselected(selectedBean);
+      this.updateTooltip();
+    }
+    finally
+    {
+      this.refreshingPath = false;
+    }
+  }
+
+  /**
+   * Setzt den vollstaendigen Pfad als Tooltip, wenn die Pfad-Anzeige aktiv ist.
+   */
+  private void updateTooltip()
+  {
+    if (this.combo == null || this.combo.isDisposed())
+      return;
+
+    if (!this.showPathName)
+    {
+      this.combo.setToolTipText(null);
+      return;
+    }
+
+    try
+    {
+      Object selected = super.getValue();
+      if (!(selected instanceof UmsatzTypBean))
+      {
+        this.combo.setToolTipText(null);
+        return;
+      }
+
+      String path = ((UmsatzTypBean) selected).getPathName();
+      this.combo.setToolTipText(StringUtils.trimToNull(path));
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to update category tooltip",e);
+    }
+  }
+
+  /**
+   * Kuerzt den String linksbuendig so, dass das Ende (Basename) sichtbar bleibt.
+   * @param value der zu kuerzende Text.
+   * @return gekuerzter Text.
+   */
+  private String abbreviateLeadingToFit(String value)
+  {
+    if (!this.showPathName)
+      return value;
+
+    if (this.combo == null || this.combo.isDisposed() || this.pathDisplayWidth <= 0)
+      return value;
+
+    GC gc = new GC(this.combo);
+    try
+    {
+      Point full = gc.textExtent(value);
+      if (full.x <= this.pathDisplayWidth)
+        return value;
+
+      final String prefix = "...";
+      int prefixWidth = gc.textExtent(prefix).x;
+      if (prefixWidth >= this.pathDisplayWidth)
+        return prefix;
+
+      int left = 0;
+      int right = value.length();
+      while (left < right)
+      {
+        int mid = (left + right) / 2;
+        String candidate = prefix + value.substring(mid);
+        if (gc.textExtent(candidate).x <= this.pathDisplayWidth)
+          right = mid;
+        else
+          left = mid + 1;
+      }
+
+      return prefix + value.substring(Math.min(left,value.length()));
+    }
+    finally
+    {
+      gc.dispose();
+    }
+  }
+
+  /**
+   * Liefert ein Eingabefeld bestehend aus Selectbox und zusaetzlichem Dialog-Button.
+   * @param position Position des Dialogs.
+   * @param typ Filter auf Kategorie-Typen fuer den Dialog.
+   * @return kombiniertes Eingabefeld.
+   */
+  public Input getSelectionWithDialogButton(int position, int typ)
+  {
+    return new UmsatzTypDialogButtonInput(position,typ);
+  }
+
+  /**
+   * Loest ein Selection-Event auf der Selectbox aus.
+   */
+  private void fireSelection()
+  {
+    try
+    {
+      if (getParent() == null || getParent().isDisposed())
+        return;
+      Control control = getControl();
+      if (control == null || control.isDisposed())
+        return;
+      control.notifyListeners(SWT.Selection,new Event());
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to fire selection event",e);
+    }
+  }
+
+  /**
+   * Wrapper aus Auswahlfeld plus "..."-Button zum Starten des Kategorie-Dialogs.
+   */
+  private class UmsatzTypDialogButtonInput extends ButtonInput
+  {
+    private final int position;
+    private final int typ;
+
+    private UmsatzTypDialogButtonInput(int position, int typ)
+    {
+      this.position = position;
+      this.typ = typ;
+      this.setButtonText("...");
+      this.addButtonListener(new Listener()
+      {
+        public void handleEvent(Event event)
+        {
+          try
+          {
+            UmsatzTyp current = (UmsatzTyp) UmsatzTypInput.this.getValue();
+            if (current == UmsatzTypUtil.UNASSIGNED)
+              current = null;
+
+            UmsatzTypListDialog d = new UmsatzTypListDialog(UmsatzTypDialogButtonInput.this.position,current,UmsatzTypDialogButtonInput.this.typ);
+            UmsatzTyp selected = (UmsatzTyp) d.open();
+            UmsatzTypInput.this.setValue(selected);
+            refreshComment();
+            fireSelection();
+          }
+          catch (OperationCanceledException oce)
+          {
+            Logger.debug("operation cancelled");
+          }
+          catch (Exception e)
+          {
+            Logger.error("unable to choose category",e);
+          }
+        }
+      });
+    }
+
+    /**
+     * @see de.willuhn.jameica.gui.input.ButtonInput#getClientControl(org.eclipse.swt.widgets.Composite)
+     */
+    public Control getClientControl(Composite parent)
+    {
+      UmsatzTypInput.this.paint(parent);
+      return UmsatzTypInput.this.getParent();
+    }
+
+    /**
+     * @see de.willuhn.jameica.gui.input.Input#getValue()
+     */
+    public Object getValue()
+    {
+      return UmsatzTypInput.this.getValue();
+    }
+
+    /**
+     * @see de.willuhn.jameica.gui.input.Input#setValue(java.lang.Object)
+     */
+    public void setValue(Object value)
+    {
+      UmsatzTypInput.this.setValue(value);
     }
   }
 }

--- a/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/KontoauszugList.java
@@ -56,6 +56,7 @@ import de.willuhn.jameica.hbci.gui.action.KontoFetchUmsaetze;
 import de.willuhn.jameica.hbci.gui.action.UmsatzDetail;
 import de.willuhn.jameica.hbci.gui.action.UmsatzExport;
 import de.willuhn.jameica.hbci.gui.dialogs.AdresseAuswahlDialog;
+import de.willuhn.jameica.hbci.gui.dialogs.UmsatzTypListDialog;
 import de.willuhn.jameica.hbci.gui.dialogs.UmsatzTypNewDialog;
 import de.willuhn.jameica.hbci.gui.filter.KontoFilter;
 import de.willuhn.jameica.hbci.gui.formatter.IbanFormatter;
@@ -108,6 +109,7 @@ public class KontoauszugList extends UmsatzList
   private DateInput end                = null;
   private RangeInput range             = null;
   private UmsatzTypInput kategorie     = null;
+  private Input kategorieAuswahl       = null;
   private CheckboxInput subKategorien  = null;
 
   // Gegenkonto/Betrag
@@ -177,7 +179,7 @@ public class KontoauszugList extends UmsatzList
       
       Container left = new SimpleContainer(columns.getComposite());
       left.addLabelPair(i18n.tr("Konto"),                   this.getKontoAuswahl());
-      left.addLabelPair(i18n.tr("Kategorie"),               this.getKategorie());
+      left.addLabelPair(i18n.tr("Kategorie"),               this.getKategorieAuswahl());
       left.addCheckbox(this.getSubKategorien(),i18n.tr("Untergeordnete Kategorien einbeziehen"));
       
       Container right = new SimpleContainer(columns.getComposite());
@@ -397,6 +399,7 @@ public class KontoauszugList extends UmsatzList
     if (preset == null || (preset.getID() == null && preset != UmsatzTypUtil.UNASSIGNED)) // // ID ist NULL, wenn sie zwischenzeitlich geloescht wurde
       preset = null; 
     this.kategorie = new UmsatzTypInput(preset,UmsatzTyp.TYP_EGAL, true);
+    this.kategorie.setShowPathName(true);
     this.kategorie.setPleaseChoose(i18n.tr("<Alle Kategorien>"));
     this.kategorie.setComment("");
     this.kategorie.addListener(this.listener);
@@ -406,20 +409,42 @@ public class KontoauszugList extends UmsatzList
     {
       public void handleEvent(Event event)
       {
-        try
-        {
-          getSubKategorien().setEnabled(kategorie.getValue() != null);
-        }
-        catch (Exception e)
-        {
-          Logger.error("unable to update checkbox",e);
-        }
+        updateSubKategorienEnabled();
       }
     });
     
     return this.kategorie;
   }
   
+
+  /**
+   * Liefert die Kategorie-Auswahl als Dropdown mit zusaetzlichem Dialog-Button.
+   * @return Auswahlfeld.
+   * @throws RemoteException
+   */
+  private Input getKategorieAuswahl() throws RemoteException
+  {
+    if (this.kategorieAuswahl != null)
+      return this.kategorieAuswahl;
+
+    this.kategorieAuswahl = this.getKategorie().getSelectionWithDialogButton(UmsatzTypListDialog.POSITION_CENTER,UmsatzTyp.TYP_EGAL);
+    return this.kategorieAuswahl;
+  }
+
+  /**
+   * Aktualisiert den Enabled-Status der Unterkategorien-Checkbox.
+   */
+  private void updateSubKategorienEnabled()
+  {
+    try
+    {
+      getSubKategorien().setEnabled(getKategorie().getValue() != null);
+    }
+    catch (Exception e)
+    {
+      Logger.error("unable to update checkbox",e);
+    }
+  }
   /**
    * Liefert eine Checkbox die angibt ob Unterkategorien ermittelt werden sollen.
    * @return Checkbox.
@@ -805,6 +830,7 @@ public class KontoauszugList extends UmsatzList
       getKontoAuswahl().setValue(null);
       getKategorie().setValue(null);
       getSubKategorien().setValue(Boolean.FALSE);
+      updateSubKategorienEnabled();
       getGegenkontoNummer().setText("");
       getGegenkontoBLZ().setValue(null);
       getGegenkontoName().setValue(null);

--- a/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/AbstractUmsatzDetail.java
@@ -98,7 +98,7 @@ public abstract class AbstractUmsatzDetail extends AbstractView
 
     SimpleContainer bottom = new SimpleContainer(getParent(),true);
     bottom.addSeparator();
-    bottom.addLabelPair(i18n.tr("Kategorie"),                   control.getUmsatzTyp());
+    bottom.addLabelPair(i18n.tr("Kategorie"),                   control.getUmsatzTypField());
     bottom.addHeadline(i18n.tr("Verwendungszweck"));
     bottom.addPart(control.getZweck());
     bottom.addInput(control.getZweckSwitch());

--- a/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypDetail.java
+++ b/src/de/willuhn/jameica/hbci/gui/views/UmsatzTypDetail.java
@@ -49,7 +49,7 @@ public class UmsatzTypDetail extends AbstractView
     
     left.addHeadline(i18n.tr("Eigenschaften"));
     left.addLabelPair(i18n.tr("Bezeichnung"), control.getName());
-    left.addLabelPair(i18n.tr("Übergeordnete Kategorie"), control.getParent());
+    left.addLabelPair(i18n.tr("Übergeordnete Kategorie"), control.getParentField());
     
     left.addHeadline(i18n.tr("Zuordnung der Umsätze"));
     left.addInput(control.getKonto());


### PR DESCRIPTION
…tegorie-Bäume


Hallo Olaf,

nachdem Du doch tatsächlich meine "Extrameile", n autarke Branches pro PR, mit einem einzigen Merge Feature Branch -> Master obsolet gemacht hast - sequentiell querabhängige PRs hatte ich initial im Februar schon  :)


....  gerne wie angeregt von Dir:  **"2 in 1" Ansatz, damit Nutzer mit nur wenig Kategorien keine Mehrklicks haben**

**Aber**:  

Mein Ausgangspunkt war ein Usability-Enhancement für große Umsatzkategorie-Bäume, mit bewusst vorhandenen Dopplungen auf Baum- und Blattebene!

Beispiel Baumkontext:
`Saldo privat/Feste Ausgaben/Mobilität/<AutoName>`
`Saldo privat/Variable Ausgaben/Mobilität/<AutoName>` mit jeweils festen/variablen Unterkategorien.

Beispiel Blattebene: Kategorien wie `.../Reparaturen` können in n Zweigen vorkommen.

Mein Vorschlag hatte hier das "Readonly-Feld" deshalb, da dieses den bei großen Bäumen mit Dopplungen äußerst wichtigen **Kategoriepfad** anzeigt. Nicht nur den Basename des Knoten oder Blatts, wie Deine originale DropDown.


Deinen Vorschag zu 100% aufgreifend, mit meinem Wunsch vereint, jetzt mein neuer Vorschlag:  

- Wie von Dir gewünscht: Bestehende direkte Auswahl (Dropdown)  erhalten
- Gleichzeitig Deine  vorhandene, gut bedienbare Dialog-Auswahl via Button ("...") zur Navigation im Baum wiederverwenden.
- Meine neue Erweiterung: Die DropDown zeigt jetzt neu pro Listenelement den absoluten Pfad. 
- "Responsive" gekürzt rechtsbündig, der "Basename" der Kategorie soll immer sichtbar bleiben:
<img width="715" height="50" alt="grafik" src="https://github.com/user-attachments/assets/1dc07e5d-7c49-4f11-b5e2-2db3ab0dfff3" />
<img width="453" height="49" alt="grafik" src="https://github.com/user-attachments/assets/d65df541-dfc5-478f-bcd1-517f7da69fa6" />

Nach Navigation oder automatischer Zuordnung per Pattern/Regex bleibt durch die Pfadanzeige der Kontext der gewählten Kategorie auf einen Blick sichtbar (mein Haupt-Use-Case).

Umsetzung zentral in UmsatzTypInput und Verwendung in:
- Umsatzübersicht (Kategoriefilter)
- Umsatz-Detail (Kategorie)
- Umsatzkategorie-Detail (Übergeordnete Kategorie)

Keine Änderung an Datenbank, Matching-Logik oder Persistenz.



P.S.: Eigentlich würde ich den absoluten Kategoriepfad auch gerne in der Tabelle "Umsätze" einbauen, Spalte "Kategorie" - ok für Dich? Wenn nicht zu aufwändig, "rechtsbündig", dieses Positionieren ist aber IMHO etwas GUI Hack...  Ich war etwas überrascht: Im Februar hattest Du meine PRs als gut strukturiert gelobt - jetzt scheinen sie Dir eher lästige Mehrarbeit "aufgezwzungen" zu haben? Da Hibiscus Dein Baby - bitte Hinweis, ich richte mich danach!