### PR TITLE
Kreditkartenumsätze dynamisch per DKKKU synchronisieren

### DIFF
--- a/src/de/willuhn/jameica/hbci/server/BPDUtil.java
+++ b/src/de/willuhn/jameica/hbci/server/BPDUtil.java
@@ -75,7 +75,12 @@ public class BPDUtil
     /**
      * Query fuer Abruf der Umsaetze im CAMT-Format.
      */
-    UmsatzCamt("KUmsZeitCamt","HKCAZ")
+    UmsatzCamt("KUmsZeitCamt","HKCAZ"),
+
+    /**
+     * Query fuer den Abruf von Kreditkartenumsaetzen per DKKKU.
+     */
+    KreditkartenUmsatz("KreditkartenUmsatz","DKKKU")
     
     ;
     

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIKreditkartenUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIKreditkartenUmsatzJob.java
@@ -40,68 +40,37 @@ public class HBCIKreditkartenUmsatzJob extends HBCIUmsatzJob
   public HBCIKreditkartenUmsatzJob(Konto konto, int timeRange, Integer maxEntries)
       throws ApplicationException, RemoteException
   {
-    this(konto,null,null,timeRange,maxEntries);
-  }
-
-  /**
-   * ct.
-   * @param konto das Kreditkartenkonto.
-   * @param dateFrom Beginn des expliziten Abrufzeitraums oder NULL.
-   * @param dateTo Ende des expliziten Abrufzeitraums oder NULL.
-   * @param timeRange maximaler Umsatzzeitraum laut BPD.
-   * @param maxEntries maximale Anzahl Eintraege oder NULL, wenn der Parameter
-   * von der Bank nicht unterstuetzt wird.
-   * @throws ApplicationException
-   * @throws RemoteException
-   */
-  public HBCIKreditkartenUmsatzJob(Konto konto, LocalDate dateFrom, LocalDate dateTo,
-                                   int timeRange, Integer maxEntries)
-      throws ApplicationException, RemoteException
-  {
     super(konto);
 
-    if ((dateFrom == null) != (dateTo == null))
-      throw new ApplicationException("Start- und Enddatum m\u00fcssen gemeinsam angegeben werden");
-
     final LocalDate today = LocalDate.now();
-    if (dateTo != null && dateTo.isAfter(today))
-      throw new ApplicationException("Das Enddatum darf nicht in der Zukunft liegen");
-
-    if (dateFrom != null && dateFrom.isAfter(dateTo))
-      throw new ApplicationException("Das Startdatum liegt nach dem Enddatum");
-
     if (maxEntries != null && (maxEntries.intValue() < 1 || maxEntries.intValue() > 9999))
-      throw new ApplicationException("Ung\u00fcltige maximale Anzahl Eintr\u00e4ge: " + maxEntries);
+      throw new ApplicationException(i18n.tr("Ung\u00fcltige maximale Anzahl Eintr\u00e4ge: {0}",maxEntries.toString()));
 
     String cardNumber = konto.getKontonummer();
     if (cardNumber == null || cardNumber.isBlank())
-      throw new ApplicationException("Das Kreditkartenkonto besitzt keine Kartennummer");
+      throw new ApplicationException(i18n.tr("Das Kreditkartenkonto besitzt keine Kartennummer"));
 
     setJobParam("cardnumber",cardNumber);
     String cardSubNumber = konto.getUnterkonto();
     if (cardSubNumber != null && !cardSubNumber.isBlank())
       setJobParam("cardsubnumber",cardSubNumber);
 
-    LocalDate effectiveFrom = dateFrom;
-    if (effectiveFrom == null)
-    {
-      java.util.Date saldoDate = konto.getSaldoDatum();
-      if (saldoDate != null)
-        effectiveFrom = new Date(saldoDate.getTime()).toLocalDate();
+    LocalDate effectiveFrom = null;
+    java.util.Date saldoDate = konto.getSaldoDatum();
+    if (saldoDate != null)
+      effectiveFrom = new Date(saldoDate.getTime()).toLocalDate();
 
-      int days = timeRange > 0 ? timeRange : HBCIProperties.UMSATZ_DEFAULT_DAYS;
-      LocalDate earliest = today.minusDays(days);
-      if (effectiveFrom == null || effectiveFrom.isBefore(earliest))
-        effectiveFrom = earliest;
-      if (effectiveFrom.isAfter(today))
-        effectiveFrom = today;
-      dateTo = today;
-    }
+    int days = timeRange > 0 ? timeRange : HBCIProperties.UMSATZ_DEFAULT_DAYS;
+    LocalDate earliest = today.minusDays(days);
+    if (effectiveFrom == null || effectiveFrom.isBefore(earliest))
+      effectiveFrom = earliest;
+    if (effectiveFrom.isAfter(today))
+      effectiveFrom = today;
 
     // DKKKU uses these fields in the actual bank request. Filtering the
     // Hibiscus database after the request would not trigger a backfill.
     setJobParam("startdate",Date.valueOf(effectiveFrom));
-    setJobParam("enddate",Date.valueOf(dateTo));
+    setJobParam("enddate",Date.valueOf(today));
     if (maxEntries != null)
       setJobParam("maxentries",maxEntries);
   }

--- a/src/de/willuhn/jameica/hbci/server/hbci/HBCIKreditkartenUmsatzJob.java
+++ b/src/de/willuhn/jameica/hbci/server/hbci/HBCIKreditkartenUmsatzJob.java
@@ -1,0 +1,117 @@
+/**********************************************************************
+ *
+ * Copyright (c) 2026 Franz Bettag
+ * All rights reserved.
+ *
+ * This software is copyrighted work licensed under the terms of the
+ * Jameica License.  Please consult the file "LICENSE" for details.
+ *
+ **********************************************************************/
+
+package de.willuhn.jameica.hbci.server.hbci;
+
+import java.rmi.RemoteException;
+import java.sql.Date;
+import java.time.LocalDate;
+
+import de.willuhn.jameica.hbci.HBCIProperties;
+import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.util.ApplicationException;
+
+/**
+ * Job fuer den Abruf von Kreditkartenumsaetzen per DKKKU.
+ */
+public class HBCIKreditkartenUmsatzJob extends HBCIUmsatzJob
+{
+  /**
+   * Standardwert fuer die maximale Anzahl Eintraege pro Antwort.
+   */
+  public final static int DEFAULT_MAX_ENTRIES = 999;
+
+  /**
+   * ct.
+   * @param konto das Kreditkartenkonto.
+   * @param timeRange maximaler Umsatzzeitraum laut BPD.
+   * @param maxEntries maximale Anzahl Eintraege oder NULL, wenn der Parameter
+   * von der Bank nicht unterstuetzt wird.
+   * @throws ApplicationException
+   * @throws RemoteException
+   */
+  public HBCIKreditkartenUmsatzJob(Konto konto, int timeRange, Integer maxEntries)
+      throws ApplicationException, RemoteException
+  {
+    this(konto,null,null,timeRange,maxEntries);
+  }
+
+  /**
+   * ct.
+   * @param konto das Kreditkartenkonto.
+   * @param dateFrom Beginn des expliziten Abrufzeitraums oder NULL.
+   * @param dateTo Ende des expliziten Abrufzeitraums oder NULL.
+   * @param timeRange maximaler Umsatzzeitraum laut BPD.
+   * @param maxEntries maximale Anzahl Eintraege oder NULL, wenn der Parameter
+   * von der Bank nicht unterstuetzt wird.
+   * @throws ApplicationException
+   * @throws RemoteException
+   */
+  public HBCIKreditkartenUmsatzJob(Konto konto, LocalDate dateFrom, LocalDate dateTo,
+                                   int timeRange, Integer maxEntries)
+      throws ApplicationException, RemoteException
+  {
+    super(konto);
+
+    if ((dateFrom == null) != (dateTo == null))
+      throw new ApplicationException("Start- und Enddatum m\u00fcssen gemeinsam angegeben werden");
+
+    final LocalDate today = LocalDate.now();
+    if (dateTo != null && dateTo.isAfter(today))
+      throw new ApplicationException("Das Enddatum darf nicht in der Zukunft liegen");
+
+    if (dateFrom != null && dateFrom.isAfter(dateTo))
+      throw new ApplicationException("Das Startdatum liegt nach dem Enddatum");
+
+    if (maxEntries != null && (maxEntries.intValue() < 1 || maxEntries.intValue() > 9999))
+      throw new ApplicationException("Ung\u00fcltige maximale Anzahl Eintr\u00e4ge: " + maxEntries);
+
+    String cardNumber = konto.getKontonummer();
+    if (cardNumber == null || cardNumber.isBlank())
+      throw new ApplicationException("Das Kreditkartenkonto besitzt keine Kartennummer");
+
+    setJobParam("cardnumber",cardNumber);
+    String cardSubNumber = konto.getUnterkonto();
+    if (cardSubNumber != null && !cardSubNumber.isBlank())
+      setJobParam("cardsubnumber",cardSubNumber);
+
+    LocalDate effectiveFrom = dateFrom;
+    if (effectiveFrom == null)
+    {
+      java.util.Date saldoDate = konto.getSaldoDatum();
+      if (saldoDate != null)
+        effectiveFrom = new Date(saldoDate.getTime()).toLocalDate();
+
+      int days = timeRange > 0 ? timeRange : HBCIProperties.UMSATZ_DEFAULT_DAYS;
+      LocalDate earliest = today.minusDays(days);
+      if (effectiveFrom == null || effectiveFrom.isBefore(earliest))
+        effectiveFrom = earliest;
+      if (effectiveFrom.isAfter(today))
+        effectiveFrom = today;
+      dateTo = today;
+    }
+
+    // DKKKU uses these fields in the actual bank request. Filtering the
+    // Hibiscus database after the request would not trigger a backfill.
+    setJobParam("startdate",Date.valueOf(effectiveFrom));
+    setJobParam("enddate",Date.valueOf(dateTo));
+    if (maxEntries != null)
+      setJobParam("maxentries",maxEntries);
+  }
+
+  /**
+   * @see de.willuhn.jameica.hbci.server.hbci.AbstractHBCIJob#getIdentifier()
+   */
+  @Override
+  public String getIdentifier()
+  {
+    return "KreditkartenUmsatz";
+  }
+}

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszug.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszug.java
@@ -11,7 +11,6 @@
 package de.willuhn.jameica.hbci.synchronize.hbci;
 
 import java.rmi.RemoteException;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,18 +42,6 @@ public class HBCISynchronizeJobKontoauszug extends SynchronizeJobKontoauszug imp
     Konto k              = (Konto) this.getContext(CTX_ENTITY);
     Boolean forceSaldo   = (Boolean) this.getContext(CTX_FORCE_SALDO);
     Boolean forceUmsatz  = (Boolean) this.getContext(CTX_FORCE_UMSATZ);
-    LocalDate dateFrom   = (LocalDate) this.getContext(CTX_DATE_FROM);
-    LocalDate dateTo     = (LocalDate) this.getContext(CTX_DATE_TO);
-    Integer maxEntries   = (Integer) this.getContext(CTX_MAX_ENTRIES);
-
-    if ((dateFrom == null) != (dateTo == null))
-      throw new ApplicationException("Start- und Enddatum m\u00fcssen gemeinsam angegeben werden");
-
-    if (dateFrom != null && dateFrom.isAfter(dateTo))
-      throw new ApplicationException("Das Startdatum liegt nach dem Enddatum");
-
-    if (dateTo != null && dateTo.isAfter(LocalDate.now()))
-      throw new ApplicationException("Das Enddatum darf nicht in der Zukunft liegen");
     
     SynchronizeOptions o = new SynchronizeOptions(k);
     
@@ -67,59 +54,17 @@ public class HBCISynchronizeJobKontoauszug extends SynchronizeJobKontoauszug imp
       {
         TypedProperties bpd = support.getBpd();
         int timeRange = bpd != null ? bpd.getInt("timerange",0) : 0;
-        boolean canRange = bpd == null || bpd.getBoolean("canrange",true);
         boolean canMaxEntries = bpd != null && bpd.getBoolean("canmaxentries",false);
-
-        if (dateFrom != null && !canRange)
-          throw new ApplicationException("Die Bank unterst\u00fctzt keinen DKKKU-Zeitraum");
-
-        if (maxEntries != null && !canMaxEntries)
-          throw new ApplicationException("Die Bank unterst\u00fctzt keine maximale DKKKU-Anzahl");
-
-        Integer effectiveMaxEntries = maxEntries;
-        if (effectiveMaxEntries == null && canMaxEntries)
-          effectiveMaxEntries = Integer.valueOf(HBCIKreditkartenUmsatzJob.DEFAULT_MAX_ENTRIES);
-
-        if (dateFrom == null)
-        {
-          jobs.add(new HBCIKreditkartenUmsatzJob(k,timeRange,effectiveMaxEntries));
-        }
-        else
-        {
-          // Groessere Backfills werden anhand des von der Bank gemeldeten
-          // Zeitfensters in mehrere echte DKKKU-Auftraege zerlegt.
-          LocalDate cursor = dateFrom;
-          while (!cursor.isAfter(dateTo))
-          {
-            LocalDate sliceEnd = timeRange > 0 ? cursor.plusDays(timeRange - 1L) : dateTo;
-            if (sliceEnd.isAfter(dateTo))
-              sliceEnd = dateTo;
-
-            jobs.add(new HBCIKreditkartenUmsatzJob(k,cursor,sliceEnd,timeRange,effectiveMaxEntries));
-            cursor = sliceEnd.plusDays(1L);
-          }
-        }
+        Integer maxEntries = canMaxEntries ? Integer.valueOf(HBCIKreditkartenUmsatzJob.DEFAULT_MAX_ENTRIES) : null;
+        jobs.add(new HBCIKreditkartenUmsatzJob(k,timeRange,maxEntries));
       }
       else
       {
-        if (dateFrom != null || maxEntries != null)
-          throw new ApplicationException("Ein expliziter Umsatzzeitraum ist nur f\u00fcr DKKKU verf\u00fcgbar");
         jobs.add(new HBCIUmsatzJob(k));
       }
     }
 
     return jobs.toArray(new AbstractHBCIJob[0]);
-  }
-
-  /**
-   * Prueft kontobezogen anhand von BPD und UPD, ob DKKKU angeboten wird.
-   * @param konto das zu pruefende Konto.
-   * @return true, wenn der Geschaeftsvorfall fuer das Konto angeboten wird.
-   * @throws RemoteException
-   */
-  public static boolean supportsDkkku(Konto konto) throws RemoteException
-  {
-    return getDkkkuSupport(konto) != null;
   }
 
   private static Support getDkkkuSupport(Konto konto) throws RemoteException

--- a/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszug.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/hbci/HBCISynchronizeJobKontoauszug.java
@@ -11,16 +11,23 @@
 package de.willuhn.jameica.hbci.synchronize.hbci;
 
 import java.rmi.RemoteException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
 import de.willuhn.jameica.hbci.SynchronizeOptions;
 import de.willuhn.jameica.hbci.rmi.Konto;
+import de.willuhn.jameica.hbci.rmi.KontoType;
+import de.willuhn.jameica.hbci.server.BPDUtil;
+import de.willuhn.jameica.hbci.server.BPDUtil.Query;
+import de.willuhn.jameica.hbci.server.BPDUtil.Support;
 import de.willuhn.jameica.hbci.server.hbci.AbstractHBCIJob;
+import de.willuhn.jameica.hbci.server.hbci.HBCIKreditkartenUmsatzJob;
 import de.willuhn.jameica.hbci.server.hbci.HBCISaldoJob;
 import de.willuhn.jameica.hbci.server.hbci.HBCIUmsatzJob;
 import de.willuhn.jameica.hbci.synchronize.jobs.SynchronizeJobKontoauszug;
 import de.willuhn.util.ApplicationException;
+import de.willuhn.util.TypedProperties;
 
 /**
  * Ein Synchronize-Job fuer das Abrufen der Umsaetze und des Saldos eines Kontos.
@@ -36,14 +43,110 @@ public class HBCISynchronizeJobKontoauszug extends SynchronizeJobKontoauszug imp
     Konto k              = (Konto) this.getContext(CTX_ENTITY);
     Boolean forceSaldo   = (Boolean) this.getContext(CTX_FORCE_SALDO);
     Boolean forceUmsatz  = (Boolean) this.getContext(CTX_FORCE_UMSATZ);
+    LocalDate dateFrom   = (LocalDate) this.getContext(CTX_DATE_FROM);
+    LocalDate dateTo     = (LocalDate) this.getContext(CTX_DATE_TO);
+    Integer maxEntries   = (Integer) this.getContext(CTX_MAX_ENTRIES);
+
+    if ((dateFrom == null) != (dateTo == null))
+      throw new ApplicationException("Start- und Enddatum m\u00fcssen gemeinsam angegeben werden");
+
+    if (dateFrom != null && dateFrom.isAfter(dateTo))
+      throw new ApplicationException("Das Startdatum liegt nach dem Enddatum");
+
+    if (dateTo != null && dateTo.isAfter(LocalDate.now()))
+      throw new ApplicationException("Das Enddatum darf nicht in der Zukunft liegen");
     
     SynchronizeOptions o = new SynchronizeOptions(k);
     
     List<AbstractHBCIJob> jobs = new ArrayList<AbstractHBCIJob>();
     if (o.getSyncSaldo() || (forceSaldo != null && forceSaldo.booleanValue())) jobs.add(new HBCISaldoJob(k));
-    if (o.getSyncKontoauszuege() || (forceUmsatz != null && forceUmsatz.booleanValue())) jobs.add(new HBCIUmsatzJob(k));
+    if (o.getSyncKontoauszuege() || (forceUmsatz != null && forceUmsatz.booleanValue()))
+    {
+      Support support = getDkkkuSupport(k);
+      if (support != null)
+      {
+        TypedProperties bpd = support.getBpd();
+        int timeRange = bpd != null ? bpd.getInt("timerange",0) : 0;
+        boolean canRange = bpd == null || bpd.getBoolean("canrange",true);
+        boolean canMaxEntries = bpd != null && bpd.getBoolean("canmaxentries",false);
+
+        if (dateFrom != null && !canRange)
+          throw new ApplicationException("Die Bank unterst\u00fctzt keinen DKKKU-Zeitraum");
+
+        if (maxEntries != null && !canMaxEntries)
+          throw new ApplicationException("Die Bank unterst\u00fctzt keine maximale DKKKU-Anzahl");
+
+        Integer effectiveMaxEntries = maxEntries;
+        if (effectiveMaxEntries == null && canMaxEntries)
+          effectiveMaxEntries = Integer.valueOf(HBCIKreditkartenUmsatzJob.DEFAULT_MAX_ENTRIES);
+
+        if (dateFrom == null)
+        {
+          jobs.add(new HBCIKreditkartenUmsatzJob(k,timeRange,effectiveMaxEntries));
+        }
+        else
+        {
+          // Groessere Backfills werden anhand des von der Bank gemeldeten
+          // Zeitfensters in mehrere echte DKKKU-Auftraege zerlegt.
+          LocalDate cursor = dateFrom;
+          while (!cursor.isAfter(dateTo))
+          {
+            LocalDate sliceEnd = timeRange > 0 ? cursor.plusDays(timeRange - 1L) : dateTo;
+            if (sliceEnd.isAfter(dateTo))
+              sliceEnd = dateTo;
+
+            jobs.add(new HBCIKreditkartenUmsatzJob(k,cursor,sliceEnd,timeRange,effectiveMaxEntries));
+            cursor = sliceEnd.plusDays(1L);
+          }
+        }
+      }
+      else
+      {
+        if (dateFrom != null || maxEntries != null)
+          throw new ApplicationException("Ein expliziter Umsatzzeitraum ist nur f\u00fcr DKKKU verf\u00fcgbar");
+        jobs.add(new HBCIUmsatzJob(k));
+      }
+    }
 
     return jobs.toArray(new AbstractHBCIJob[0]);
+  }
+
+  /**
+   * Prueft kontobezogen anhand von BPD und UPD, ob DKKKU angeboten wird.
+   * @param konto das zu pruefende Konto.
+   * @return true, wenn der Geschaeftsvorfall fuer das Konto angeboten wird.
+   * @throws RemoteException
+   */
+  public static boolean supportsDkkku(Konto konto) throws RemoteException
+  {
+    return getDkkkuSupport(konto) != null;
+  }
+
+  private static Support getDkkkuSupport(Konto konto) throws RemoteException
+  {
+    if (!isCreditCardAccount(konto))
+      return null;
+
+    Support support = BPDUtil.getSupport(konto,Query.KreditkartenUmsatz);
+    return support != null && support.isSupported() ? support : null;
+  }
+
+  private static boolean isCreditCardAccount(Konto konto) throws RemoteException
+  {
+    if (konto == null)
+      return false;
+
+    KontoType type = KontoType.find(konto.getAccountType());
+    if (type == KontoType.KREDITKARTE)
+      return true;
+
+    // Einige Institute liefern fuer Kartenkonten keinen Kontotyp. Eine
+    // Kartennummer hat mindestens 12 Stellen, nationale Kontonummern hoechstens 10.
+    String number = konto.getKontonummer();
+    if (number == null)
+      return false;
+    number = number.replace(" ","").replace("-","");
+    return number.matches("[0-9]{12,19}");
   }
 
 }

--- a/src/de/willuhn/jameica/hbci/synchronize/jobs/SynchronizeJobKontoauszug.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/jobs/SynchronizeJobKontoauszug.java
@@ -31,23 +31,6 @@ public class SynchronizeJobKontoauszug extends AbstractSynchronizeJob
    */
   public final static String CTX_FORCE_UMSATZ = "ctx.konto.umsatz.force";
 
-  /**
-   * Optionaler Beginn des Umsatzzeitraums als {@link java.time.LocalDate}.
-   * Start- und Enddatum muessen gemeinsam gesetzt werden.
-   */
-  public final static String CTX_DATE_FROM = "ctx.konto.umsatz.date.from";
-
-  /**
-   * Optionales Ende des Umsatzzeitraums als {@link java.time.LocalDate}.
-   * Start- und Enddatum muessen gemeinsam gesetzt werden.
-   */
-  public final static String CTX_DATE_TO = "ctx.konto.umsatz.date.to";
-
-  /**
-   * Optionale maximale Anzahl von Eintraegen je Bankantwort als {@link Integer}.
-   */
-  public final static String CTX_MAX_ENTRIES = "ctx.konto.umsatz.maxentries";
-
   @Override
   public boolean isRecurring()
   {

--- a/src/de/willuhn/jameica/hbci/synchronize/jobs/SynchronizeJobKontoauszug.java
+++ b/src/de/willuhn/jameica/hbci/synchronize/jobs/SynchronizeJobKontoauszug.java
@@ -31,11 +31,27 @@ public class SynchronizeJobKontoauszug extends AbstractSynchronizeJob
    */
   public final static String CTX_FORCE_UMSATZ = "ctx.konto.umsatz.force";
 
+  /**
+   * Optionaler Beginn des Umsatzzeitraums als {@link java.time.LocalDate}.
+   * Start- und Enddatum muessen gemeinsam gesetzt werden.
+   */
+  public final static String CTX_DATE_FROM = "ctx.konto.umsatz.date.from";
+
+  /**
+   * Optionales Ende des Umsatzzeitraums als {@link java.time.LocalDate}.
+   * Start- und Enddatum muessen gemeinsam gesetzt werden.
+   */
+  public final static String CTX_DATE_TO = "ctx.konto.umsatz.date.to";
+
+  /**
+   * Optionale maximale Anzahl von Eintraegen je Bankantwort als {@link Integer}.
+   */
+  public final static String CTX_MAX_ENTRIES = "ctx.konto.umsatz.maxentries";
+
   @Override
   public boolean isRecurring()
   {
     return true;
   }
 }
-
 


### PR DESCRIPTION
## Zweck

Hibiscus verwendet für Kartenkonten derzeit den normalen HKKAZ/HKCAZ-Umsatzabruf. Institute, die Kreditkartenumsätze ausschließlich per DKKKU liefern, geben damit keine Einzelumsätze zurück oder melden den Geschäftsvorfall als nicht unterstützt.

Dieser PR ergänzt die native, kontobezogene DKKKU-Synchronisierung. Er hängt von [HBCI4Java PR #144](https://github.com/hbci4j/hbci4java/pull/144) ab.

## Änderungen

- erkennt DKKKU dynamisch anhand der gecachten BPD und UPD des jeweiligen Kontos
- enthält keine feste BLZ, Karten- oder Hibiscus-Konto-ID
- begrenzt die Auswahl auf Kreditkartenkonten; fehlende Kontotypen werden über eine gültige Kartennummernform aufgefangen
- setzt Kartennummer, Unterkartennummer, Startdatum, Enddatum und – falls laut BPD erlaubt – `maxentries` im tatsächlichen Bankauftrag
- stellt optionale `LocalDate`-Kontexte für kontrollierte historische Abrufe bereit
- zerlegt größere Backfills anhand des von der Bank gemeldeten `timerange` in mehrere DKKKU-Aufträge
- verwendet weiterhin den bestehenden `HBCIUmsatzJob`-Mergepfad; wiederholte Abrufe bleiben dadurch idempotent
- behält den normalen wiederkehrenden Sync ohne expliziten Zeitraum bei

Nach einem HBCI4Java-Update muss bei bestehenden Installationen einmal BPD/UPD aktualisiert werden, damit das zuvor unbekannte DIKKUS-Segment im Cache landet.

## Tests

Mit Jameica 2.13.0-nightly und Java 17 erfolgreich ausgeführt:

- vollständiger Hibiscus-Compile mit 867 Quelldateien
- Erstellung von `hibiscus.jar`