### PR TITLE
Sparquote und Einnahme/Ausgabe

### DIFF
--- a/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
+++ b/src/de/willuhn/jameica/hbci/gui/controller/EinnahmeAusgabeControl.java
@@ -57,6 +57,7 @@ import de.willuhn.jameica.hbci.server.EinnahmeAusgabe;
 import de.willuhn.jameica.hbci.server.EinnahmeAusgabeTreeNode;
 import de.willuhn.jameica.hbci.server.KontoUtil;
 import de.willuhn.jameica.hbci.server.Range.Category;
+import de.willuhn.jameica.hbci.server.UmsatzTypUtil;
 import de.willuhn.jameica.hbci.server.UmsatzUtil;
 import de.willuhn.jameica.hbci.server.Value;
 import de.willuhn.jameica.messaging.StatusBarMessage;
@@ -416,6 +417,8 @@ public class EinnahmeAusgabeControl extends AbstractControl
     {
       final Umsatz u = (Umsatz) umsaetze.next();
       if (u.hasFlag(Umsatz.FLAG_NOTBOOKED))
+        continue;
+      if (UmsatzTypUtil.isExcludedFromReports(u.getUmsatzTyp()))
         continue;
 
       umsatzList.add(u);

--- a/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/SparQuote.java
@@ -60,6 +60,7 @@ import de.willuhn.jameica.hbci.rmi.Konto;
 import de.willuhn.jameica.hbci.rmi.Umsatz;
 import de.willuhn.jameica.hbci.server.Range;
 import de.willuhn.jameica.hbci.server.Range.Category;
+import de.willuhn.jameica.hbci.server.UmsatzTypUtil;
 import de.willuhn.jameica.hbci.server.UmsatzUtil;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
@@ -415,10 +416,47 @@ public class SparQuote implements Part
     final Date end     = (Date) this.getTo().getValue();
     final int monate   = ((Integer) this.getMonatAuswahl().getValue()).intValue();
     final int stichtag = ((Integer) this.getTagAuswahl().getValue()).intValue();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Relevante Umsaetze laden. Ignorierte Kategorien duerfen auch die
+    // automatische Ermittlung des Auswertungsbeginns nicht beeinflussen.
+    DBIterator umsaetze = UmsatzUtil.getUmsaetze();
+    Object o = getKontoAuswahl().getValue();
+    if (o != null && (o instanceof Konto))
+      umsaetze.addFilter("konto_id = " + ((Konto) o).getID());
+    else if (o != null && (o instanceof String))
+      umsaetze.addFilter("konto_id in (select id from konto where kategorie = ?)", (String) o);
+
+    if (start != null)
+      umsaetze.addFilter("datum >= ?", new java.sql.Date(start.getTime()));
+
+    final List<Umsatz> umsatzList = new ArrayList<Umsatz>();
+    while (umsaetze.hasNext())
+    {
+      Umsatz u = (Umsatz) umsaetze.next();
+      Date date = u.getDatum();
+      if (date == null)
+      {
+        Logger.debug("no date found for umsatz, skipping record");
+        continue;
+      }
+      if (end != null && date.after(end))
+        // Keine Umsaetze nach dem gewuenschten Zeitraum verarbeiten
+        break;
+      if (UmsatzTypUtil.isExcludedFromReports(u.getUmsatzTyp()))
+        // Keine Umsaetze, wenn die Kategorie von der Auswertung ausgeschlossen ist
+        continue;
+
+      umsatzList.add(u);
+    }
+    ////////////////////////////////////////////////////////////////////////////
     
     ////////////////////////////////////////////////////////////////////////////
     // Wir iterieren erstmal ueber den Zeitraum und erzeugen die passenden Time-Boxen
-    Date from = start != null ? start : UmsatzUtil.getOldest(getKontoAuswahl().getValue());
+    Date from = start;
+    if (from == null && !umsatzList.isEmpty())
+      from = umsatzList.get(0).getDatum();
+
     from          = DateUtil.startOfDay(from != null ? from : new Date());
     final Date to = DateUtil.endOfDay(end != null ? end : new Date());
     
@@ -474,30 +512,9 @@ public class SparQuote implements Part
     ////////////////////////////////////////////////////////////////////////////
     // Iterieren ueber die Umsaetze und einsortieren in die passende Timebox
 
-    DBIterator umsaetze = UmsatzUtil.getUmsaetze();
-    Object o = getKontoAuswahl().getValue();
-    if (o != null && (o instanceof Konto))
-      umsaetze.addFilter("konto_id = " + ((Konto) o).getID());
-    else if (o != null && (o instanceof String))
-      umsaetze.addFilter("konto_id in (select id from konto where kategorie = ?)", (String) o);
-
-    if (start != null)
-      umsaetze.addFilter("datum >= ?", new java.sql.Date(start.getTime()));
-
-    while (umsaetze.hasNext())
+    for (Umsatz u:umsatzList)
     {
-      Umsatz u = (Umsatz) umsaetze.next();
       Date date = u.getDatum();
-      if (date == null)
-      {
-        Logger.debug("no date found for umsatz, skipping record");
-        continue;
-      } else if (end != null && date.after(end))
-      {
-        //keine Umsätze nach dem gwünschten Zeitraum verarbeiten
-        break;
-      }
-      
       UmsatzEntry e = this.getEntry(date);
       if (e == null)
       {

--- a/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTree.java
+++ b/src/de/willuhn/jameica/hbci/gui/parts/UmsatzTree.java
@@ -45,6 +45,7 @@ import de.willuhn.jameica.hbci.messaging.NeueUmsaetze;
 import de.willuhn.jameica.hbci.rmi.Umsatz;
 import de.willuhn.jameica.hbci.rmi.UmsatzTyp;
 import de.willuhn.jameica.hbci.server.UmsatzTreeNode;
+import de.willuhn.jameica.hbci.server.UmsatzTypUtil;
 import de.willuhn.jameica.hbci.server.VerwendungszweckUtil.Tag;
 import de.willuhn.jameica.messaging.StatusBarMessage;
 import de.willuhn.jameica.system.Application;
@@ -224,14 +225,12 @@ public class UmsatzTree extends TreePart
    */
   private UmsatzTreeNode getNode(Map<String,UmsatzTreeNode> lookup,UmsatzTyp ut) throws RemoteException
   {
+    if (UmsatzTypUtil.isExcludedFromReports(ut))
+      return null;
+
     UmsatzTreeNode node = lookup.get(ut != null ? ut.getID() : null);
     if (node != null)
       return node; // haben wir schon.
-    
-    // "ut" null gibt es. Das ist der Fall, wenn ein Umsatz keiner Kategorie zugeordnet ist.
-    // Wir wollen hier aber geziehlt die raus haben, die nicht in den Auswertungen erscheinen sollen.
-    if (ut != null && ut.hasFlag(UmsatzTyp.FLAG_SKIP_REPORTS))
-      return null;
     
     // Neu anlegen
     node = new UmsatzTreeNode(ut);

--- a/src/de/willuhn/jameica/hbci/server/UmsatzTypUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/UmsatzTypUtil.java
@@ -82,6 +82,26 @@ public class UmsatzTypUtil
     }
     return i18n.tr("egal");
   }
+
+  /**
+   * Prueft, ob die Umsatz-Kategorie oder eine ihrer uebergeordneten Kategorien
+   * von Auswertungen ausgeschlossen ist.
+   * @param type die zu pruefende Umsatz-Kategorie oder NULL fuer nicht zugeordnete Umsaetze.
+   * @return true, wenn die Kategorie von Auswertungen ausgeschlossen ist.
+   * @throws RemoteException
+   */
+  public static boolean isExcludedFromReports(UmsatzTyp type) throws RemoteException
+  {
+    UmsatzTyp current = type;
+    for (int i=0;i<100 && current != null;++i)
+    {
+      if (current.hasFlag(UmsatzTyp.FLAG_SKIP_REPORTS))
+        return true;
+
+      current = (UmsatzTyp) current.getParent();
+    }
+    return false;
+  }
   
   /**
    * Liefert eine Liste aller Umsatz-Kategorien, sortiert nach Nummer und Name.


### PR DESCRIPTION
Mit dieser Änderung werden auch bei den Diagrammen Sparquote und Einnahme/Ausgaben Umsätze herausgefiltert, deren Kategorien auf "In Auswertungen ignorieren" gesetzt sind. 