### PR TITLE
"Synchronisierung starten" als Menüpunkt

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
         <item id="hibiscus.menu.transfer.sepasammelueb"  name="Neue Sammelüberweisung..." shortcut="ALT+W"    icon="sueberweisung.png"               action="de.willuhn.jameica.hbci.gui.action.SepaSammelUeberweisungNew" />
         <item id="hibiscus.menu.transfer.sepasammellast" name="Neue Sammellastschrift..." shortcut="ALT+F"    icon="slastschrift.png"                action="de.willuhn.jameica.hbci.gui.action.SepaSammelLastschriftNew" />
       </item>
+      <item id="hibiscus.menu.synchronize"               name="S&amp;ynchronisierung starten"                  icon="mail-send-receive.png"           action="de.willuhn.jameica.hbci.gui.action.SynchronizeStart" />
       <item id="hibiscus.menu.ibancalculator"            name="IBAN-Rechner"                                  icon="accessories-calculator.png"      action="de.willuhn.jameica.hbci.gui.action.IbanCalc" />
       <item id="hibiscus.menu.messages"                  name="&amp;Bank-Nachrichten"                         icon="dialog-information.png"          action="de.willuhn.jameica.hbci.gui.action.NachrichtList" />
       <item id="hibiscus.menu.settings"                  name="&amp;Einstellungen"                            icon="document-properties.png"         action="de.willuhn.jameica.hbci.gui.action.Settings" />

--- a/src/de/willuhn/jameica/hbci/gui/action/SynchronizeStart.java
+++ b/src/de/willuhn/jameica/hbci/gui/action/SynchronizeStart.java
@@ -1,0 +1,62 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Olaf Willuhn
+ * All rights reserved.
+ * 
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details. 
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci.gui.action;
+
+import java.util.List;
+
+import de.willuhn.jameica.gui.Action;
+import de.willuhn.jameica.hbci.HBCI;
+import de.willuhn.jameica.hbci.gui.parts.SynchronizeList;
+import de.willuhn.jameica.hbci.synchronize.Synchronization;
+import de.willuhn.jameica.messaging.StatusBarMessage;
+import de.willuhn.jameica.system.Application;
+import de.willuhn.jameica.system.OperationCanceledException;
+import de.willuhn.logging.Logger;
+import de.willuhn.util.ApplicationException;
+import de.willuhn.util.I18N;
+
+/**
+ * Startet die aktiven Synchronisierungsaufgaben.
+ */
+public class SynchronizeStart implements Action
+{
+  private final static I18N i18n = Application.getPluginLoader().getPlugin(HBCI.class).getResources().getI18N();
+
+  /**
+   * @see de.willuhn.jameica.gui.Action#handleAction(java.lang.Object)
+   */
+  @Override
+  public void handleAction(Object context) throws ApplicationException
+  {
+    try
+    {
+      final List<Synchronization> list = SynchronizeList.getActiveSyncs();
+      if (list.isEmpty())
+        throw new ApplicationException(i18n.tr("Keine Synchronisierungsaufgaben ausgew\u00E4hlt"));
+      
+      Synchronize sync = new Synchronize();
+      sync.handleAction(list);
+    }
+    catch (OperationCanceledException oce)
+    {
+      // ignore
+    }
+    catch (ApplicationException ae)
+    {
+      throw ae;
+    }
+    catch (Exception e)
+    {
+      Logger.error("error while synchronizing",e);
+      Application.getMessagingFactory().sendMessage(new StatusBarMessage(i18n.tr("Synchronisierung fehlgeschlagen: {0}",e.getMessage()),StatusBarMessage.TYPE_ERROR));
+    }
+  }
+}


### PR DESCRIPTION
"Synchronisierung starten" als Menüpunkt hinzufügt.
Dies ermöglicht mit dem passenden jameica-Patch, die Funktionalität über die neue Symbolleiste zu starten.